### PR TITLE
Fix for issue #283: S3 get_object request doesn't really support the Range header

### DIFF
--- a/lib/fog/storage/requests/aws/get_object.rb
+++ b/lib/fog/storage/requests/aws/get_object.rb
@@ -43,7 +43,7 @@ module Fog
           headers['If-Unmodified-Since'] = Fog::Time.at(options['If-Unmodified-Since'].to_i).to_date_header if options['If-Modified-Since']
           headers.merge!(options)
           request({
-            :expects  => headers.include?('Range') ? [ 200, 206 ] : 200,
+            :expects  => [ 200, 206 ],
             :headers  => headers,
             :host     => "#{bucket_name}.#{@host}",
             :idempotent => true,


### PR DESCRIPTION
Okay, this is the small fix for the Range header. I hope a new minor version will be out soon so I'll be able to get rid of the monkey patching I've done in my own code :)

Really awesome project - thanks!
