### PR TITLE
Fix custom caller_reference not working with AWS DNS to create zone

### DIFF
--- a/lib/fog/dns/requests/aws/create_hosted_zone.rb
+++ b/lib/fog/dns/requests/aws/create_hosted_zone.rb
@@ -10,18 +10,18 @@ module Fog
         # ==== Parameters
         # * name<~String> - The name of the domain. Must be a fully-specified domain that ends with a period
         # * options<~Hash>
-        #   * caller_ref<~String> - unique string that identifies the request & allows failed 
+        #   * caller_ref<~String> - unique string that identifies the request & allows failed
         #                           calls to be retried without the risk of executing the operation twice
-        #   * comment<~Integer> - 
+        #   * comment<~Integer> -
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         #     * 'HostedZone'<~Hash>:
-        #       * 'Id'<~String> - 
-        #       * 'Name'<~String> - 
+        #       * 'Id'<~String> -
+        #       * 'Name'<~String> -
         #       * 'CallerReference'<~String>
-        #       * 'Comment'<~String> - 
+        #       * 'Comment'<~String> -
         #     * 'ChangeInfo'<~Hash> -
         #       * 'Id'<~String>
         #       * 'Status'<~String>
@@ -33,16 +33,16 @@ module Fog
 
           optional_tags = ''
           if options[:caller_ref]
-              optional_tags+= "<CallerReference>#{options[:call_ref]}</CallerReference>"
+              optional_tags+= "<CallerReference>#{options[:caller_ref]}</CallerReference>"
           else
             #make sure we have a unique call reference
             caller_ref = "ref-#{rand(1000000).to_s}"
-            optional_tags+= "<CallerReference>#{caller_ref}</CallerReference>"            
+            optional_tags+= "<CallerReference>#{caller_ref}</CallerReference>"
           end
           if options[:comment]
               optional_tags+= "<HostedZoneConfig><Comment>#{options[:comment]}</Comment></HostedZoneConfig>"
           end
-            
+
           request({
             :body       => %Q{<?xml version="1.0" encoding="UTF-8"?><CreateHostedZoneRequest xmlns="https://route53.amazonaws.com/doc/2010-10-01/"><Name>#{name}</Name>#{optional_tags}</CreateHostedZoneRequest>},
             :parser     => Fog::Parsers::AWS::DNS::CreateHostedZone.new,


### PR DESCRIPTION
See files changed, pretty trivial change.

zomg fix it.

:)
