### PR TITLE
Support HTTPS on Elastic Load Balancers

### DIFF
--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -85,7 +85,7 @@ module Fog
               :host               => @host,
               :path               => @path,
               :port               => @port,
-              :version            => '2009-11-25'
+              :version            => '2010-07-01'
             }
           )
 

--- a/lib/fog/aws/requests/elb/create_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer.rb
@@ -14,6 +14,7 @@ module Fog
         #   * 'Protocol'<~String> - Protocol to use. Either HTTP or TCP.
         #   * 'LoadBalancerPort'<~Integer> - The port that the ELB will listen to for outside traffic
         #   * 'InstancePort'<~Integer> - The port on the instance that the ELB will forward traffic to
+        #   * 'SSLCertificateId'<~String> - ARN of the server certificate
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
@@ -27,15 +28,18 @@ module Fog
           listener_protocol = []
           listener_lb_port = []
           listener_instance_port = []
+          listener_ssl_certificate_id = []
           listeners.each do |listener|
             listener_protocol.push(listener['Protocol'])
             listener_lb_port.push(listener['LoadBalancerPort'])
             listener_instance_port.push(listener['InstancePort'])
+            listener_ssl_certificate_id.push(listener['SSLCertificateId'])
           end
 
           params.merge!(AWS.indexed_param('Listeners.member.%d.Protocol', listener_protocol))
           params.merge!(AWS.indexed_param('Listeners.member.%d.LoadBalancerPort', listener_lb_port))
           params.merge!(AWS.indexed_param('Listeners.member.%d.InstancePort', listener_instance_port))
+          params.merge!(AWS.indexed_param('Listeners.member.%d.SSLCertificateId', listener_ssl_certificate_id))
 
           request({
             'Action'           => 'CreateLoadBalancer',


### PR DESCRIPTION
If using the HTTPS protocol, an IAM SSL Certificate ID is also required.
