### PR TITLE
Fog.credentials_path should deal with missing env vars better

### DIFF
--- a/lib/fog/core/credentials.rb
+++ b/lib/fog/core/credentials.rb
@@ -18,7 +18,10 @@ module Fog
 
   # @return [String] The path for configuration_file
   def self.credentials_path
-    @credential_path ||= File.expand_path(ENV["FOG_RC"] || (ENV['HOME'] && '~/.fog'))
+    @credential_path ||= begin
+      path = ENV["FOG_RC"] || (ENV['HOME'] && '~/.fog')
+      File.expand_path(path) if path
+    end
   end
 
   # @return [String] The new path for credentials file

--- a/tests/core/credential_tests.rb
+++ b/tests/core/credential_tests.rb
@@ -1,0 +1,36 @@
+Shindo.tests do
+  before do
+    @old_home = ENV['HOME']
+    @old_rc   = ENV['FOG_RC']
+    Fog.instance_variable_set('@credential_path', nil) # kill memoization
+  end
+
+  after do
+    ENV['HOME'] = @old_home
+    ENV['FOG_RC'] = @ld_rc
+  end
+
+  tests('credentials_path') do
+    returns('/rc/path', 'FOG_RC takes precedence over HOME') {
+      ENV['HOME'] = '/home/path'
+      ENV['FOG_RC'] = '/rc/path'
+    }
+
+    returns('/expanded/path', 'properly expands paths') {
+      ENV['FOG_RC'] = '/expanded/subdirectory/../path'
+      Fog.credentials_path
+    }
+
+    returns('/home/me/.fog', 'falls back to home path if FOG_RC not set') {
+      ENV['HOME'] = '/home/me'
+      ENV.delete('FOG_RC')
+      Fog.credentials_path
+    }
+
+    returns(nil, 'returns nil when neither FOG_RC or HOME are set') {
+      ENV.delete('HOME')
+      ENV.delete('FOG_RC')
+      Fog.credentials_path
+    }
+  end
+end


### PR DESCRIPTION
Currently if FOG_RC and HOME are unset you an error is raised from expand_path because it's given a nil value.

Instead the method should simply return nil when it can't find a path for the credentials. Fog.credentials handles nil values from credentials_path already.
