### PR TITLE
Fix to SimpleDB to allow non-ascii characters

### DIFF
--- a/lib/fog/aws/simpledb.rb
+++ b/lib/fog/aws/simpledb.rb
@@ -4,7 +4,7 @@ module Fog
 
       requires :aws_access_key_id, :aws_secret_access_key
       recognizes :host, :nil_string, :path, :port, :scheme, :persistent
-      
+
       request_path 'fog/aws/requests/simpledb'
       request :batch_put_attributes
       request :create_domain
@@ -43,7 +43,7 @@ module Fog
         # Initialize connection to SimpleDB
         #
         # ==== Notes
-        # options parameter must include values for :aws_access_key_id and 
+        # options parameter must include values for :aws_access_key_id and
         # :aws_secret_access_key in order to create a connection
         #
         # ==== Examples
@@ -164,7 +164,7 @@ module Fog
           response = @connection.request({
             :body       => body,
             :expects    => 200,
-            :headers    => { 'Content-Type' => 'application/x-www-form-urlencoded' },
+            :headers    => { 'Content-Type' => 'application/x-www-form-urlencoded; charset=utf-8' },
             :host       => @host,
             :idempotent => idempotent,
             :method     => 'POST',


### PR DESCRIPTION
When sending non-ascii characters encoded as UTF-8 to SimpleDB with fog, the response is a 403. This is mitigated by setting the appropriate Content-Type header.

To reproduce (this is on REE):

```
    sdb = Fog::AWS::SimpleDB.new(:aws_access_key_id => key_id, :aws_secret_access_key => key, :host => "sdb.#{region}.amazonaws.com")
    sdb.put_attributes(domain, "some-item", {:n => 'aña'})
```

(See also: https://forums.aws.amazon.com/thread.jspa?messageID=220215)
