### PR TITLE
[aws|rds] Remove redundant NotFound class

### DIFF
--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -2,7 +2,6 @@ module Fog
   module AWS
     class RDS < Fog::Service
 
-      class NotFound < Fog::Errors::Error; end
       class IdentifierTaken < Fog::Errors::Error; end
 
       requires :aws_access_key_id, :aws_secret_access_key


### PR DESCRIPTION
This class is already defined in core.
