### PR TITLE
Content length calculation, ETag header and LastModified header

### DIFF
--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -21,26 +21,34 @@ module Fog
       end
     end
 
+    def self.get_body_size(body)
+      case
+      when body.respond_to?(:bytesize) then body.bytesize
+      when body.respond_to?(:size) then body.size
+      when body.respond_to?(:stat) then body.stat.size
+      else
+        0
+      end
+    end
+    
     def self.parse_data(data)
       metadata = {
         :body => nil,
         :headers => {}
       }
-
-      if data.is_a?(String)
-        metadata[:body] = data
-        metadata[:headers]['Content-Length'] = metadata[:body].size
-      else
+      
+      metadata[:body] = data
+      metadata[:headers]['Content-Length'] = get_body_size(data)
+      
+      if data.respond_to?(:path)
         filename = ::File.basename(data.path)
         unless (mime_types = MIME::Types.of(filename)).empty?
           metadata[:headers]['Content-Type'] = mime_types.first.content_type
         end
-        metadata[:body] = data
-        metadata[:headers]['Content-Length'] = ::File.size(data.path)
       end
       # metadata[:headers]['Content-MD5'] = Base64.encode64(Digest::MD5.digest(metadata[:body])).strip
       metadata
     end
-
+    
   end
 end

--- a/lib/fog/storage/models/aws/file.rb
+++ b/lib/fog/storage/models/aws/file.rb
@@ -117,12 +117,10 @@ module Fog
           options['x-amz-storage-class'] = storage_class if storage_class
 
           data = connection.put_object(directory.key, key, body, options)
+          data.headers.delete('Content-Length')
+          data.headers['ETag'].gsub!('"','')
           merge_attributes(data.headers)
-          if body.is_a?(String)
-            self.content_length = body.size
-          else
-            self.content_length = ::File.size(body.path)
-          end
+          self.content_length = Fog::Storage.get_body_size(body)
           true
         end
 

--- a/lib/fog/storage/models/aws/files.rb
+++ b/lib/fog/storage/models/aws/files.rb
@@ -46,6 +46,7 @@ module Fog
             :body => data.body,
             :key  => key
           })
+          normalise_headers(file_data)
           new(file_data)
         rescue Excon::Errors::NotFound
           nil
@@ -62,6 +63,7 @@ module Fog
           file_data = data.headers.merge({
             :key => key
           })
+          normalise_headers(file_data)
           new(file_data)
         rescue Excon::Errors::NotFound
           nil
@@ -70,6 +72,11 @@ module Fog
         def new(attributes = {})
           requires :directory
           super({ :directory => directory }.merge!(attributes))
+        end
+
+        def normalise_headers(headers)
+          headers['Last-Modified'] = Time.parse(headers['Last-Modified'])
+          headers['ETag'].gsub!('"','')
         end
 
       end


### PR DESCRIPTION
A few unrelated changes all for storage, mostly aws in this pull, sorry:
- normalise ETag header: remove quotes
- normalise LastModified headers to be consistent between save/create (perhaps the file model should use the :time attribute for this)
- decouple body size calculation from File/String, this makes it possible to stream non-File/String objects if they implement the protocol for :size, :read (needs excon geemus/excon#32)
