### PR TITLE
AWS::ELB Requests

### DIFF
--- a/lib/fog/aws/requests/elb/disable_availability_zones_for_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/disable_availability_zones_for_load_balancer.rb
@@ -19,7 +19,7 @@ module Fog
         #     * 'DisableAvailabilityZonesForLoadBalancerResult'<~Hash>:
         #       * 'AvailabilityZones'<~Array> - array of strings describing instances currently enabled
         def disable_availability_zones_for_load_balancer(availability_zones, lb_name)
-          params = AWS.indexed_param('AvailabilityZones.member', [*availability_zones], 1)
+          params = AWS.indexed_param('AvailabilityZones.member', [*availability_zones])
           request({
             'Action'           => 'DisableAvailabilityZonesForLoadBalancer',
             'LoadBalancerName' => lb_name,

--- a/lib/fog/aws/requests/elb/enable_availability_zones_for_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/enable_availability_zones_for_load_balancer.rb
@@ -19,7 +19,7 @@ module Fog
         #     * 'EnableAvailabilityZonesForLoadBalancerResult'<~Hash>:
         #       * 'AvailabilityZones'<~Array> - array of strings describing instances currently enabled
         def enable_availability_zones_for_load_balancer(availability_zones, lb_name)
-          params = AWS.indexed_param('AvailabilityZones.member', [*availability_zones], 1)
+          params = AWS.indexed_param('AvailabilityZones.member', [*availability_zones])
           request({
             'Action'           => 'EnableAvailabilityZonesForLoadBalancer',
             'LoadBalancerName' => lb_name,

--- a/lib/fog/aws/requests/elb/register_instances_with_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/register_instances_with_load_balancer.rb
@@ -20,7 +20,7 @@ module Fog
         #       * 'Instances'<~Array> - array of hashes describing instances currently enabled
         #         * 'InstanceId'<~String>
         def register_instances_with_load_balancer(instance_ids, lb_name)
-          params = AWS.indexed_param('Instances.member.%d.InstanceId', [*instance_ids], 1)
+          params = AWS.indexed_param('Instances.member.%d.InstanceId', [*instance_ids])
           request({
             'Action'           => 'RegisterInstancesWithLoadBalancer',
             'LoadBalancerName' => lb_name,


### PR DESCRIPTION
Some of the request classes were passing a 3rd argument (1) to the AWS.indexed_param method.
