### PR TITLE
[aws|elb] Add tests for create, describe, and delete.

### DIFF
--- a/tests/aws/requests/elb/helper.rb
+++ b/tests/aws/requests/elb/helper.rb
@@ -1,0 +1,34 @@
+class AWS
+  module ELB
+    module Formats
+
+      BASIC = {
+        'ResponseMetadata' => {'RequestId' => String}
+      }
+
+      LOAD_BALANCER = {
+        "CreatedTime" => Time,
+        "ListenerDescriptions" => Array,
+        "HealthCheck" => {"HealthyThreshold" => Integer, "Timeout" => Integer, "UnhealthyThreshold" => Integer, "Interval" => Integer, "Target" => String},
+        "Policies" => {"LBCookieStickinessPolicies" => Array, "AppCookieStickinessPolicies" => Array},
+        "AvailabilityZones" => Array,
+        "DNSName" => String,
+        "LoadBalancerName"=> String,
+        "Instances"=> Array
+      }
+
+      CREATE_LOAD_BALANCER = BASIC.merge({
+        'CreateLoadBalancerResult' => { 'DNSName' => String }
+      })
+
+      DESCRIBE_LOAD_BALANCERS = BASIC.merge({
+        'DescribeLoadBalancersResult' => {'LoadBalancerDescriptions' => [LOAD_BALANCER]}
+      })
+
+      DELETE_LOAD_BALANCER = BASIC.merge({
+        'DeleteLoadBalancerResult' =>  NilClass
+      })
+
+    end
+  end
+end

--- a/tests/aws/requests/elb/load_balancer_tests.rb
+++ b/tests/aws/requests/elb/load_balancer_tests.rb
@@ -1,0 +1,21 @@
+Shindo.tests('AWS::ELB | load_balancer_tests', ['aws', 'elb']) do
+  @load_balancer_id = 'fog-test-elb'
+
+  tests('success') do
+    pending if Fog.mocking?
+
+    tests("#create_load_balancer").formats(AWS::ELB::Formats::CREATE_LOAD_BALANCER) do
+      zones = ['us-east-1a']
+      listeners = [{'LoadBalancerPort' => 80, 'InstancePort' => 80, 'Protocol' => 'http'}]
+      AWS[:elb].create_load_balancer(zones, @load_balancer_id, listeners).body
+    end
+
+    tests("#describe_load_balancers").formats(AWS::ELB::Formats::DESCRIBE_LOAD_BALANCERS) do
+      AWS[:elb].describe_load_balancers.body
+    end
+
+    tests("#delete_load_balancer").formats(AWS::ELB::Formats::DELETE_LOAD_BALANCER) do
+      AWS[:elb].delete_load_balancer(@load_balancer_id).body
+    end
+  end
+end


### PR DESCRIPTION
This adds 3  tests for Fog::AWS::ELB (create, describe, delete). It's not very much, but it's a start.

It might be enough to close https://github.com/geemus/fog/issues#issue/142
