### PR TITLE
Use Net::SSH's KeyManager to detect ssh-agent

### DIFF
--- a/lib/fog/core/ssh.rb
+++ b/lib/fog/core/ssh.rb
@@ -2,9 +2,6 @@ module Fog
   module SSH
 
     def self.new(address, username, options = {})
-      unless options[:key_data] || options[:keys] || options[:password] || ENV['SSH_AUTH_SOCK']
-        raise ArgumentError.new(':key_data, :keys, :password or ENV[\'SSH_AUTH_SOCK\'] are required to initialize SSH')
-      end
       if Fog.mocking?
         Fog::SSH::Mock.new(address, username, options)
       else
@@ -40,6 +37,13 @@ module Fog
 
       def initialize(address, username, options)
         require 'net/ssh'
+
+        key_manager = Net::SSH::Authentication::KeyManager.new(nil, options)
+
+        unless options[:key_data] || options[:keys] || options[:password] || key_manager.agent
+          raise ArgumentError.new(':key_data, :keys, :password or a loaded ssh-agent is required to initialize SSH')
+        end
+
         @address  = address
         @username = username
         @options  = { :paranoid => false }.merge(options)


### PR DESCRIPTION
The presence of `ENV['SSH_AUTH_SOCK']` is necessary but not sufficient for `ssh-agent` support (e.g. no agent may be listening on the socket; the listening agent may be SSH2-compatible and hence [currently unsupported](https://github.com/net-ssh/net-ssh/blob/v2.0.0/lib/net/ssh/authentication/agent.rb#L83-84)) so it is better to delegate this decision to `Net::SSH`.

This is [davidx's work](https://github.com/davidx/fog/compare/af6ad7f...9aa94ce); I just rebased it.
