### PR TITLE
Fix AWS instance mock dns filter name

### DIFF
--- a/lib/fog/compute/requests/aws/describe_instances.rb
+++ b/lib/fog/compute/requests/aws/describe_instances.rb
@@ -83,7 +83,7 @@ module Fog
             'architecture'      => 'architecture',
             'availability-zone' => 'availabilityZone',
             'client-token'      => 'clientToken',
-            'dns-token'         => 'dnsName',
+            'dns-name'         => 'dnsName',
             'group-id'          => 'groupId',
             'image-id'          => 'imageId',
             'instance-id'       => 'instanceId',


### PR DESCRIPTION
The correct name of the dns filter is dns-name, not dns-token.  Appears to have been a typo in the mock.
