### PR TITLE
Upload / delete server certificates

### DIFF
--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -13,6 +13,7 @@ module Fog
       request :delete_access_key
       request :delete_group
       request :delete_group_policy
+      request :delete_server_certificate
       request :delete_signing_certificate
       request :delete_user
       request :delete_user_policy
@@ -33,6 +34,7 @@ module Fog
       request :update_group
       request :update_user
       request :update_signing_certificate
+      request :upload_server_certificate
       request :upload_signing_certificate
 
       class Mock

--- a/lib/fog/aws/requests/iam/delete_server_certificate.rb
+++ b/lib/fog/aws/requests/iam/delete_server_certificate.rb
@@ -1,0 +1,32 @@
+module Fog
+  module AWS
+    class IAM
+      class Real
+
+        require 'fog/aws/parsers/iam/basic'
+
+        # Deletes the specified server certificate.
+        #
+        # ==== Parameters
+        # * server_certificate_name<~String>: The name of the server certificate you want to delete.
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'RequestId'<~String> - Id of the request
+        #
+        # ==== See Also
+        # http://docs.amazonwebservices.com/IAM/latest/APIReference/API_DeleteServerCertificate.html
+        #
+        def delete_server_certificate(server_certificate_name)
+          request({
+            'Action'                => 'DeleteServerCertificate',
+            'ServerCertificateName' => server_certificate_name,
+            :parser                 => Fog::Parsers::AWS::IAM::Basic.new
+          })
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/iam/upload_server_certificate.rb
+++ b/lib/fog/aws/requests/iam/upload_server_certificate.rb
@@ -1,0 +1,45 @@
+module Fog
+  module AWS
+    class IAM
+      class Real
+
+        require 'fog/aws/parsers/iam/basic'
+
+        # Uploads a server certificate entity for the AWS Account.
+        # Includes a public key certificate, a private key, and an optional certificate chain, which should all be PEM-encoded.
+        #
+        # ==== Parameters
+        # * certificate<~Hash>: The contents of the public key certificate in PEM-encoded format.
+        # * private_key<~Hash>: The contents of the private key in PEM-encoded format.
+        # * name<~Hash>: The name for the server certificate. Do not include the path in this value.
+        # * options<~Hash>:
+        #   * 'CertificateChain'<~String> - The contents of the certificate chain. Typically a concatenation of the PEM-encoded public key certificates of the chain.
+        #   * 'Path'<~String> - The path for the server certificate.
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'UploadServerCertificateResult'<~Hash>:
+        #       * 'CertificateId'<~String> -
+        #       * 'UserName'<~String> -
+        #       * 'CertificateBody'<~String> -
+        #       * 'Status'<~String> -
+        #     * 'RequestId'<~String> - Id of the request
+        #
+        # ==== See Also
+        # http://docs.amazonwebservices.com/IAM/latest/APIReference/index.html?API_UploadServerCertificate.html
+        #
+        def upload_server_certificate(certificate, private_key, name, options = {})
+          request({
+            'Action'                => 'UploadServerCertificate',
+            'CertificateBody'       => certificate,
+            'PrivateKey'            => private_key,
+            'ServerCertificateName' => name,
+            :parser                 => Fog::Parsers::AWS::IAM::Basic.new
+          }.merge!(options))
+        end
+
+      end
+    end
+  end
+end


### PR DESCRIPTION
This allows uploading server certificates (SSL certs) for use on AWS.  Particularly useful in conjunction with elastic load balancers.
