### PR TITLE
Problem when parsing  a Route 53 DKIM record

### DIFF
--- a/lib/fog/core/parser.rb
+++ b/lib/fog/core/parser.rb
@@ -15,7 +15,8 @@ module Fog
       end
 
       def characters(string)
-        @value = string
+        @value ||= ''
+        @value << string
       end
 
       def start_element(name, attrs = [])


### PR DESCRIPTION
When parsing a Route53 DNS record containing a  double quote character " such as
"v=DKIM1; k=rsa; p=MIGfMA0GCSqG....x59/8qdGvAo+S5xwIDAQAB"
the parser just retains the last double quote.
