### PR TITLE
Idempotent instances on AWS

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -12,6 +12,7 @@ module Fog
         attribute :ami_launch_index,      :aliases => 'amiLaunchIndex'
         attribute :availability_zone,     :aliases => 'availabilityZone'
         attribute :block_device_mapping,  :aliases => 'blockDeviceMapping'
+        attribute :client_token,          :aliases => 'clientToken'
         attribute :dns_name,              :aliases => 'dnsName'
         attribute :groups
         attribute :flavor_id,             :aliases => 'instanceType'
@@ -128,6 +129,7 @@ module Fog
 
           options = {
             'BlockDeviceMapping'          => block_device_mapping,
+            'ClientToken'                 => client_token,
             'InstanceType'                => flavor_id,
             'KernelId'                    => kernel_id,
             'KeyName'                     => key_name,

--- a/lib/fog/aws/requests/compute/run_instances.rb
+++ b/lib/fog/aws/requests/compute/run_instances.rb
@@ -93,11 +93,15 @@ module Fog
           if options['UserData']
             options['UserData'] = Base64.encode64(options['UserData'])
           end
+
+          idempotent = !options['ClientToken'].empty?
+
           request({
             'Action'    => 'RunInstances',
             'ImageId'   => image_id,
             'MinCount'  => min_count,
             'MaxCount'  => max_count,
+            :idempotent => idempotent,
             :parser     => Fog::Parsers::AWS::Compute::RunInstances.new
           }.merge!(options))
         end

--- a/spec/aws/models/compute/server_spec.rb
+++ b/spec/aws/models/compute/server_spec.rb
@@ -23,6 +23,7 @@ describe 'Fog::AWS::Compute::Server' do
     it "should remap attributes from parser" do
       server = @servers.new({
         'amiLaunchIndex'    => 'ami_launch_index',
+        'clientToken'       => 'client_token',
         'dnsName'           => 'dns_name',
         'imageId'           => 'image_id',
         'instanceId'        => 'instance_id',
@@ -35,6 +36,7 @@ describe 'Fog::AWS::Compute::Server' do
         'ramdiskId'         => 'ramdisk_id'
       })
       server.ami_launch_index.should == 'ami_launch_index'
+      server.client_token.should == 'client_token'
       server.dns_name.should == 'dns_name'
       server.image_id.should == 'image_id'
       server.id.should == 'instance_id'


### PR DESCRIPTION
I added a field for ClientToken to the AWS servers. It'd be cool to make this a bit more built in but at least it should be useable at this point. There's something up with my home laptop and I can't run the specs or use the fog binary so I'll have to check it when I get to work.
