### PR TITLE
Allow additional connection options

### DIFF
--- a/lib/fog/core/connection.rb
+++ b/lib/fog/core/connection.rb
@@ -1,8 +1,8 @@
 module Fog
   class Connection
 
-    def initialize(url, persistent=false)
-      @excon = Excon.new(url)
+    def initialize(url, persistent=false, params={})
+      @excon = Excon.new(url, params)
       @persistent = persistent
     end
 


### PR DESCRIPTION
Adds an additional optional param when creating a Fog::Connection object which can pass on other connection params to the underlying Excon object.
