### PR TITLE
Describe instance doesn't list tags

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_instances.rb
@@ -72,12 +72,12 @@ module Fog
               if @in_block_device_mapping
                 @instance['blockDeviceMapping'] << @block_device_mapping
                 @block_device_mapping = {}
-              elsif @in_instances_set
-                @reservation['instancesSet'] << @instance
-                @instance = { 'blockDeviceMapping' => [], 'instanceState' => {}, 'monitoring' => {}, 'placement' => {}, 'productCodes' => [], 'stateReason' => {}, 'tagSet' => {} }
               elsif @in_tag_set
                 @instance['tagSet'][@tag['key']] = @tag['value']
                 @tag = {}
+              elsif @in_instances_set
+                @reservation['instancesSet'] << @instance
+                @instance = { 'blockDeviceMapping' => [], 'instanceState' => {}, 'monitoring' => {}, 'placement' => {}, 'productCodes' => [], 'stateReason' => {}, 'tagSet' => {} }
               elsif !@in_subset
                 @response['reservationSet'] << @reservation
                 @reservation = { 'groupSet' => [], 'instancesSet' => [] }


### PR DESCRIPTION
Due to a bug in the parser's item element context check, tags never get added to the instance.  This patch reorders the context check in the describe instance parser so that the most specific possible context is checked before less specific contexts.
