### PR TITLE
Add support for AWS RDS DB security groups

### DIFF
--- a/lib/fog/aws/parsers/rds/authorize_db_security_group_ingress.rb
+++ b/lib/fog/aws/parsers/rds/authorize_db_security_group_ingress.rb
@@ -1,0 +1,38 @@
+module Fog
+  module Parsers
+    module AWS
+      module RDS
+
+        require 'fog/aws/parsers/rds/security_group_parser'
+
+        class AuthorizeDBSecurityGroupIngress < Fog::Parsers::AWS::RDS::SecurityGroupParser
+
+          def reset
+            @response = { 'AuthorizeDBSecurityGroupIngressResult' => {}, 'ResponseMetadata' => {} }
+            super
+          end
+
+          def start_element(name, attrs = [])
+            super
+          end
+
+          def end_element(name)
+            case name
+            when 'DBSecurityGroup' then
+              @response['AuthorizeDBSecurityGroupIngressResult']['DBSecurityGroup'] = @security_group
+              @security_group = fresh_security_group
+            when 'RequestId'
+              @response['ResponseMetadata'][name] = @value
+            else
+              super
+            end
+
+          end
+
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/fog/aws/parsers/rds/create_db_security_group.rb
+++ b/lib/fog/aws/parsers/rds/create_db_security_group.rb
@@ -1,0 +1,38 @@
+module Fog
+  module Parsers
+    module AWS
+      module RDS
+
+        require 'fog/aws/parsers/rds/security_group_parser'
+
+        class CreateDBSecurityGroup < Fog::Parsers::AWS::RDS::SecurityGroupParser
+
+          def reset
+            @response = { 'CreateDBSecurityGroupResult' => {}, 'ResponseMetadata' => {} }
+            super
+          end
+
+          def start_element(name, attrs = [])
+            super
+          end
+
+          def end_element(name)
+            case name
+            when 'DBSecurityGroup' then
+              @response['CreateDBSecurityGroupResult']['DBSecurityGroup'] = @security_group
+              @security_group = fresh_security_group
+            when 'RequestId'
+              @response['ResponseMetadata'][name] = @value
+            else
+              super
+            end
+
+          end
+
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/fog/aws/parsers/rds/delete_db_security_group.rb
+++ b/lib/fog/aws/parsers/rds/delete_db_security_group.rb
@@ -1,0 +1,33 @@
+module Fog
+  module Parsers
+    module AWS
+      module RDS
+        require 'fog/aws/parsers/rds/snapshot_parser'
+
+        class DeleteDBSecurityGroup < Fog::Parsers::AWS::RDS::SnapshotParser
+
+          def reset
+            @response = { 'ResponseMetadata' => {} }
+            super
+          end
+
+          def start_element(name, attrs = [])
+            super
+          end
+
+          def end_element(name)
+            case name
+            when 'RequestId'
+              @response['ResponseMetadata'][name] = @value
+            else
+              super
+            end
+          end
+
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/fog/aws/parsers/rds/describe_db_security_groups.rb
+++ b/lib/fog/aws/parsers/rds/describe_db_security_groups.rb
@@ -1,0 +1,39 @@
+module Fog
+  module Parsers
+    module AWS
+      module RDS
+
+        require 'fog/aws/parsers/rds/security_group_parser'
+
+        class DescribeDBSecurityGroups < Fog::Parsers::AWS::RDS::SecurityGroupParser
+
+          def reset
+            @response = { 'DescribeDBSecurityGroupsResult' => {'DBSecurityGroups' => []}, 'ResponseMetadata' => {} }
+            super
+          end
+
+          def start_element(name, attrs = [])
+            super
+          end
+
+          def end_element(name)
+            case name
+            when 'DBSecurityGroup' then
+              @response['DescribeDBSecurityGroupsResult']['DBSecurityGroups'] << @security_group
+              @security_group = fresh_security_group
+            when 'Marker'
+              @response['DescribeDBSecurityGroupsResult']['Marker'] = @value
+            when 'RequestId'
+              @response['ResponseMetadata'][name] = @value
+            else
+              super
+            end
+
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/parsers/rds/revoke_db_security_group_ingress.rb
+++ b/lib/fog/aws/parsers/rds/revoke_db_security_group_ingress.rb
@@ -1,0 +1,39 @@
+module Fog
+  module Parsers
+    module AWS
+      module RDS
+
+        require 'fog/aws/parsers/rds/security_group_parser'
+
+        class RevokeDBSecurityGroupIngress < Fog::Parsers::AWS::RDS::SecurityGroupParser
+
+          def reset
+            @response = { 'RevokeDBSecurityGroupIngressResult' => {}, 'ResponseMetadata' => {} }
+            super
+          end
+
+          def start_element(name, attrs = [])
+            super
+          end
+
+          def end_element(name)
+            case name
+            when 'DBSecurityGroup' then
+              @response['RevokeDBSecurityGroupIngressResult']['DBSecurityGroup'] = @security_group
+              @security_group = fresh_security_group
+            when 'RequestId'
+              @response['ResponseMetadata'][name] = @value
+            else
+              super
+            end
+
+          end
+
+        end
+
+      end
+    end
+  end
+end
+
+

