### PR TITLE
[aws|rds] Improve instance tests

### DIFF
--- a/tests/aws/requests/rds/instance_tests.rb
+++ b/tests/aws/requests/rds/instance_tests.rb
@@ -1,131 +1,127 @@
 Shindo.tests('AWS::RDS | instance requests', ['aws', 'rds']) do
-  @db_instance_id='fog-test'
-  @db_replica_id='fog-replica'
-  
+  # random_differentiator
+  # Useful when rapidly re-running tests, so we don't have to wait
+  # serveral minutes for deleted servers to disappear
+  suffix = rand(65536).to_s(16)
+
+  @db_instance_id       = "fog-test-#{suffix}"
+  @db_replica_id        = "fog-replica-#{suffix}"
+  @db_snapshot_id       = "fog-snapshot"
+  @db_final_snapshot_id = "fog-final-snapshot"
+
   tests('success') do
     pending if Fog.mocking?
-    
+
     tests("#create_db_instance").formats(AWS::RDS::Formats::CREATE_DB_INSTANCE) do
       result = AWS[:rds].create_db_instance(@db_instance_id, 'AllocatedStorage' => 5,
-                                                'DBInstanceClass' => 'db.m1.small',
-                                                'Engine' => 'mysql',
-                                                'EngineVersion' => '5.1.50',
-                                                'MasterUsername' => 'foguser',
-                                                'BackupRetentionPeriod' => 1,
-                                                'MasterUserPassword' => 'fogpassword').body
-    
+                                            'DBInstanceClass' => 'db.m1.small',
+                                            'Engine' => 'mysql',
+                                            'EngineVersion' => '5.1.50',
+                                            'MasterUsername' => 'foguser',
+                                            'BackupRetentionPeriod' => 1,
+                                            'MasterUserPassword' => 'fogpassword').body
+
       instance = result['CreateDBInstanceResult']['DBInstance']
       returns('creating'){ instance['DBInstanceStatus']}
       result
     end
-       
+
     tests("#describe_db_instances").formats(AWS::RDS::Formats::DESCRIBE_DB_INSTANCES) do
       AWS[:rds].describe_db_instances.body
     end
-    
+
     server = AWS[:rds].servers.get(@db_instance_id)
     server.wait_for {ready?}
-    
-    
+
+
+    new_storage = 6
     tests("#modify_db_instance with immediate apply").formats(AWS::RDS::Formats::MODIFY_DB_INSTANCE) do
-      body = AWS[:rds].modify_db_instance( @db_instance_id, true, 'AllocatedStorage'=> 10).body
+      body = AWS[:rds].modify_db_instance(@db_instance_id, true, 'AllocatedStorage'=> new_storage).body
       tests 'pending storage' do
         instance = body['ModifyDBInstanceResult']['DBInstance']
-        returns(10){instance['PendingModifiedValues']['AllocatedStorage']}
+        returns(new_storage){instance['PendingModifiedValues']['AllocatedStorage']}
       end
-      body      
+      body
     end
-    server.wait_for { state == 'modifying'}
-    server.wait_for { state == 'available'}
-  
-    server.reload
+
+    server.wait_for { state == 'modifying' }
+    server.wait_for { state == 'available' }
     tests 'new storage' do
-      returns(10){ server.allocated_storage}
+      returns(new_storage){ server.allocated_storage}
     end
-    server.wait_for { state == 'available'}
 
     tests("reboot db instance") do
       tests("#reboot").formats(AWS::RDS::Formats::REBOOT_DB_INSTANCE) do
-        AWS[:rds].reboot_db_instance( @db_instance_id).body
+        AWS[:rds].reboot_db_instance(@db_instance_id).body
       end
 
-      server.wait_for { state == 'rebooting'}
+      server.wait_for { state == 'rebooting' }
       server.wait_for { state == 'available'}
-      server.reload
     end
-    
-    
+
     tests("#create_db_snapshot").formats(AWS::RDS::Formats::CREATE_DB_SNAPSHOT) do
-      body = AWS[:rds].create_db_snapshot(@db_instance_id, 'fog-snapshot').body
+      body = AWS[:rds].create_db_snapshot(@db_instance_id, @db_snapshot_id).body
       returns('creating'){ body['CreateDBSnapshotResult']['DBSnapshot']['Status']}
       body
     end
