### PR TITLE
Fix rds snapshots safer

### DIFF
--- a/lib/fog/aws/rds/models/snapshots.rb
+++ b/lib/fog/aws/rds/models/snapshots.rb
@@ -25,7 +25,7 @@ module Fog
         end
 
         def get(identity)
-          data = connection.describe_db_snapshots(identity).body['DescribeDBSnapshotsResult']['DBSnapshots'].first
+          data = connection.describe_db_snapshots(:snapshot_id => identity).body['DescribeDBSnapshotsResult']['DBSnapshots'].first
           new(data) # data is an attribute hash
         rescue Fog::AWS::RDS::NotFound
           nil


### PR DESCRIPTION
Fixes snapshots.get() method in the RDS snapshot collection.

This patch doesn't change the API for RDS#describe_snapshots.

Choose either this patch or https://github.com/geemus/fog/pull/211