--- a/lib/fog/aws/parsers/rds/security_group_parser.rb
+++ b/lib/fog/aws/parsers/rds/security_group_parser.rb
@@ -1,0 +1,39 @@
+module Fog
+  module Parsers
+    module AWS
+      module RDS
+
+        class SecurityGroupParser < Fog::Parsers::Base
+
+          def reset
+            @security_group = fresh_security_group
+          end
+
+          def fresh_security_group
+            {'EC2SecurityGroups' => [], 'IPRanges' => []}
+          end
+
+          def start_element(name, attrs = [])
+            super
+            case name
+            when 'EC2SecurityGroup', 'IPRange'; then @ingress = {}
+            end
+
+          end
+
+          def end_element(name)
+            case name
+            when 'DBSecurityGroupDescription' then @security_group['DBSecurityGroupDescription'] = @value
+            when 'DBSecurityGroupName' then @security_group['DBSecurityGroupName'] = @value
+            when 'OwnerId' then @security_group['OwnerId'] = @value
+            when 'EC2SecurityGroup', 'IPRange'
+              @security_group["#{name}s"] << @ingress unless @ingress.empty?
+            when 'EC2SecurityGroupName', 'EC2SecurityGroupOwnerId', 'CIDRIP', 'Status'
+              @ingress[name] = @value
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -27,6 +27,12 @@ module Fog
       request :modify_db_parameter_group
       request :describe_db_parameter_groups
 
+      request :describe_db_security_groups
+      request :create_db_security_group
+      request :delete_db_security_group
+      request :authorize_db_security_group_ingress
+      request :revoke_db_security_group_ingress
+
       request :describe_db_parameters
       
       model_path 'fog/aws/rds/models'
@@ -39,6 +45,9 @@ module Fog
 
       model       :parameter
       collection  :parameters
+
+      model       :security_group
+      collection  :security_groups
 
       class Mock
 

