### PR TITLE
Mock AWS ids are not always the correct length

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -170,7 +170,7 @@ module Fog
       end
 
       private
-
+      
       def self.random_selection(characters, length)
         selection = ''
         length.times do
@@ -194,7 +194,7 @@ module Fog
 
       def self.hex(length)
         max = ('f' * length).to_i(16)
-        rand(max).to_s(16)
+        rand(max).to_s(16).rjust(length, '0')
       end
 
       def self.base64(length)


### PR DESCRIPTION
Hex vales used for mock AWS ids are expected to be exactly 8 characters.  This was exposed by the regex in the create_tags mock.
