### PR TITLE
Fix rackspace escaping

### DIFF
--- a/lib/fog/core.rb
+++ b/lib/fog/core.rb
@@ -8,6 +8,7 @@ $LOAD_PATH.unshift __LIB_DIR__ unless
 require 'rubygems'
 require 'base64'
 require 'cgi'
+require 'uri'
 require 'excon'
 require 'fileutils'
 require 'formatador'

--- a/lib/fog/storage/requests/rackspace/delete_container.rb
+++ b/lib/fog/storage/requests/rackspace/delete_container.rb
@@ -12,7 +12,7 @@ module Fog
           response = request(
             :expects  => 204,
             :method   => 'DELETE',
-            :path     => CGI.escape(name)
+            :path     => URI.escape(name)
           )
           response
         end

--- a/lib/fog/storage/requests/rackspace/delete_object.rb
+++ b/lib/fog/storage/requests/rackspace/delete_object.rb
@@ -13,7 +13,7 @@ module Fog
           response = request(
             :expects  => 204,
             :method   => 'DELETE',
-            :path     => "#{CGI.escape(container)}/#{CGI.escape(object)}"
+            :path     => "#{URI.escape(container)}/#{URI.escape(object)}"
           )
           response
         end

--- a/lib/fog/storage/requests/rackspace/get_container.rb
+++ b/lib/fog/storage/requests/rackspace/get_container.rb
@@ -33,7 +33,7 @@ module Fog
           response = request(
             :expects  => 200,
             :method   => 'GET',
-            :path     => container,
+            :path     => URI.escape(container),
             :query    => {'format' => 'json'}.merge!(options)
           )
           response

--- a/lib/fog/storage/requests/rackspace/get_object.rb
+++ b/lib/fog/storage/requests/rackspace/get_object.rb
@@ -14,7 +14,7 @@ module Fog
             :block    => block,
             :expects  => 200,
             :method   => 'GET',
-            :path     => "#{CGI.escape(container)}/#{CGI.escape(object)}"
+            :path     => "#{URI.escape(container)}/#{URI.escape(object)}"
           }, false, &block)
           response
         end

--- a/lib/fog/storage/requests/rackspace/head_container.rb
+++ b/lib/fog/storage/requests/rackspace/head_container.rb
@@ -17,7 +17,7 @@ module Fog
           response = request(
             :expects  => 204,
             :method   => 'HEAD',
-            :path     => container,
+            :path     => URI.escape(container),
             :query    => {'format' => 'json'}
           )
           response

--- a/lib/fog/storage/requests/rackspace/head_object.rb
+++ b/lib/fog/storage/requests/rackspace/head_object.rb
@@ -13,7 +13,7 @@ module Fog
           response = request({
             :expects  => 200,
             :method   => 'GET',
-            :path     => "#{CGI.escape(container)}/#{CGI.escape(object)}"
+            :path     => "#{URI.escape(container)}/#{URI.escape(object)}"
           }, false)
           response
         end

--- a/lib/fog/storage/requests/rackspace/put_container.rb
+++ b/lib/fog/storage/requests/rackspace/put_container.rb
@@ -12,7 +12,7 @@ module Fog
           response = request(
             :expects  => [201, 202],
             :method   => 'PUT',
-            :path     => CGI.escape(name)
+            :path     => URI.escape(name)
           )
           response
         end

--- a/lib/fog/storage/requests/rackspace/put_object.rb
+++ b/lib/fog/storage/requests/rackspace/put_object.rb
@@ -16,7 +16,7 @@ module Fog
             :expects  => 201,
             :headers  => headers,
             :method   => 'PUT',
-            :path     => "#{CGI.escape(container)}/#{CGI.escape(object)}"
+            :path     => "#{URI.escape(container)}/#{URI.escape(object)}"
           )
           response
         end


### PR DESCRIPTION
CGI.escape doesn't properly escape container or object names with spaces or other important characters in them when accessing the Rackspace Storage REST API.  Using URI.escape does.

From master:

```
>> d = f.directories.get("Raw Video")
Excon::Errors::BadRequest: Expected(200) <=> Actual(400 Bad Request)
```

From this branch:

```
>> d = f.directories.get("Raw Video") 
=>   Fog::Rackspace::Storage::Directory
    key"Raw Video",
    bytes"12845395968",
    count"20"
```
