### PR TITLE
Collection.rb - slice needs special treatment

### DIFF
--- a/lib/fog/core/collection.rb
+++ b/lib/fog/core/collection.rb
@@ -5,7 +5,7 @@ module Fog
     include Fog::Attributes::InstanceMethods
 
     Array.public_instance_methods(false).each do |method|
-      unless [:reject, :select].include?(method.to_sym)
+      unless [:reject, :select, :slice].include?(method.to_sym)
         class_eval <<-RUBY
           def #{method}(*args)
             unless @loaded
@@ -17,7 +17,7 @@ module Fog
       end
     end
 
-    %w[reject select].each do |method|
+    %w[reject select slice].each do |method|
       class_eval <<-RUBY
         def #{method}(*args)
           unless @loaded


### PR DESCRIPTION
slice was failing due to lazy loading. Other ops I thought would similarly fail such as -, +, rotate, etc did not. The only one I found that needed tweaking was slice.

t1 = ec2.tags.all(:key => 'ec2-tag')
irb(main):013:0> t2 = t1.slice(2,3)
NoMethodError: undefined method `describe_tags' for nil:NilClass
        from /opt/ruby-enterprise-1.8.7/lib/ruby/gems/1.8/gems/activesupport-3.0.3/lib/active_support/whiny_nil.rb:48:in`>
        from /opt/code/fog/lib/fog/compute/models/aws/tags.rb:21:in `all'
        from /opt/code/fog/lib/fog/core/collection.rb:137:in`lazy_load'
        from (eval):3:in `empty?'
        from /opt/code/fog/lib/fog/core/collection.rb:84:in`inspect'
        from /opt/ruby-enterprise-1.8.7/lib/ruby/gems/1.8/gems/formatador-0.0.16/lib/formatador.rb:92:in `indent'
        from /opt/code/fog/lib/fog/core/collection.rb:77:in`inspect'
        from /opt/ruby-enterprise-1.8.7/lib/ruby/1.8/irb.rb:310:in `output_value'
