### PR TITLE
Aws tag destroy

### DIFF
--- a/lib/fog/compute/models/aws/tag.rb
+++ b/lib/fog/compute/models/aws/tag.rb
@@ -18,7 +18,7 @@ module Fog
 
         def destroy
           requires :key, :resource_id
-          connection.delete_tags(resource_id, key)
+          connection.delete_tags(resource_id, key => value)
           true
         end
 


### PR DESCRIPTION
The destroy method of aws.tag.rb doesn't appear to work. Changing the arg in the call to delete_tags from a String to a hash appears to resolve the issue.

def self.remove_tag(snapshot, tag_name)
    tags = aws_connection.tags.all({:key => tag_name}) 
    tags.each {|t| t.destroy if t.resource_id == snapshot.id } if tags 
end

irb(main):003:0> Snapshot.remove_tag(snap, 'example_tag')
NoMethodError: undefined method `keys' for "":String
    from /opt/code/fog/lib/fog/compute/requests/aws/delete_tags.rb:28:in`delete_tags'
    from /opt/code/fog/lib/fog/compute/models/aws/tag.rb:21:in `destroy'
    from /opt/code/backupadmin/app/models/snapshot.rb:43:in`remove_tag'
    from (eval):5:in `each'
    from (eval):5:in`each'
    from /opt/code/backupadmin/app/models/snapshot.rb:43:in `remove_tag'
    from (irb):3
