### PR TITLE
BlueBox Group support

### DIFF
--- a/lib/fog/bluebox/models/compute/server.rb
+++ b/lib/fog/bluebox/models/compute/server.rb
@@ -56,7 +56,7 @@ module Fog
           options = if !@password && !@ssh_key
             raise(ArgumentError, "password or ssh_key is required for this operation")
           elsif @ssh_key
-            {'ssh_key' => @ssh_key}
+            {'ssh_public_key' => @ssh_key}
           elsif @password
             {'password' => @password}
           end


### PR DESCRIPTION
I've recently created a box using the SSH key support, and they call this "ssh_public_key" in the documentation here: https://boxpanel.blueboxgrp.com/public/the_vault/index.php/Blocks_API#POST_.2Fapi.2Fblocks
