### PR TITLE
Fix rds snapshots

### DIFF
--- a/lib/fog/aws/requests/rds/describe_db_snapshots.rb
+++ b/lib/fog/aws/requests/rds/describe_db_snapshots.rb
@@ -17,15 +17,11 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         def describe_db_snapshots(opts={})
-          params = {}
-          params['DBInstanceIdentifier'] = opts[:identifier] if opts[:identifier]
-          params['DBSnapshotIdentifier'] = opts[:snapshot_id] if opts[:snapshot_id]
-          params['Marker'] = opts[:marker] if opts[:marker]
-          params['MaxRecords'] = opts[:max_records] if opts[:max_records]
+          opts = {'DBSnapshotIdentifier' => opts} if opts.is_a? String
           request({
             'Action'  => 'DescribeDBSnapshots',
             :parser   => Fog::Parsers::AWS::RDS::DescribeDBSnapshots.new
-          }.merge(params))
+          }.merge(opts))
         end
 
       end


### PR DESCRIPTION
The snapshots.get(id) method returns the first snapshot, not the snapshot you intend.

This patch fixes that by changing the RDS#describe_snapshots arguments to match what the snapshots collection is using.

Note that this patch changes the API to RDS#describe_snapshots (for the better, IMHO).

In a moment, I'll submit another patch that fixes the bug without changing the API.

Choose either this patch (to improve the API), or the other one (to preserve backwards compatibility).
