### PR TITLE
squashed commits (starting from 76624c4, ending with 1717638)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,13 @@
 PATH
   remote: .
   specs:
-    fog (0.3.23)
+    fog (0.3.25)
       builder
       excon (>= 0.2.4)
       formatador (>= 0.0.16)
       json
       mime-types
+      named-parameters (>= 0.0.14)
       net-ssh (~> 2.0.23)
       nokogiri (~> 1.4.3.1)
       ruby-hmac
@@ -21,6 +22,7 @@ GEM
       formatador (>= 0.0.12)
     json (1.4.6)
     mime-types (1.16)
+    named-parameters (0.0.14)
     net-ssh (2.0.23)
     nokogiri (1.4.3.1)
     rake (0.8.7)
@@ -40,6 +42,7 @@ DEPENDENCIES
   formatador (>= 0.0.16)
   json
   mime-types
+  named-parameters (>= 0.0.14)
   net-ssh (~> 2.0.23)
   nokogiri (~> 1.4.3.1)
   rake

--- a/README.rdoc
+++ b/README.rdoc
@@ -129,8 +129,7 @@ Enjoy, and let me know what I can do to continue improving fog!
 * Follow {@fog}[http://twitter.com/fog] and/or {@geemus}[http://twitter.com/geemus] on Twitter
 * Discuss in irc on the {#ruby-fog}[irc://irc.freenode.net/ruby-fog] channel on Freenode
 * Discuss via email on the {mailing list}[http://groups.google.com/group/ruby-fog] (note: release notes appear on this list)
-* See upcoming work in the {tracker}[http://www.pivotaltracker.com/projects/54635]
-* Report bugs in {issues}[http://github.com/geemus/fog/issues]
+* Report bugs or find stuff to work on in {issues}[http://github.com/geemus/fog/issues]
 * Learn about {contributing}[http://github.com/geemus/fog/wiki/contributor-guide] or find more info about the {Providers}[http://github.com/geemus/fog/wiki/Providers] (including some todo items)
 * See what already uses fog and add your own stuff to {the list}[http://wiki.github.com/geemus/fog/in-the-wild]
 

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -7,8 +7,8 @@ Gem::Specification.new do |s|
   ## If your rubyforge_project name is different, then edit it and comment out
   ## the sub! line in the Rakefile
   s.name              = 'fog'
-  s.version           = '0.3.23'
-  s.date              = '2010-11-19'
+  s.version           = '0.3.25'
+  s.date              = '2010-11-23'
   s.rubyforge_project = 'fog'
 
   ## Make sure your summary is short. The description may be as long
@@ -47,6 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency('formatador', '>=0.0.16')
   s.add_dependency('json')
   s.add_dependency('mime-types')
+  s.add_dependency('named-parameters', '>=0.0.14')
   s.add_dependency('net-ssh', '~>2.0.23')
   s.add_dependency('nokogiri', '~>1.4.3.1')
   s.add_dependency('ruby-hmac')
@@ -274,6 +275,7 @@ Gem::Specification.new do |s|
     lib/fog/aws/requests/storage/put_bucket_logging.rb
     lib/fog/aws/requests/storage/put_bucket_versioning.rb
     lib/fog/aws/requests/storage/put_object.rb
+    lib/fog/aws/requests/storage/put_object_acl.rb
     lib/fog/aws/requests/storage/put_object_url.rb
     lib/fog/aws/requests/storage/put_request_payment.rb
     lib/fog/aws/requests/storage/upload_part.rb

--- a/lib/fog.rb
+++ b/lib/fog.rb
@@ -4,6 +4,7 @@ require 'cgi'
 require 'excon'
 require 'formatador'
 require 'time'
+require 'named-parameters'
 
 __DIR__ = File.dirname(__FILE__)
 
@@ -18,7 +19,7 @@ module Fog
   @mocking = false
 
   unless const_defined?(:VERSION)
-    VERSION = '0.3.23'
+    VERSION = '0.3.25'
   end
 
   module Mock

--- a/lib/fog/aws/cdn.rb
+++ b/lib/fog/aws/cdn.rb
@@ -3,6 +3,7 @@ module Fog
     class CDN < Fog::Service
 
       requires :aws_access_key_id, :aws_secret_access_key
+      recognizes :host, :path, :port, :scheme, :version, :persistent
 
       model_path 'fog/aws/models/cdn'
 

--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -2,7 +2,7 @@ module Fog
   module AWS
     class Compute < Fog::Service
 
-      requires   :aws_access_key_id, :aws_secret_access_key
+      requires :aws_access_key_id, :aws_secret_access_key
       recognizes :endpoint, :region, :host, :path, :port, :scheme, :persistent
 
       model_path 'fog/aws/models/compute'

--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -3,6 +3,7 @@ module Fog
     class ELB < Fog::Service
 
       requires :aws_access_key_id, :aws_secret_access_key
+      recognizes :region, :host, :path, :port, :scheme, :persistent
 
       request_path 'fog/aws/requests/elb'
       request :create_load_balancer

--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -3,6 +3,7 @@ module Fog
     class IAM < Fog::Service
 
       requires :aws_access_key_id, :aws_secret_access_key
+      recognizes :host, :path, :port, :scheme, :persistent
 
       request_path 'fog/aws/requests/iam'
       request :add_user_to_group

--- a/lib/fog/aws/models/compute/flavors.rb
+++ b/lib/fog/aws/models/compute/flavors.rb
@@ -9,6 +9,109 @@ module Fog
 
         model Fog::AWS::Compute::Flavor
 
+        # Returns an array of all key pairs that have been created
+        #
+        # AWS.key_pairs.all
+        #
+        # ==== Returns
+        #
+        # Returns an array of all available instance sizes
+        #
+        #>> AWS.flavors.all
+        #  <Fog::AWS::Compute::Flavors
+        #    [
+        #      <Fog::AWS::Compute::Flavor
+        #        id="t1.micro",
+        #        bits=0,
+        #        cores=2,
+        #        disk=0,
+        #        name="Micro Instance",
+        #        ram=613
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="m1.small",
+        #        bits=32,
+        #        cores=1,
+        #        disk=160,
+        #        name="Small Instance",
+        #        ram=1740.8
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="m1.large",
+        #        bits=64,
+        #        cores=4,
+        #        disk=850,
+        #        name="Large Instance",
+        #        ram=7680
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="m1.xlarge",
+        #        bits=64,
+        #        cores=8,
+        #        disk=1690,
+        #        name="Extra Large Instance",
+        #        ram=15360
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="c1.medium",
+        #        bits=32,
+        #        cores=5,
+        #        disk=350,
+        #        name="High-CPU Medium",
+        #        ram=1740.8
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="c1.xlarge",
+        #        bits=64,
+        #        cores=20,
+        #        disk=1690,
+        #        name="High-CPU Extra Large",
+        #        ram=7168
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="m2.xlarge",
+        #        bits=64,
+        #        cores=6.5,
+        #        disk=420,
+        #        name="High-Memory Extra Large",
+        #        ram=17510.4
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="m2.2xlarge",
+        #        bits=64,
+        #        cores=13,
+        #        disk=850,
+        #        name="High Memory Double Extra Large",
+        #        ram=35020.8
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="m2.4xlarge",
+        #        bits=64,
+        #        cores=26,
+        #        disk=1690,
+        #        name="High Memory Quadruple Extra Large",
+        #        ram=70041.6
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="cc1.4xlarge",
+        #        bits=64,
+        #        cores=33.5,
+        #        disk=1690,
+        #        name="Cluster Compute Quadruple Extra Large",
+        #        ram=23552
+        #      >,
+        #      <Fog::AWS::Compute::Flavor
+        #        id="cg1.4xlarge",
+        #        bits=64,
+        #        cores=33.5,
+        #        disk=1690,
+        #        name="Cluster GPU Quadruple Extra Large",
+        #        ram=22528
+        #      >
+        #    ]
+        #  >
+        #
+
         def all
           data = [
             { :bits => 0,  :cores =>   2,  :disk => 0,    :id =>  't1.micro',   :name => 'Micro Instance',       :ram => 613},
@@ -30,6 +133,27 @@ module Fog
           load(data)
           self
         end
+
+        # Used to retreive a flavor
+        # flavor_id is required to get the associated flavor information.
+        # flavors available currently:
+        # 't1.micro', 'm1.small', 'm1.large', 'm1.xlarge', 'c1.medium', 'c1.xlarge', 'm2.xlarge', 'm2.2xlarge', 'm2.4xlarge', 'cc1.4xlarge', 'cg1.4xlarge'
+        #
+        # You can run the following command to get the details:
+        # AWS.flavors.get("t1.micro")
+        #
+        # ==== Returns
+        #
+        #>> AWS.flavors.get("t1.micro")
+        # <Fog::AWS::Compute::Flavor
+        #  id="t1.micro",
+        #  bits=0,
+        #  cores=2,
+        #  disk=0,
+        #  name="Micro Instance",
+        #  ram=613
+        #>
+        #
 
         def get(flavor_id)
           self.class.new(:connection => connection).all.detect {|flavor| flavor.id == flavor_id}

--- a/lib/fog/aws/models/compute/key_pairs.rb
+++ b/lib/fog/aws/models/compute/key_pairs.rb
@@ -12,10 +12,42 @@ module Fog
 
         model Fog::AWS::Compute::KeyPair
 
+        # Used to create a key pair.  There are 3 arguments and only name is required.  You can generate a new key_pair as follows:
+        # AWS.key_pairs.create(:name => "test", :fingerprint => "123", :private_key => '234234')
+        #
+        # ==== Returns
+        #
+        #<Fog::AWS::Compute::KeyPair
+        #  name="test",
+        #  fingerprint="3a:d3:e5:17:e5:e7:f7:de:fe:db:1b:c2:55:7d:94:0b:07:2e:05:aa",
+        #  private_key="-----BEGIN RSA PRIVATE KEY-----\nf/VtfXJ/ekTSlRS2GSItBSzMrEGoZ+EXeMOuiA7HFkDcgKt6aBiOX9Bysiyfc1rIrgWdFKqXBRJA\nrtvBPa3/32koMPV4FxG7RZrPuKLITmFoEV86M0DSLo+ErlOPuDChfrR9dk6eI17/o1VmSvYsIpDc\njvbgx+tt7ZEPvduoUag7YdnUI0f20fttsdXjMlyDg9pPOVF3/hqucqOb3t5y9lvVJJxdTnEDFSjb\nvodpaDT9+ssw4IsQsZEIvfL0hK+Lt4phbclUWfG7JVnYfdd2u4zU6Nqe0+3qoR0ZOH4/zaUko7z8\n7JMbJqs5bmdWfnQTrvbJ13545FRI/W48ZRJxqPcj0t2MzasbT4gMgtNJrSadq78RkRJjNTu4lZmK\nvJejkBZPicHvo5IRSEbDc90Rhdh0aZNifXn0d0DSV2N6Ywo2o1lwRAi3/l6XSjukyRpTPcMr14MP\ntGwS1Tvez41Oa7Y96VfsJB2xtKc6LGRFiPUg2ZAEHU15Q9bIISVzHXgdAcef1bsh8UN/fDBrTusm\nvJisQ+dLaPH7cZ03od+XTwJc+IyeL4RqWuASE0NNfEVJMS+qcpt0WeNzfG0C27SwIcfEKL0sC0kn\nCfX2WpZDg7T5xN+88ftKJaN9tymxTgvoJVS1/WKvWBAXVozKp4f6K8wKmwf7VdUt/FWbUi54LW02\nf1ONkaYEOVwDgWlGxVSx43MWqvVdT2MPFNEBL7OA1LPwCO2nyQQ9UM9gCE65S9Najf939Bq8xwqx\nGNFlLmaH6biZUyL8ewRJ8Y7rMQ5cXy/gHZywjkuoyLQ8vVpmVpb7r1FaM/AYSr5l6gJEWdqbJleN\ntnhjPeE6qXISzIUBvwKzzgFTyW8ZHQtgbP3bHEiPG2/OjKHnLUoOId/eetcE+ovIxWsBrTDbf2SV\nYUD91u+W9K35eX89ZaIiohLNg4z9+QHCs4rcWyOXEfprBKcP2QU5+Y9ysnXLAmZt6QhInaAsUpQZ\nyhImA24UqvqrK0yyGhf/quouK7q0QkVQR+f7nGClIaphJkxO/xylrnK/pYObr4s3B8kmksuHiYOu\n1yz6SeRkj8F9dxkRmzbBK/G0tLkxIElDbM7icI9gsEO7vvgaR/K8hSDi0RkFPG43I20tU8PqwHe7\nR4jFW+6sB2+9FDeLn+qkoDSaxzmAuIRW082z/r7rJVIpFEo14hNhQYkNXpH40+P/hA9RFgvhZe8M\nvK4rz/eu246Kij6kObieTfpZhgGHqvtU8x5cnqEZOz5Hc5m4B+gMaTA53kFSPOA0pn6gqgiuYEdI\nZUhO8P1PkNqkmLz7NJRnz3qpAo6RisAxPBVr2WdSg4bP0YpGS/0TE4OOJwGLldx6dCsX60++mn0q\n1fhNw8oyZiguYMAeEEDWP8x/bsRaFz5L8uQVnnnj8ei1oTmZ+Uw9/48snWYcurL2jsbuWhhE0NTt\nfe/cqov7ZaZHs+Tr20ZBEDEqUEWr/MMskj/ZSVxnza1G/hztFJMAThF9ZJoGQkHWHfXCGOLLGY+z\nqi0SC8EIeu8PUxjO2SRj9S9o/Dwg3iHyM3pj57kD7fDNnl3Ed6LMoCXoaQV8BdMX4xh=\n-----END RSA PRIVATE KEY-----"
+        #>
+        #
+        # The key_pair can be retreived by running AWS.key_pairs.get("test").  See get method below.
+        #
+
         def initialize(attributes)
           self.filters ||= {}
           super
         end
+
+        # Returns an array of all key pairs that have been created
+        #
+        # AWS.key_pairs.all
+        #
+        # ==== Returns
+        #
+        # <Fog::AWS::Compute::KeyPairs
+        #  key_name=nil
+        #  [
+        #    <Fog::AWS::Compute::KeyPair
+        #      name="test",
+        #      fingerprint="1f:26:3d:83:e7:4f:48:74:c3:1c:e6:b3:c7:f6:ec:d8:cb:09:b3:7f",
+        #      private_key=nil
+        #    >
+        #  ]
+        #>
+        #
 
         def all(filters = filters)
           unless filters.is_a?(Hash)
@@ -26,6 +58,22 @@ module Fog
           data = connection.describe_key_pairs(filters).body
           load(data['keySet'])
         end
+
+        # Used to retreive a key pair that was created with the AWS.key_pairs.create method.
+        # The name is required to get the associated key_pair information.
+        #
+        # You can run the following command to get the details:
+        # AWS.key_pairs.get("test")
+        #
+        # ==== Returns
+        #
+        #>> AWS.key_pairs.get("test")
+        #  <Fog::AWS::Compute::KeyPair
+        #    name="test",
+        #    fingerprint="1f:26:3d:83:e7:4f:48:74:c3:1c:e6:b3:c7:f6:ec:d8:cb:09:b3:7f",
+        #    private_key=nil
+        #  >
+        #
 
         def get(key_name)
           if key_name

--- a/lib/fog/aws/models/compute/volume.rb
+++ b/lib/fog/aws/models/compute/volume.rb
@@ -87,7 +87,7 @@ module Fog
           @server = nil
           self.server_id = nil
           unless new_record?
-            connection.detach_volume(@id)
+            connection.detach_volume(id)
             reload
           end
         end
@@ -96,7 +96,7 @@ module Fog
           @server = nil
           self.server_id = nil
           unless new_record?
-            connection.detach_volume(@id, 'Force' => true)
+            connection.detach_volume(id, 'Force' => true)
             reload
           end
         end

--- a/lib/fog/aws/models/compute/volumes.rb
+++ b/lib/fog/aws/models/compute/volumes.rb
@@ -12,10 +12,54 @@ module Fog
 
         model Fog::AWS::Compute::Volume
 
+        # Used to create a volume.  There are 3 arguments and availability_zone and size are required.  You can generate a new key_pair as follows:
+        # AWS.volumes.create(:availability_zone => 'us-east-1a', :size => 't1.micro')
+        #
+        # ==== Returns
+        #
+        #<Fog::AWS::Compute::Volume
+        #  id="vol-1e2028b9",
+        #  attached_at=nil,
+        #  availability_zone="us-east-1a",
+        #  created_at=Tue Nov 23 23:30:29 -0500 2010,
+        #  delete_on_termination=nil,
+        #  device=nil,
+        #  server_id=nil,
+        #  size="t1.micro",
+        #  snapshot_id=nil,
+        #  state="creating",
+        #  tags=nil
+        #>
+        #
+        # The volume can be retreived by running AWS.volumes.get("vol-1e2028b9").  See get method below.
+        #
+
         def initialize(attributes)
           self.filters ||= {}
           super
         end
+
+        # Used to return all volumes.
+        # AWS.volumes.all
+        #
+        # ==== Returns
+        #
+        #<Fog::AWS::Compute::Volume
+        #  id="vol-1e2028b9",
+        #  attached_at=nil,
+        #  availability_zone="us-east-1a",
+        #  created_at=Tue Nov 23 23:30:29 -0500 2010,
+        #  delete_on_termination=nil,
+        #  device=nil,
+        #  server_id=nil,
+        #  size="t1.micro",
+        #  snapshot_id=nil,
+        #  state="creating",
+        #  tags=nil
+        #>
+        #
+        # The volume can be retreived by running AWS.volumes.get("vol-1e2028b9").  See get method below.
+        #
 
         def all(filters = filters)
           unless filters.is_a?(Hash)
@@ -30,6 +74,30 @@ module Fog
           end
           self
         end
+
+        # Used to retreive a volume
+        # volume_id is required to get the associated volume information.
+        #
+        # You can run the following command to get the details:
+        # AWS.volumes.get("vol-1e2028b9")
+        #
+        # ==== Returns
+        #
+        #>> AWS.volumes.get("vol-1e2028b9")
+        # <Fog::AWS::Compute::Volume
+        #    id="vol-1e2028b9",
+        #    attached_at=nil,
+        #    availability_zone="us-east-1a",
+        #    created_at=Tue Nov 23 23:30:29 -0500 2010,
+        #    delete_on_termination=nil,
+        #    device=nil,
+        #    server_id=nil,
+        #    size="t1.micro",
+        #    snapshot_id=nil,
+        #    state="available",
+        #    tags={}
+        #  >
+        #
 
         def get(volume_id)
           if volume_id

--- a/lib/fog/aws/requests/storage/put_object_acl.rb
+++ b/lib/fog/aws/requests/storage/put_object_acl.rb
@@ -1,0 +1,93 @@
+module Fog
+  module AWS
+    class Storage
+      class Real
+
+        # Change access control list for an S3 object
+        #
+        # ==== Parameters
+        # * bucket_name<~String> - name of bucket to modify
+        # * object_name<~String> - name of object to get access control list for
+        # * acl<~Hash>:
+        #   * Owner<~Hash>:
+        #     * ID<~String>: id of owner
+        #     * DisplayName<~String>: display name of owner
+        #   * AccessControlList<~Array>:
+        #     * Grantee<~Hash>:
+        #         * 'DisplayName'<~String> - Display name of grantee
+        #         * 'ID'<~String> - Id of grantee
+        #       or
+        #         * 'EmailAddress'<~String> - Email address of grantee
+        #       or
+        #         * 'URI'<~String> - URI of group to grant access for
+        #     * Permission<~String> - Permission, in [FULL_CONTROL, WRITE, WRITE_ACP, READ, READ_ACP]
+        # * options<~Hash>:
+        #   * 'versionId'<~String> - specify a particular version to retrieve
+        #
+        # ==== See Also
+        # http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTObjectPUTacl.html
+
+        def put_object_acl(bucket_name, object_name, acl, options = {})
+          query = {'acl' => nil}
+          if version_id = options.delete('versionId')
+            query['versionId'] = version_id
+          end
+
+          data =
+<<-DATA
+<AccessControlPolicy>
+  <Owner>
+    <ID>#{acl['Owner']['ID']}</ID>
+    <DisplayName>#{acl['Owner']['DisplayName']}</DisplayName>
+  </Owner>
+  <AccessControlList>
+DATA
+
+          acl['AccessControlList'].each do |grant|
+            data << "    <Grant>"
+            type = case grant['Grantee'].keys.sort
+            when ['DisplayName', 'ID']
+              'CanonicalUser'
+            when ['EmailAddress']
+              'AmazonCustomerByEmail'
+            when ['URI']
+              'Group'
+            end
+            data << "      <Grantee xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:type=\"#{type}\">"
+            for key, value in grant['Grantee']
+              data << "        <#{key}>#{value}</#{key}>"
+            end
+            data << "      </Grantee>"
+            data << "      <Permission>#{grant['Permission']}</Permission>"
+            data << "    </Grant>"
+          end
+
+          data <<
+<<-DATA
+  </AccessControlList>
+</AccessControlPolicy>
+DATA
+
+          request({
+            :body     => data,
+            :expects  => 200,
+            :headers  => {},
+            :host     => "#{bucket_name}.#{@host}",
+            :method   => 'PUT',
+            :path       => CGI.escape(object_name),
+            :query    => query
+          })
+        end
+
+      end
+
+      class Mock # :nodoc:all
+
+        def put_object_acl(bucket_name, object_name, options, acl)
+          Fog::Mock.not_implemented
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/simpledb.rb
+++ b/lib/fog/aws/simpledb.rb
@@ -3,7 +3,8 @@ module Fog
     class SimpleDB < Fog::Service
 
       requires :aws_access_key_id, :aws_secret_access_key
-
+      recognizes :host, :nil_string, :path, :port, :scheme, :persistent
+      
       request_path 'fog/aws/requests/simpledb'
       request :batch_put_attributes
       request :create_domain

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -3,7 +3,8 @@ module Fog
     class Storage < Fog::Service
 
       requires :aws_access_key_id, :aws_secret_access_key
-
+      recognizes :endpoint, :region, :host, :path, :port, :scheme, :persistent
+      
       model_path 'fog/aws/models/storage'
       collection  :directories
       model       :directory
@@ -38,6 +39,7 @@ module Fog
       request :put_bucket_logging
       request :put_bucket_versioning
       request :put_object
+      request :put_object_acl
       request :put_object_url
       request :put_request_payment
       request :upload_part
@@ -174,6 +176,7 @@ module Fog
         end
       end
 
+      
       class Real
         include Utils
         extend Fog::Deprecation

--- a/lib/fog/bluebox/compute.rb
+++ b/lib/fog/bluebox/compute.rb
@@ -3,6 +3,7 @@ module Fog
     class Compute < Fog::Service
 
       requires :bluebox_api_key, :bluebox_customer_id
+      recognizes :bluebox_host, :bluebox_port, :bluebox_scheme, :persistent
 
       model_path 'fog/bluebox/models/compute'
       model       :flavor

--- a/lib/fog/brightbox/compute.rb
+++ b/lib/fog/brightbox/compute.rb
@@ -5,6 +5,7 @@ module Fog
       API_URL = "https://api.gb1.brightbox.com/"
 
       requires :brightbox_client_id, :brightbox_secret
+      recognizes :brightbox_auth_url, :brightbox_api_url
 
       model_path 'fog/brightbox/models/compute'
       model :account # Singular resource, no collection

--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -148,6 +148,7 @@ module Fog
         !identity
       end
 
+      # check that the attributes specified in args exist and is not nil
       def requires(*args)
         missing = []
         for arg in [:connection] | args

--- a/lib/fog/core/credentials.rb
+++ b/lib/fog/core/credentials.rb
@@ -28,28 +28,29 @@ module Fog
         unless credentials && credentials[credential]
           print("\n  To run as '#{credential}', add the following to #{config_path}\n")
           yml = <<-YML
-
 :#{credential}:
-  :aws_access_key_id:     INTENTIONALLY_LEFT_BLANK
-  :aws_secret_access_key: INTENTIONALLY_LEFT_BLANK
-  :bluebox_api_key:       INTENTIONALLY_LEFT_BLANK
-  :bluebox_customer_id:   INTENTIONALLY_LEFT_BLANK
-  :brightbox_client_id:   INTENTIONALLY_LEFT_BLANK
-  :brightbox_secret:      INTENTIONALLY_LEFT_BLANK
-  :go_grid_api_key:       INTENTIONALLY_LEFT_BLANK
-  :go_grid_shared_secret: INTENTIONALLY_LEFT_BLANK
-  :local_root:            INTENTIONALLY_LEFT_BLANK
-  :new_servers_password:  INTENTIONALLY_LEFT_BLANK
-  :new_servers_username:  INTENTIONALLY_LEFT_BLANK
-  :public_key_path:       INTENTIONALLY_LEFT_BLANK
-  :private_key_path:      INTENTIONALLY_LEFT_BLANK
-  :rackspace_api_key:     INTENTIONALLY_LEFT_BLANK
-  :rackspace_username:    INTENTIONALLY_LEFT_BLANK
-  :slicehost_password:    INTENTIONALLY_LEFT_BLANK
-  :terremark_username:    INTENTIONALLY_LEFT_BLANK
-  :terremark_password:    INTENTIONALLY_LEFT_BLANK
+  :aws_access_key_id:                INTENTIONALLY_LEFT_BLANK
+  :aws_secret_access_key:            INTENTIONALLY_LEFT_BLANK
+  :bluebox_api_key:                  INTENTIONALLY_LEFT_BLANK
+  :bluebox_customer_id:              INTENTIONALLY_LEFT_BLANK
+  :brightbox_client_id:              INTENTIONALLY_LEFT_BLANK
+  :brightbox_secret:                 INTENTIONALLY_LEFT_BLANK
+  :go_grid_api_key:                  INTENTIONALLY_LEFT_BLANK
+  :go_grid_shared_secret:            INTENTIONALLY_LEFT_BLANK
+  :google_storage_access_key_id:     INTENTIONALLY_LEFT_BLANK
+  :google_storage_secret_access_key: INTENTIONALLY_LEFT_BLANK
+  :local_root:                       INTENTIONALLY_LEFT_BLANK
+  :new_servers_password:             INTENTIONALLY_LEFT_BLANK
+  :new_servers_username:             INTENTIONALLY_LEFT_BLANK
+  :public_key_path:                  INTENTIONALLY_LEFT_BLANK
+  :private_key_path:                 INTENTIONALLY_LEFT_BLANK
+  :rackspace_api_key:                INTENTIONALLY_LEFT_BLANK
+  :rackspace_username:               INTENTIONALLY_LEFT_BLANK
+  :slicehost_password:               INTENTIONALLY_LEFT_BLANK
+  :terremark_username:               INTENTIONALLY_LEFT_BLANK
+  :terremark_password:               INTENTIONALLY_LEFT_BLANK
 YML
-          print(yml)
+          print("\n#{yml}\n")
           raise(ArgumentError.new("Missing Credentials"))
         end
         credentials[credential]

--- a/lib/fog/core/service.rb
+++ b/lib/fog/core/service.rb
@@ -34,13 +34,24 @@ module Fog
         EOS
       end
 
+      def requirements
+        declared_parameters_for :new, :required
+      end
+
       def new(options={})
         if Fog.bin
-          default_credentials = Fog.credentials.reject {|key, value| !requirements.include?(key)}
+          #requirements = declared_parameters
+          #puts "*x" * 10
+          #puts "[#{self}]"
+          #puts "* credentials: #{Fog.credentials.inspect}"
+          #puts "- requirements: #{requirements.inspect}"
+          #puts "* options (before filter): #{options.inspect}"
+          default_credentials = filter_parameters(Fog.credentials)
           options = default_credentials.merge(options)
+          #puts "* options (after filter): #{options.inspect}"
+          #puts "*x" * 10
         end
 
-        validate_arguments(options)
         setup_requirements
 
         if Fog.mocking?
@@ -110,39 +121,8 @@ module Fog
         @requests ||= []
       end
 
-      def requires(*args)
-        requirements.concat(args)
-      end
-
-      def requirements
-        @requirements ||= []
-      end
-
-      def recognizes(*args)
-        recognized.concat(args)
-      end
-
-      def recognized
-        @recognized ||= []
-      end
-
       def reset_data(keys=Mock.data.keys)
         Mock.reset_data(keys)
-      end
-
-      def validate_arguments(options)
-        missing = requirements - options.keys
-        unless missing.empty?
-          raise ArgumentError, "Missing required arguments: #{missing.join(', ')}"
-        end
-
-        # FIXME: avoid failing for the services that don't have recognizes yet
-        unless recognizes.empty?
-          unrecognized = options.keys - requirements - recognized
-          unless unrecognized.empty?
-            raise ArgumentError, "Unrecognized arguments: #{unrecognized.join(', ')}"
-          end
-        end
       end
 
     end

--- a/lib/fog/go_grid/compute.rb
+++ b/lib/fog/go_grid/compute.rb
@@ -2,8 +2,8 @@ module Fog
   module GoGrid
     class Compute < Fog::Service
 
-      requires :go_grid_api_key
-      requires :go_grid_shared_secret
+      requires :go_grid_api_key, :go_grid_shared_secret
+      recognizes :host, :path, :port, :scheme, :persistent
 
       model_path 'fog/go_grid/models/compute'
       model         :image

--- a/lib/fog/google/storage.rb
+++ b/lib/fog/google/storage.rb
@@ -3,6 +3,7 @@ module Fog
     class Storage < Fog::Service
 
       requires :google_storage_access_key_id, :google_storage_secret_access_key
+      recognizes :host, :port, :scheme, :persistent
 
       model_path 'fog/google/models/storage'
       collection  :directories
@@ -135,6 +136,7 @@ module Fog
         end
       end
 
+    
       class Real
         include Utils
         extend Fog::Deprecation

--- a/lib/fog/linode/compute.rb
+++ b/lib/fog/linode/compute.rb
@@ -3,6 +3,7 @@ module Fog
     class Compute < Fog::Service
 
       requires :linode_api_key
+      recognizes :port, :scheme, :persistent
 
       model_path 'fog/linode/models/compute'
 

--- a/lib/fog/local/models/storage/file.rb
+++ b/lib/fog/local/models/storage/file.rb
@@ -45,7 +45,11 @@ module Fog
         def save(options = {})
           requires :body, :directory, :key
           file = ::File.new(path, 'w')
-          file.write(body)
+          if body.is_a?(String)
+            file.write(body)
+          else
+            file.write(body.read)
+          end
           file.close
           merge_attributes(
             :content_length => ::File.size(path),
@@ -61,7 +65,7 @@ module Fog
         end
 
         def path
-          connection.path_to(::File.join(directory.key, key))
+          connection.path_to(::File.join(directory.key, CGI.escape(key)))
         end
 
       end

--- a/lib/fog/local/models/storage/files.rb
+++ b/lib/fog/local/models/storage/files.rb
@@ -20,7 +20,7 @@ module Fog
               path = file_path(key)
               {
                 :content_length => ::File.size(path),
-                :key            => key,
+                :key            => CGI.unescape(key),
                 :last_modified  => ::File.mtime(path)
               }
             end
@@ -32,7 +32,7 @@ module Fog
 
         def get(key, &block)
           requires :directory
-          path = file_path(key)
+          path = file_path(CGI.escape(key))
           if ::File.exists?(path)
             data = {
               :content_length => ::File.size(path),
@@ -48,6 +48,20 @@ module Fog
               body = ::File.read(path)
               new(data.merge!(:body => body))
             end
+          else
+            nil
+          end
+        end
+
+        def head(key)
+          requires :directory
+          path = file_path(CGI.escape(key))
+          if ::File.exists?(path)
+            new({
+              :content_length => ::File.size(path),
+              :key            => key,
+              :last_modified  => ::File.mtime(path)
+            })
           else
             nil
           end

--- a/lib/fog/new_servers/compute.rb
+++ b/lib/fog/new_servers/compute.rb
@@ -4,8 +4,8 @@ module Fog
   module NewServers
     class Compute < Fog::Service
 
-      requires :new_servers_password
-      requires :new_servers_username
+      requires :new_servers_password, :new_servers_username
+      recognizes :host, :port, :scheme, :persistent
 
       model_path 'fog/new_servers/models/compute'
 

--- a/lib/fog/rackspace.rb
+++ b/lib/fog/rackspace.rb
@@ -1,6 +1,7 @@
 module Fog
   module Rackspace
-
+    
+    include NamedParameters
     extend Fog::Provider
 
     service_path 'fog/rackspace'
@@ -10,6 +11,11 @@ module Fog
     service 'servers'
     service 'storage'
 
+    # NOTE: might be better to rely on the caller alone to enforce parameter 
+    # requirements...
+    has_named_parameters :'self.authenticate', 
+      :required => [ :rackspace_api_key, :rackspace_username ],
+      :optional => [ :rackspace_auth_url ]
     def self.authenticate(options)
       rackspace_auth_url = options[:rackspace_auth_url] || "auth.api.rackspacecloud.com"
       connection = Fog::Connection.new("https://" + rackspace_auth_url)

--- a/lib/fog/rackspace/cdn.rb
+++ b/lib/fog/rackspace/cdn.rb
@@ -3,6 +3,9 @@ module Fog
     class CDN < Fog::Service
 
       requires :rackspace_api_key, :rackspace_username
+      # NOTE: recognizes clause delegates to Fog::Rackspace.authenticate's so 
+      #       we also declare those parameters that the authenticate expects...
+      recognizes :rackspace_auth_url, :persistent
 
       model_path 'fog/rackspace/models/cdn'
 

--- a/lib/fog/rackspace/compute.rb
+++ b/lib/fog/rackspace/compute.rb
@@ -3,6 +3,9 @@ module Fog
     class Compute < Fog::Service
 
       requires :rackspace_api_key, :rackspace_username
+      # NOTE: recognizes clause delegates to Fog::Rackspace.authenticate's so 
+      #       we also declare those parameters that the authenticate expects...
+      recognizes :rackspace_auth_url, :persistent
 
       model_path 'fog/rackspace/models/compute'
       model       :flavor

--- a/lib/fog/rackspace/models/storage/directory.rb
+++ b/lib/fog/rackspace/models/storage/directory.rb
@@ -40,7 +40,7 @@ module Fog
           requires :key
           @public_url ||= begin
             begin response = connection.cdn.head_container(key)
-              response.headers['X-CDN-URI']
+              response.headers['X-CDN-Enabled'] == 'True' && response.headers['X-CDN-URI']
             rescue Fog::Service::NotFound
               nil
             end
@@ -51,7 +51,10 @@ module Fog
           requires :key
           connection.put_container(key)
           if @public
-            @public_url = connection.cdn.put_container(key).headers['X-CDN-URI']
+            @public_url = connection.cdn.put_container(key, 'X-CDN-Enabled' => 'True').headers['X-CDN-URI']
+          else
+            connection.cdn.put_container(key, 'X-CDN-Enabled' => 'False')
+            @public_url = nil
           end
           true
         end

--- a/lib/fog/rackspace/models/storage/files.rb
+++ b/lib/fog/rackspace/models/storage/files.rb
@@ -49,12 +49,12 @@ module Fog
 
         def get_url(key, expires)
           requires :directory
-          connection.get_object_url(directory.name, key, expires)
+          connection.get_object_url(directory.key, key, expires)
         end
 
         def head(key, options = {})
           requires :directory
-          data = connection.head_object(directory.name, key, options)
+          data = connection.head_object(directory.key, key)
           file_data = data.headers.merge({
             :key => key
           })

--- a/lib/fog/rackspace/storage.rb
+++ b/lib/fog/rackspace/storage.rb
@@ -3,6 +3,9 @@ module Fog
     class Storage < Fog::Service
 
       requires :rackspace_api_key, :rackspace_username
+      # NOTE: recognizes clause delegates to Fog::Rackspace.authenticate's so 
+      #       we also declare those parameters that the authenticate expects...
+      recognizes :rackspace_auth_url, :persistent
 
       model_path 'fog/rackspace/models/storage'
       model       :directory

--- a/lib/fog/slicehost/compute.rb
+++ b/lib/fog/slicehost/compute.rb
@@ -3,6 +3,7 @@ module Fog
     class Compute < Fog::Service
 
       requires :slicehost_password
+      recognizes :host, :port, :scheme, :persistent
 
       model_path 'fog/slicehost/models/compute'
       model       :flavor

--- a/lib/fog/terremark/ecloud.rb
+++ b/lib/fog/terremark/ecloud.rb
@@ -32,7 +32,9 @@ module Fog
       end
 
       class Real
-
+        requires :terremark_ecloud_password, :terremark_ecloud_username
+        recognizes :host, :path, :port, :scheme, :persistent
+        
         include Fog::Terremark::Shared::Real
         include Fog::Terremark::Shared::Parser
 

--- a/lib/fog/vcloud.rb
+++ b/lib/fog/vcloud.rb
@@ -19,7 +19,8 @@ end
 module Fog
   class Vcloud < Fog::Service
 
-    requires :username, :password, :versions_uri
+    requires :username, :password, :module, :versions_uri
+    recognizes :version, :persistent
 
     model_path 'fog/vcloud/models'
     model :vdc

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -1,12 +1,16 @@
+__DIR__ = File.dirname(__FILE__)
+__LIB_DIR__ = File.join(__DIR__, '../lib')
+
+[ __DIR__, __LIB_DIR__ ].each do |directory|
+  $LOAD_PATH.unshift directory unless
+    $LOAD_PATH.include?(directory) ||
+    $LOAD_PATH.include?(File.expand_path(directory))
+end
+
 require 'fog'
 require 'fog/core/bin'
+
 Fog.bin = true
-
-__DIR__ = File.dirname(__FILE__)
-
-$LOAD_PATH.unshift __DIR__ unless
-  $LOAD_PATH.include?(__DIR__) ||
-  $LOAD_PATH.include?(File.expand_path(__DIR__))
 
 require 'tests/helpers/collection_tests'
 require 'tests/helpers/model_tests'
@@ -20,8 +24,20 @@ require 'tests/helpers/storage/directories_tests'
 require 'tests/helpers/storage/file_tests'
 require 'tests/helpers/storage/files_tests'
 
+# Use so you can run in mock mode from the command line:
+#
+# FOG_MOCK=true fog
+
 if ENV["FOG_MOCK"] == "true"
   Fog.mock!
+end
+
+# check to see which credentials are available and add others to the skipped tags list
+all_providers = ['aws', 'bluebox', 'brightbox', 'gogrid', 'google', 'linode', 'local', 'newservers', 'rackspace', 'slicehost', 'terremark']
+available_providers = Fog.providers.map {|provider| provider.to_s.downcase}
+for provider in (all_providers - available_providers)
+  Formatador.display_line("[yellow]Skipping tests for [bold]#{provider}[/] [yellow]due to lacking credentials (add some to '~/.fog' to run them)[/]")
+  Thread.current[:tags] << ('-' << provider)
 end
 
 # Boolean hax


### PR DESCRIPTION
Basically everything starting from the Nov 21 pull request, to Nov 29. I apologize for the large number of combined commits.

Anyway, invoking `bin/fog` still shows:

```
$ ./bin/fog 
  Welcome to fog interactive!
  :default credentials provide AWS, Bluebox, Brightbox, GoGrid, Google, Local, NewServers and Slicehost
  You have access to the following Vcloud services: :ecloud.
```

And the tests returns the same results as before (same amount of passed, failures, and pendings); so maybe everything's covered this time around.