--- a/lib/fog/aws/rds/models/security_group.rb
+++ b/lib/fog/aws/rds/models/security_group.rb
@@ -1,0 +1,73 @@
+require 'fog/core/model'
+
+module Fog
+  module AWS
+    class RDS
+
+      class SecurityGroup < Fog::Model
+
+        identity   :id, :aliases => ['DBSecurityGroupName']
+        attribute  :description, :aliases => 'DBSecurityGroupDescription'
+        attribute  :ec2_security_groups, :aliases => 'EC2SecurityGroups', :type => :array
+        attribute  :ip_ranges, :aliases => 'IPRanges', :type => :array
+        attribute  :owner_id, :aliases => 'OwnerId'
+
+        def ready?
+          (ec2_security_groups + ip_ranges).all?{|ingress| ingress['Status'] == 'authorized'}
+        end
+
+        def destroy
+          requires :id
+          connection.delete_db_security_group(id)
+          true
+        end
+
+        def save
+          requires :id
+          requires :description
+
+          data = connection.create_db_security_group(id, description).body['CreateDBSecurityGroupResult']['DBSecurityGroup']
+          merge_attributes(data)
+          true
+        end
+
+        # group_owner_id defaults to the current owner_id
+        def authorize_ec2_security_group(group_name, group_owner_id=owner_id)
+          authorize_ingress({
+            'EC2SecurityGroupName' => group_name,
+            'EC2SecurityGroupOwnerId' => group_owner_id
+          })
+        end
+
+        def authorize_cidrip(cidrip)
+          authorize_ingress({'CIDRIP' => cidrip})
+        end
+
+        def authorize_ingress(opts)
+          data = connection.authorize_db_security_group_ingress(id, opts).body['AuthorizeDBSecurityGroupIngressResult']['DBSecurityGroup']
+          merge_attributes(data)
+        end
+
+        # group_owner_id defaults to the current owner_id
+        def revoke_ec2_security_group(group_name, group_owner_id=owner_id)
+          revoke_ingress({
+            'EC2SecurityGroupName' => group_name,
+            'EC2SecurityGroupOwnerId' => group_owner_id
+          })
+        end
+
+        def revoke_cidrip(cidrip)
+          revoke_ingress({'CIDRIP' => cidrip})
+        end
+
+        def revoke_ingress(opts)
+          data = connection.revoke_db_security_group_ingress(id, opts).body['RevokeDBSecurityGroupIngressResult']['DBSecurityGroup']
+          merge_attributes(data)
+        end
+
+
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/rds/models/security_groups.rb
+++ b/lib/fog/aws/rds/models/security_groups.rb
@@ -1,0 +1,43 @@
+require 'fog/core/collection'
+require 'fog/aws/rds/models/security_group'
+
+module Fog
+  module AWS
+    class RDS
+
+      class SecurityGroups < Fog::Collection
+        attribute :server
+        attribute :filters
+        model Fog::AWS::RDS::SecurityGroup
+
+        def initialize(attributes={})
+          self.filters ||= {}
+          if attributes[:server]
+            filters[:identifier] = attributes[:server].id
+          end
+          super
+        end
+
+        def all(filters = filters)
+          self.filters = filters
+          data = connection.describe_db_security_groups(filters).body['DescribeDBSecurityGroupsResult']['DBSecurityGroups']
+          load(data) # data is an array of attribute hashes
+        end
+
+        # Example:
+        # get('my_db_security_group') # => model for my_db_security_group
+        def get(identity)
+          data = connection.describe_db_security_groups(identity).body['DescribeDBSecurityGroupsResult']['DBSecurityGroups'].first
+          new(data) # data is an attribute hash
+        rescue Fog::AWS::RDS::NotFound
+          nil
+        end
+
+        def new(attributes = {})
+          super
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/rds/authorize_db_security_group_ingress.rb
+++ b/lib/fog/aws/requests/rds/authorize_db_security_group_ingress.rb
@@ -1,0 +1,43 @@
+module Fog
+  module AWS
+    class RDS
+      class Real
+
+        require 'fog/aws/parsers/rds/authorize_db_security_group_ingress'
+
+        # authorizes a db security group ingress
+        # http://docs.amazonwebservices.com/AmazonRDS/latest/APIReference/index.html?API_AuthorizeDBSecurityGroupIngress.html
+        # ==== Parameters
+        # * CIDRIP <~String> - The IP range to authorize
+        # * DBSecurityGroupName <~String> - The name for the DB Security Group.
+        # * EC2SecurityGroupName <~String> - Name of the EC2 Security Group to authorize.
+        # * EC2SecurityGroupOwnerId <~String> - AWS Account Number of the owner of the security group specified in the EC2SecurityGroupName parameter. The AWS Access Key ID is not an acceptable value.
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        def authorize_db_security_group_ingress(name, opts={})
+          unless opts.key?('CIDRIP') || (opts.key?('EC2SecurityGroupName') && opts.key?('EC2SecurityGroupOwnerId'))
+            raise ArgumentError, 'Must specify CIDRIP, or both EC2SecurityGroupName and EC2SecurityGroupOwnerId'
+          end
+
+          request({
+            'Action'  => 'AuthorizeDBSecurityGroupIngress',
+            :parser   => Fog::Parsers::AWS::RDS::AuthorizeDBSecurityGroupIngress.new,
+            'DBSecurityGroupName' => name
+          }.merge(opts))
+
+        end
+
+      end
+
+      class Mock
+
+        def authorize_db_security_group_ingress(name, opts = {})
+          Fog::Mock.not_implemented
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/fog/aws/requests/rds/create_db_security_group.rb
+++ b/lib/fog/aws/requests/rds/create_db_security_group.rb
@@ -1,0 +1,37 @@
+module Fog
+  module AWS
+    class RDS
+      class Real
+
+        require 'fog/aws/parsers/rds/create_db_security_group'
+
+        # creates a db security group
+        # http://docs.amazonwebservices.com/AmazonRDS/latest/APIReference/index.html?API_CreateDBSecurityGroup.html
+        # ==== Parameters
+        # * DBSecurityGroupDescription <~String> - The description for the DB Security Group
+        # * DBSecurityGroupName <~String> - The name for the DB Security Group. This value is stored as a lowercase string. Must contain no more than 255 alphanumeric characters or hyphens. Must not be "Default".
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        def create_db_security_group(name, description = name)
+          request({
+            'Action'  => 'CreateDBSecurityGroup',
+            'DBSecurityGroupName' => name,
+            'DBSecurityGroupDescription' => description,
+            :parser   => Fog::Parsers::AWS::RDS::CreateDBSecurityGroup.new
+          })
+        end
+
+      end
+
+      class Mock
+
+        def create_db_security_group(name, description = name)
+          Fog::Mock.not_implemented
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/fog/aws/requests/rds/delete_db_security_group.rb
+++ b/lib/fog/aws/requests/rds/delete_db_security_group.rb
@@ -1,0 +1,36 @@
+module Fog
+  module AWS
+    class RDS
+      class Real
+
+        require 'fog/aws/parsers/rds/delete_db_security_group'
+
+        # deletes a db security group
+        # http://docs.amazonwebservices.com/AmazonRDS/latest/APIReference/index.html?API_DeleteDBSecurityGroup.html
+        # ==== Parameters
+        # * DBSecurityGroupName <~String> - The name for the DB Security Group to delete
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        def delete_db_security_group(name)
+          request({
+            'Action'  => 'DeleteDBSecurityGroup',
+            'DBSecurityGroupName' => name,
+            :parser   => Fog::Parsers::AWS::RDS::DeleteDBSecurityGroup.new
+          })
+        end
+
+      end
+
+      class Mock
+
+        def delete_db_security_group(name, description = name)
+          Fog::Mock.not_implemented
+        end
+
+      end
+    end
+  end
+end
+
+

