### PR TITLE
cleaned up some warnings and fixed error building gem 

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -563,16 +563,11 @@ Gem::Specification.new do |s|
     spec/aws/requests/simpledb/put_attributes_spec.rb
     spec/aws/requests/simpledb/select_spec.rb
     spec/aws/requests/storage/copy_object_spec.rb
-    spec/aws/requests/storage/delete_bucket_spec.rb
-    spec/aws/requests/storage/delete_object_spec.rb
     spec/aws/requests/storage/get_bucket_location_spec.rb
     spec/aws/requests/storage/get_bucket_spec.rb
     spec/aws/requests/storage/get_object_spec.rb
     spec/aws/requests/storage/get_request_payment_spec.rb
-    spec/aws/requests/storage/get_service_spec.rb
     spec/aws/requests/storage/head_object_spec.rb
-    spec/aws/requests/storage/put_bucket_spec.rb
-    spec/aws/requests/storage/put_object_spec.rb
     spec/aws/requests/storage/put_request_payment_spec.rb
     spec/bluebox/models/compute/flavors_spec.rb
     spec/bluebox/models/compute/server_spec.rb

--- a/lib/fog/local/storage.rb
+++ b/lib/fog/local/storage.rb
@@ -1,6 +1,6 @@
 module Fog
   module Local
-  class Storage < Fog::Service
+    class Storage < Fog::Service
 
       requires :local_root
 

--- a/lib/fog/terremark/ecloud.rb
+++ b/lib/fog/terremark/ecloud.rb
@@ -25,9 +25,9 @@ module Fog
 
        if Fog.mocking?
           Fog::Terremark::Ecloud::Mock.new(options)
-        else
+       else
           Fog::Terremark::Ecloud::Real.new(options)
-        end
+       end
      end
 
      class Real
@@ -45,7 +45,7 @@ module Fog
           @connection = Fog::Connection.new("#{@scheme}://#{@host}:#{@port}", options[:persistent])
         end
 
-      end
+    end
 
      class Mock
        include Fog::Terremark::Shared::Mock
@@ -60,7 +60,7 @@ module Fog
        end
      end
 
-    end
+   end
   end
 end
 

--- a/lib/fog/terremark/vcloud.rb
+++ b/lib/fog/terremark/vcloud.rb
@@ -25,9 +25,9 @@ module Fog
 
        if Fog.mocking?
           Fog::Terremark::Vcloud::Mock.new(options)
-        else
+       else
           Fog::Terremark::Vcloud::Real.new(options)
-        end
+       end
      end
 
      class Real
@@ -91,7 +91,7 @@ module Fog
             nil
           end
         end
-      end
+     end
 
      class Mock
        include Fog::Terremark::Shared::Mock
@@ -106,7 +106,7 @@ module Fog
        end
      end
 
-    end
+   end
   end
 end
 

--- a/lib/fog/vcloud/terremark/ecloud.rb
+++ b/lib/fog/vcloud/terremark/ecloud.rb
@@ -179,8 +179,8 @@ module Fog
 
           def mock_ip_and_service_from_service_url(uri)
             if ip = mock_data[:organizations].map { |org| org[:vdcs] }.flatten.map { |vdc| vdc[:public_ips] }.flatten.compact.detect { |pip| pip[:services].detect { |service| service[:href] == uri } }
-              if service = ip[:services].detect { |service| service[:href] == uri }
-                [ip, service]
+              if desired_service = ip[:services].detect { |service| service[:href] == uri }
+                [ip, desired_service]
               else
                 [ip, nil]
               end


### PR DESCRIPTION
the following warnings where fixed:

/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/core/ssh.rb:59: warning: shadowing outer local variable - channel
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/core/ssh.rb:64: warning: shadowing outer local variable - channel
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/core/ssh.rb:68: warning: shadowing outer local variable - channel
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/core/ssh.rb:73: warning: shadowing outer local variable - channel
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/core/ssh.rb:77: warning: shadowing outer local variable - channel
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/local/storage.rb:56: warning: mismatched indentations at 'end' with 'class' at 3
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/terremark/ecloud.rb:30: warning: mismatched indentations at 'end' with 'if' at 26
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/terremark/ecloud.rb:63: warning: mismatched indentations at 'end' with 'module' at 3
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/terremark/vcloud.rb:30: warning: mismatched indentations at 'end' with 'if' at 26
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/terremark/vcloud.rb:94: warning: mismatched indentations at 'end' with 'class' at 33
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/terremark/vcloud.rb:109: warning: mismatched indentations at 'end' with 'module' at 3
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/vcloud/terremark/ecloud.rb:182: warning: shadowing outer local variable - service

the following warnings still exist (ran out of time tonight):
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/terremark/ecloud.rb:48: warning: mismatched indentations at 'end' with 'class' at 33
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/aws/compute.rb:77: warning: shadowing outer local variable - hash
/Users/anuaimi/.rvm/gems/ruby-1.9.2-p0@rails3/bundler/gems/fog-3ec39c332fe4/lib/fog/aws/storage.rb:78: warning: shadowing outer local variable - hash

the following error building the gem is fixed (believe related to last commit where files were deleted):
athir-nuaimis-macbook-pro:fog anuaimi$ gem build fog.gemspec 
ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
    ["spec/aws/requests/storage/delete_bucket_spec.rb", "spec/aws/requests/storage/delete_object_spec.rb", "spec/aws/requests/storage/get_service_spec.rb", "spec/aws/requests/storage/put_bucket_spec.rb", "spec/aws/requests/storage/put_object_spec.rb"] are not files
