### PR TITLE
Allow string keys in credentials file [issue 179]

### DIFF
--- a/lib/fog/core/credentials.rb
+++ b/lib/fog/core/credentials.rb
@@ -32,11 +32,21 @@ module Fog
   def self.credentials
     @credentials  ||= begin
       if credentials_path && File.exists?(credentials_path)
-        credentials = YAML.load_file(credentials_path)
+        credentials = self.symbolize_credentials(YAML.load_file(credentials_path))
         (credentials && credentials[credential]) or raise LoadError.new(missing_credentials)
       else
         {}
       end
+    end
+  end
+  
+  def self.symbolize_credentials(args)
+    if args.is_a? Hash
+      Hash[ args.collect do |key, value|
+        [key.to_sym, self.symbolize_credentials(value)]
+      end ]
+    else
+      args
     end
   end
 


### PR DESCRIPTION
Allow string or symbols for keys in credentials file.

I saw your twitter call to action - I've started with an easy one.