--- a/lib/fog/aws/requests/rds/describe_db_security_groups.rb
+++ b/lib/fog/aws/requests/rds/describe_db_security_groups.rb
@@ -1,0 +1,39 @@
+module Fog
+  module AWS
+    class RDS
+      class Real
+
+        require 'fog/aws/parsers/rds/describe_db_security_groups'
+
+        # Describe all or specified db snapshots
+        # http://docs.amazonwebservices.com/AmazonRDS/latest/APIReference/index.html?API_DescribeDBSecurityGroups.html
+        # ==== Parameters
+        # * DBSecurityGroupName <~String> - The name of the DB Security Group to return details for.
+        # * Marker               <~String> - An optional marker provided in the previous DescribeDBInstances request
+        # * MaxRecords           <~Integer> - Max number of records to return (between 20 and 100)
+        # Only one of DBInstanceIdentifier or DBSnapshotIdentifier can be specified
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        def describe_db_security_groups(opts={})
+          opts = {'DBSecurityGroupName' => opts} if opts.is_a?(String)
+
+          request({
+            'Action'  => 'DescribeDBSecurityGroups',
+            :parser   => Fog::Parsers::AWS::RDS::DescribeDBSecurityGroups.new
+          }.merge(opts))
+        end
+
+      end
+
+      class Mock
+
+        def describe_db_security_group(opts={})
+          Fog::Mock.not_implemented
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/fog/aws/requests/rds/revoke_db_security_group_ingress.rb
+++ b/lib/fog/aws/requests/rds/revoke_db_security_group_ingress.rb
@@ -1,0 +1,44 @@
+module Fog
+  module AWS
+    class RDS
+      class Real
+
+        require 'fog/aws/parsers/rds/revoke_db_security_group_ingress'
+
+        # revokes a db security group ingress
+        # http://docs.amazonwebservices.com/AmazonRDS/latest/APIReference/index.html?API_RevokeDBSecurityGroupIngress.html
+        # ==== Parameters
+        # * CIDRIP <~String> - The IP range to revoke
+        # * DBSecurityGroupName <~String> - The name for the DB Security Group.
+        # * EC2SecurityGroupName <~String> - Name of the EC2 Security Group to revoke.
+        # * EC2SecurityGroupOwnerId <~String> - AWS Account Number of the owner of the security group specified in the EC2SecurityGroupName parameter. The AWS Access Key ID is not an acceptable value.
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        def revoke_db_security_group_ingress(name, opts={})
+          unless opts.key?('CIDRIP') || (opts.key?('EC2SecurityGroupName') && opts.key?('EC2SecurityGroupOwnerId'))
+            raise ArgumentError, 'Must specify CIDRIP, or both EC2SecurityGroupName and EC2SecurityGroupOwnerId'
+          end
+
+          request({
+            'Action'  => 'RevokeDBSecurityGroupIngress',
+            :parser   => Fog::Parsers::AWS::RDS::RevokeDBSecurityGroupIngress.new,
+            'DBSecurityGroupName' => name
+          }.merge(opts))
+
+        end
+
+      end
+
+      class Mock
+
+        def revoke_db_security_group_ingress(name, opts = {})
+          Fog::Mock.not_implemented
+        end
+
+      end
+    end
+  end
+end
+
+


### PR DESCRIPTION
To compliment the recent support for Amazon Relational Database Service, this adds support for managing security groups within RDS