-    
+
     tests("#describe_db_snapshots").formats(AWS::RDS::Formats::DESCRIBE_DB_SNAPSHOTS) do
-      body = AWS[:rds].describe_db_snapshots().body
+      body = AWS[:rds].describe_db_snapshots.body
     end
-    
-    Fog.wait_for do
-      data = AWS[:rds].describe_db_snapshots(:snapshot_id => 'fog-snapshot')
-      status = data.body['DescribeDBSnapshotsResult']['DBSnapshots'].first['Status']
-      status =='available'
-    end
-    
+
     tests( "#create read replica").formats(AWS::RDS::Formats::CREATE_READ_REPLICA) do
+      AWS[:rds].servers.get(@db_instance_id).wait_for { ready? }
       AWS[:rds].create_db_instance_read_replica(@db_replica_id, @db_instance_id).body
     end
-    
+
     replica = AWS[:rds].servers.get(@db_replica_id)
     replica.wait_for {ready?}
-    
+
     tests("replica source") do
       returns(@db_instance_id){replica.read_replica_source}
     end
     server.reload
-    
+
     tests("replica identifiers") do
       returns([@db_replica_id]){server.read_replica_identifiers}
     end
 
     tests("#delete_db_instance").formats(AWS::RDS::Formats::DELETE_DB_INSTANCE) do
-      server.wait_for { state == 'available'}
+      #server.wait_for { state == 'available'}
       AWS[:rds].delete_db_instance(@db_replica_id, nil, true)
-      body = AWS[:rds].delete_db_instance(@db_instance_id, 'fog-final-snapshot').body
-      Fog.wait_for do
-        AWS[:rds].servers.length == 0
-      end
-      
+      body = AWS[:rds].delete_db_instance(@db_instance_id, @db_final_snapshot_id).body
+
       tests "final snapshot" do
-        returns('available'){AWS[:rds].describe_db_snapshots(:snapshot_id => 'fog-final-snapshot').body['DescribeDBSnapshotsResult']['DBSnapshots'].first['Status']}
+        returns('creating'){AWS[:rds].describe_db_snapshots(:snapshot_id => @db_final_snapshot_id).body['DescribeDBSnapshotsResult']['DBSnapshots'].first['Status']}
       end
       body
     end
-    
-    
-    
+
     tests("#delete_db_snapshot").formats(AWS::RDS::Formats::DELETE_DB_SNAPSHOT) do
-      AWS[:rds].delete_db_snapshot('fog-snapshot').body
+      AWS[:rds].snapshots.get(@db_snapshot_id).wait_for { ready? }
+      AWS[:rds].delete_db_snapshot(@db_snapshot_id).body
     end
-    
-    AWS[:rds].delete_db_snapshot('fog-final-snapshot')
-    
-    returns([]){ AWS[:rds].describe_db_snapshots.body['DescribeDBSnapshotsResult']['DBSnapshots']}
-        
+
+    tests("snapshot.destroy") do
+      snapshot = AWS[:rds].snapshots.get(@db_final_snapshot_id)
+      snapshot.wait_for { ready? }
+      snapshot.destroy
+      returns(nil) { AWS[:rds].snapshots.get(@db_final_snapshot_id) }
+    end
+
   end
-  
+
   tests('failure') do
     pending if Fog.mocking?
-    
+
     tests "deleting nonexisting instance" do
-      raises(Fog::AWS::RDS::NotFound) {AWS[:rds].delete_db_instance('doesnexist', 'irrelevant')}      
+      raises(Fog::AWS::RDS::NotFound) {AWS[:rds].delete_db_instance('doesnexist', 'irrelevant')}
     end
     tests "deleting non existing snapshot" do
-      raises(Fog::AWS::RDS::NotFound) {AWS[:rds].delete_db_snapshot('doesntexist')}          
+      raises(Fog::AWS::RDS::NotFound) {AWS[:rds].delete_db_snapshot('doesntexist')}
     end
     tests "modifying non existing instance" do
       raises(Fog::AWS::RDS::NotFound) { AWS[:rds].modify_db_instance 'doesntexit', true, 'AllocatedStorage'=> 10}
     end
   end
 end
-  
-    


### PR DESCRIPTION
- Tests pass even if other RDS servers & snapshots are in the AWS account
- Removed unnecessary Fog.wait_for blocks
- DRYed up values as variables
- Cleaned up whitespace
