### PR TITLE
fix Destinations for send_raw_email

### DIFF
--- a/lib/fog/aws/requests/ses/send_raw_email.rb
+++ b/lib/fog/aws/requests/ses/send_raw_email.rb
@@ -11,7 +11,7 @@ module Fog
         # * RawMessage <~String> - The message to be sent.
         # * Options <~Hash>
         #   * Source <~String> - The sender's email address. Takes precenence over Return-Path if specified in RawMessage
-        # * Destinations <~Array> - All destinations for this email.
+        #   * Destinations <~Array> - All destinations for this email.
         #
         # ==== Returns
         # * response<~Excon::Response>:


### PR DESCRIPTION
Destination in send_raw_email was sent incorrectly. Generating
Destinations=Destinations.member.1email@example.com
instead of
Destinations.member.1=email@example.com

Also corrected doc by changing "Delete an existing verified email address" to "Send a raw email".
