### PR TITLE
Rackspace Storage's head_object method uses the HEAD HTTP method, not GET

### DIFF
--- a/lib/fog/storage/requests/rackspace/head_object.rb
+++ b/lib/fog/storage/requests/rackspace/head_object.rb
@@ -12,7 +12,7 @@ module Fog
         def head_object(container, object)
           response = request({
             :expects  => 200,
-            :method   => 'GET',
+            :method   => 'HEAD',
             :path     => "#{URI.escape(container)}/#{URI.escape(object)}"
           }, false)
           response


### PR DESCRIPTION
Rackspace Storage's head_object method uses the HEAD HTTP method, not GET
