### PR TITLE
Fix rds db name

### DIFF
--- a/lib/fog/aws/parsers/rds/db_parser.rb
+++ b/lib/fog/aws/parsers/rds/db_parser.rb
@@ -45,7 +45,7 @@ module Fog
             when 'Engine', 
               'DBInstanceStatus', 'DBInstanceIdentifier', 'EngineVersion', 
               'PreferredBackupWindow', 'PreferredMaintenanceWindow', 
-              'AvailabilityZone', 'MasterUsername'
+              'AvailabilityZone', 'MasterUsername', 'DBName'
               @db_instance[name] = @value
             when 'MultiAZ', 'AutoMinorVersionUpgrade'
               if @value == 'false'


### PR DESCRIPTION
The RDS db_parser currently ignores the DBName attribute. This trivial patch fixes that.
