### PR TITLE
Base Parser fix to presumptuous strip in #characters method

### DIFF
--- a/lib/fog/core/parser.rb
+++ b/lib/fog/core/parser.rb
@@ -16,6 +16,7 @@ module Fog
 
       def characters(string)
         @value ||= ''
+        @value << string
       end
 
       def start_element(name, attrs = [])


### PR DESCRIPTION
for consideration:

removed strip statement from value in def characters. was not necessary and causes problems with AWS security groups. generally, it seems more dangerous to act on strings than to allow the actual values to pass through and allow consumers to deal with them.  specifically, it made managing AWS security groups impossible because you can't depend on the name being returned in a set to match the name of an actual specific record

in response to

https://github.com/geemus/fog/issues/#issue/241
fog / lib / fog / core / parser.rb
in def characters(string):

Parser calling .strip causes issues with AWS Security Groups that have a leading or trailing space in the name.

If I create a SecurityGroup [Compute|AWS] with a space after or before the name, ie: "Test " it is created fine. When I query against SecurityGroups.all, it is returned as just "Test" with the space missing. If I go to do a lookup: security_groups.get("Test "), it is returned, but is listed as just "Test".
