### PR TITLE
[compute|aws] Add failing tests for keypair parsing.

### DIFF
--- a/tests/compute/requests/aws/key_pair_tests.rb
+++ b/tests/compute/requests/aws/key_pair_tests.rb
@@ -20,7 +20,11 @@ Shindo.tests('AWS::Compute | key pair requests', ['aws']) do
     @public_key_material = 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA1SL+kgze8tvSFW6Tyj3RyZc9iFVQDiCKzjgwn2tS7hyWxaiDhjfY2mBYSZwFdKN+ZdsXDJL4CPutUg4DKoQneVgIC1zuXrlpPbaT0Btu2aFd4qNfJ85PBrOtw2GrWZ1kcIgzZ1mMbQt6i1vhsySD2FEj+5kGHouNxQpI5dFR5K+nGgcTLFGnzb/MPRBk136GVnuuYfJ2I4va/chstThoP8UwnoapRHcBpwTIfbmmL91BsRVqjXZEUT73nxpxFeXXidYwhHio+5dXwE0aM/783B/3cPG6FVoxrBvjoNpQpAcEyjtRh9lpwHZtSEW47WNzpIW3PhbQ8j4MryznqF1Rhw=='
 
     tests("#create_key_pair('#{@key_pair_name}')").formats(@keypair_format.merge({'keyMaterial' => String})) do
-      AWS[:compute].create_key_pair(@key_pair_name).body
+      body = AWS[:compute].create_key_pair(@key_pair_name).body
+      tests("private key is valid RSA key").returns(OpenSSL::PKey::RSA) do
+        OpenSSL::PKey::RSA.new(body['keyMaterial']).class
+      end
+      body
     end
 
     tests('#describe_key_pairs').formats(@keypairs_format) do


### PR DESCRIPTION
The private key is being truncated by the parser.

In irb, notice we only get the first line of the private key:

  Fog::Compute.new(:provider => 'AWS').key_pairs.create(:name => 'fog-test')
   =>   <Fog::AWS::Compute::KeyPair
      name="fog-test",
      fingerprint="ba:4a:33:1d:dc:71:f1:ec:e3:12:c4:8c:ad:7a:da:a5:9b:aa:3d:a1",
      private_key="-----BEGIN RSA PRIVATE KEY-----"
    > 

This is due to a bug in the current base parser. You may want to hold out on releasing today. I'll post more details momentarily.
