### PR TITLE
AWS Bugfix

### DIFF
--- a/lib/fog/compute/models/aws/server.rb
+++ b/lib/fog/compute/models/aws/server.rb
@@ -82,7 +82,7 @@ module Fog
         def key_pair
           requires :key_name
 
-          connection.keypairs.all(key_name).first
+          connection.key_pairs.all(key_name).first
         end
 
         def key_pair=(new_keypair)


### PR DESCRIPTION
Server#key_pair calls Connection#keypairs, which really should be Connection#key_pairs.
