### PR TITLE
Fix xml value parsing

### DIFF
--- a/lib/fog/core/parser.rb
+++ b/lib/fog/core/parser.rb
@@ -15,7 +15,8 @@ module Fog
       end
 
       def characters(string)
-        @value = string
+        @value ||= ''
+        @value << string
       end
 
       def start_element(name, attrs = [])


### PR DESCRIPTION
xml character entities amongst other things cause multiple calls to
Fog::Core::Parsers::Base#characters so it needs to accumulate the
passed in values.

Bug noticable in aws get bucket requests returning empty etags for
contained keys.
