### PR TITLE
Improving Fog::Model

### DIFF
--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -25,11 +25,16 @@ module Fog
 
     def reload
       requires :identity
-      if data = collection.get(identity)
-        new_attributes = data.attributes
-        merge_attributes(new_attributes)
-        self
+
+      return unless data = begin
+        collection.get(identity)
+      rescue Excon::Errors::SocketError
+        nil
       end
+
+      new_attributes = data.attributes
+      merge_attributes(new_attributes)
+      self
     end
 
     def to_json


### PR DESCRIPTION
This is a pair of changes to make Model#wait_for and Model#reload more useful.

Model#wait_for had a subtle bug where it would never drop out if reloads were failing.

Model#reload made no effort to contain network-related errors, which should (at least in certain contexts) be treated as "reload failure".  The context that called attention to this problem was Model#wait_for, which calls reload repeatedly expecting failures to be "false".  Other examples may exist, but if you'd prefer this change be limited to just Model#wait_for, I'd be happy to make that change as well.
