### PR TITLE
Initial AWS Tag support

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -19,6 +19,8 @@ module Fog
       collection  :servers
       model       :snapshot
       collection  :snapshots
+      model       :tag
+      collection  :tags
       model       :volume
       collection  :volumes
 
@@ -48,6 +50,7 @@ module Fog
       request :describe_regions
       request :describe_security_groups
       request :describe_snapshots
+      request :describe_tags
       request :describe_volumes
       request :detach_volume
       request :disassociate_address

--- a/lib/fog/aws/models/compute/image.rb
+++ b/lib/fog/aws/models/compute/image.rb
@@ -36,7 +36,13 @@ module Fog
 
           return true
         end
+        
+        def tags
+          requires :id
 
+          connection.tags(:filters => {'resource-id' => @id})
+        end
+                
       end
 
     end

--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -188,6 +188,12 @@ module Fog
           connection.stop_instances(@id)
           true
         end
+        
+        def tags
+          requires :id
+
+          connection.tags(:filters => {'resource-id' => @id})
+        end
 
         def username
           @username ||= 'root'

--- a/lib/fog/aws/models/compute/tag.rb
+++ b/lib/fog/aws/models/compute/tag.rb
@@ -1,0 +1,36 @@
+require 'fog/core/model'
+
+module Fog
+  module AWS
+    class Compute
+
+      class Tag < Fog::Model
+
+        identity  :key
+
+        attribute :value
+        attribute :resource_id,           :aliases => 'resourceId'
+        attribute :resource_type,         :aliases => 'resourceType'        
+
+        def initialize(attributes = {})
+          super
+        end
+
+        def destroy
+          requires :key, :resource_id
+          connection.delete_tags(resource_id, key)
+          true
+        end
+
+        def save
+          requires :key, :resource_id
+          connection.create_tags(resource_id, key, value)
+          true
+        end
+
+        private
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/models/compute/tags.rb
+++ b/lib/fog/aws/models/compute/tags.rb
@@ -1,0 +1,34 @@
+require 'fog/core/collection'
+require 'fog/aws/models/compute/tag'
+
+module Fog
+  module AWS
+    class Compute
+
+      class Tags < Fog::Collection
+
+        attribute :filters
+
+        model Fog::AWS::Compute::Tag
+
+        def initialize(attributes)
+          @filters ||= {}
+          super
+        end
+
+        def all(filters = @filters)
+          @filters = filters
+          data = connection.describe_tags(@filters).body
+          load(data['tagSet'])
+        end
+
+        def get(key)
+          if key
+            self.class.new(:connection => connection).all('key' => key)
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/aws/models/compute/volume.rb
+++ b/lib/fog/aws/models/compute/volume.rb
@@ -62,6 +62,12 @@ module Fog
 
           connection.snapshots(:volume => self)
         end
+        
+        def tags
+          requires :id
+
+          connection.tags(:filters => {'resource-id' => @id})
+        end
 
         private
 

--- a/lib/fog/aws/parsers/compute/describe_tags.rb
+++ b/lib/fog/aws/parsers/compute/describe_tags.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Parsers
+    module AWS
+      module Compute
+
+        class DescribeTags < Fog::Parsers::Base
+
+          def reset
+            @tag = {}
+            @response = { 'tagSet' => [] }
+          end
+
+          def end_element(name)
+            case name
+            when 'resourceId', 'resourceType', 'key', 'value'
+              @tag[name] = @value
+            when 'item'
+              @response['tagSet'] << @tag
+              @tag = {}
+            when 'requestId'
+              @response[name] = @value
+            end
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/compute/describe_tags.rb
+++ b/lib/fog/aws/requests/compute/describe_tags.rb
@@ -1,0 +1,42 @@
+module Fog
+  module AWS
+    class Compute
+      class Real
+
+        require 'fog/aws/parsers/compute/describe_tags'
+
+        # Describe all or specified tags
+        #
+        # ==== Parameters
+        # * filters<~Hash> - List of filters to limit results with
+        #
+        # === Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'requestId'<~String> - Id of request
+        #     * 'tagSet'<~Array>:
+        #       * 'resourceId'<~String> - id of resource tag belongs to
+        #       * 'resourceType'<~String> - type of resource tag belongs to
+        #       * 'key'<~String> - Tag's key
+        #       * 'value'<~String> - Tag's value
+        def describe_tags(filters = {})
+          params = AWS.indexed_filters(filters)
+          request({
+            'Action'    => 'DescribeTags',
+            :idempotent => true,
+            :parser     => Fog::Parsers::AWS::Compute::DescribeTags.new
+          }.merge!(params))
+        end
+
+      end
+
+      class Mock
+
+        def describe_tags(filters = {})
+          Fog::Mock.not_implemented
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
I've implemented the initial plumbing for AWS Tag requests.  Right now all "describe" methods work.  You can pull query a list of all tags associated with your AWS account (along with filter support). You can also call the "tags" method on the Image, Server and Volume model and get a list of the tags associated with that instance.  I am continuing on with create_tags and delete_tags next.
