### PR TITLE
adding AWS::Storage put_object_acl request (similar to put_bucket_acl)

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -274,6 +274,7 @@ Gem::Specification.new do |s|
     lib/fog/aws/requests/storage/put_bucket_logging.rb
     lib/fog/aws/requests/storage/put_bucket_versioning.rb
     lib/fog/aws/requests/storage/put_object.rb
+    lib/fog/aws/requests/storage/put_object_acl.rb
     lib/fog/aws/requests/storage/put_object_url.rb
     lib/fog/aws/requests/storage/put_request_payment.rb
     lib/fog/aws/requests/storage/upload_part.rb

--- a/lib/fog/aws/requests/storage/put_object_acl.rb
+++ b/lib/fog/aws/requests/storage/put_object_acl.rb
@@ -1,0 +1,93 @@
+module Fog
+  module AWS
+    class Storage
+      class Real
+
+        # Change access control list for an S3 object
+        #
+        # ==== Parameters
+        # * bucket_name<~String> - name of bucket to modify
+        # * object_name<~String> - name of object to get access control list for
+        # * acl<~Hash>:
+        #   * Owner<~Hash>:
+        #     * ID<~String>: id of owner
+        #     * DisplayName<~String>: display name of owner
+        #   * AccessControlList<~Array>:
+        #     * Grantee<~Hash>:
+        #         * 'DisplayName'<~String> - Display name of grantee
+        #         * 'ID'<~String> - Id of grantee
+        #       or
+        #         * 'EmailAddress'<~String> - Email address of grantee
+        #       or
+        #         * 'URI'<~String> - URI of group to grant access for
+        #     * Permission<~String> - Permission, in [FULL_CONTROL, WRITE, WRITE_ACP, READ, READ_ACP]
+        # * options<~Hash>:
+        #   * 'versionId'<~String> - specify a particular version to retrieve
+        #
+        # ==== See Also
+        # http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTObjectPUTacl.html
+
+        def put_object_acl(bucket_name, object_name, acl, options = {})
+          query = {'acl' => nil}
+          if version_id = options.delete('versionId')
+            query['versionId'] = version_id
+          end
+
+          data =
+<<-DATA
+<AccessControlPolicy>
+  <Owner>
+    <ID>#{acl['Owner']['ID']}</ID>
+    <DisplayName>#{acl['Owner']['DisplayName']}</DisplayName>
+  </Owner>
+  <AccessControlList>
+DATA
+
+          acl['AccessControlList'].each do |grant|
+            data << "    <Grant>"
+            type = case grant['Grantee'].keys.sort
+            when ['DisplayName', 'ID']
+              'CanonicalUser'
+            when ['EmailAddress']
+              'AmazonCustomerByEmail'
+            when ['URI']
+              'Group'
+            end
+            data << "      <Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"#{type}\">"
+            for key, value in grant['Grantee']
+              data << "        <#{key}>#{value}</#{key}>"
+            end
+            data << "      </Grantee>"
+            data << "      <Permission>#{grant['Permission']}</Permission>"
+            data << "    </Grant>"
+          end
+
+          data <<
+<<-DATA
+  </AccessControlList>
+</AccessControlPolicy>
+DATA
+
+          request({
+            :body     => data,
+            :expects  => 200,
+            :headers  => {},
+            :host     => "#{bucket_name}.#{@host}",
+            :method   => 'PUT',
+            :path       => CGI.escape(object_name),
+            :query    => query
+          })
+        end
+
+      end
+
+      class Mock # :nodoc:all
+
+        def put_object_acl(bucket_name, object_name, options, acl)
+          Fog::Mock.not_implemented
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -38,6 +38,7 @@ module Fog
       request :put_bucket_logging
       request :put_bucket_versioning
       request :put_object
+      request :put_object_acl
       request :put_object_url
       request :put_request_payment
       request :upload_part

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -1,12 +1,16 @@
+__DIR__ = File.dirname(__FILE__)
+__LIB_DIR__ = File.join(__DIR__, '../lib')
+
+[ __DIR__, __LIB_DIR__ ].each do |directory|
+  $LOAD_PATH.unshift directory unless
+    $LOAD_PATH.include?(directory) ||
+    $LOAD_PATH.include?(File.expand_path(directory))
+end
+
 require 'fog'
 require 'fog/core/bin'
+
 Fog.bin = true
-
-__DIR__ = File.dirname(__FILE__)
-
-$LOAD_PATH.unshift __DIR__ unless
-  $LOAD_PATH.include?(__DIR__) ||
-  $LOAD_PATH.include?(File.expand_path(__DIR__))
 
 require 'tests/helpers/collection_tests'
 require 'tests/helpers/model_tests'


### PR DESCRIPTION
Basically a modified version of put_bucket_acl - to handle versions and add the object_name to the URL.

I saw that you are doing arg-checks (bucket/object not-nil) for get__acl requests but not for put ones - probably cause S3 will raise a similar exception - so following the same style. We can be a bit more dry about creating the "data" part of the put___acl requests - where is the right place to put this code (take the acl hash and create the ACL-elements that AWS expects)?

About tests: none of the ACL requests have any tests. If we set up the @data[:acl] correctly in the put___acl do you remember if the rest of the code already respects @data[:acl]? Also a bit tricly will be the use the email addresses in put___acl - how AWS translates that to a canonical user. For mocks setting up fake data will be enough but for real tests we might have to work more.

 shindo:
   problems with require (fixed - see if you want to accept that)
   performance problems - _something_ in the storage/buckets tests grabs all the resources and makes my macbook crawl and howl :( (didn't dig in)

I suppose we should have (get-acl-after-put-acl, permission-denied-after-put-acl tests for both buckets and objects) - please let me know your thoughts.

I have tested this code manually through the cli for now.
