### PR TITLE
Fix aws attributes

### DIFF
--- a/lib/fog/core/parser.rb
+++ b/lib/fog/core/parser.rb
@@ -16,7 +16,7 @@ module Fog
 
       def characters(string)
         @value ||= ''
-        @value << string
+        @value << string.gsub(/\n.*/, '')
       end
 
       def start_element(name, attrs = [])

--- a/tests/compute/models/aws/security_group_tests.rb
+++ b/tests/compute/models/aws/security_group_tests.rb
@@ -2,4 +2,16 @@ Shindo.tests("AWS::Compute | security_group", ['aws']) do
 
   model_tests(AWS[:compute].security_groups, {:description => 'foggroupdescription', :name => 'foggroupname'}, true)
 
+  tests("a group with trailing whitespace") do
+    @group = AWS[:compute].security_groups.create(:name => "foggroup with spaces   ", :description => "   fog group desc   ")
+    test("name is correct") do
+      @group.name ==  "foggroup with spaces   "
+    end
+
+    test("description is correct") do
+      @group.description == "   fog group desc   "
+    end
+
+    @group.destroy
+  end
 end

--- a/tests/compute/models/aws/server_tests.rb
+++ b/tests/compute/models/aws/server_tests.rb
@@ -24,6 +24,12 @@ Shindo.tests("AWS::Compute | monitor", ['aws']) do
 
     @instance.save
 
+    [:id, :availability_zone, :flavor_id, :kernel_id, :image_id, :state].each do |attr|
+      test("instance##{attr} should not contain whitespace") do
+        nil == @instance.send(attr).match(/\s/)
+      end
+    end
+
     test('#monitor = true') do
       @instance.monitor = true
       @instance.monitoring == true


### PR DESCRIPTION
Commit 1364f1a0 introduces a regression where many parsed attributes contain a trailing linebreak and whitespace.

This commit removes the trailing whitespace, at least in AWS Computer server models.

I'm not very familiar with the DNS/Route 53 API, so I may have undone what commit 1364f1a0 fixed.

I added tests that some AWS EC2 attributes should not contain whitespace. It's not the best place to test this, but I didn't see any Fog::Parsers::Base unit tests.
