### PR TITLE
[compute|aws] Fix describe_instances filtering.

### DIFF
--- a/lib/fog/compute/requests/aws/describe_instances.rb
+++ b/lib/fog/compute/requests/aws/describe_instances.rb
@@ -58,7 +58,7 @@ module Fog
           params = {}
           # when seeking single instance id, old param style is most up to date
           if filters['instance-id'] && !filters['instance-id'].is_a?(Array)
-            params.merge('InstanceId' => filters.delete('instance-id'))
+            params.merge!('InstanceId' => filters.delete('instance-id'))
           end
           params.merge!(AWS.indexed_filters(filters))
 

--- a/tests/compute/requests/aws/instance_tests.rb
+++ b/tests/compute/requests/aws/instance_tests.rb
@@ -84,9 +84,16 @@ Shindo.tests('AWS::Compute | instance requests', ['aws']) do
     #   AWS[:compute].describe_instances.body
     # end
 
+    # Launch another instance to test filters
+    another_server = AWS[:compute].servers.create
+
     tests("#describe_instances('instance-id' => '#{@instance_id}')").formats(@describe_instances_format) do
-      AWS[:compute].describe_instances('instance-id' => @instance_id).body
+      body = AWS[:compute].describe_instances('instance-id' => @instance_id).body
+      tests("returns 1 instance").returns(1) { body['reservationSet'].size }
+      body
     end
+
+    another_server.destroy
 
     tests("#get_console_output('#{@instance_id}')").formats(@get_console_output_format) do
       AWS[:compute].get_console_output(@instance_id).body


### PR DESCRIPTION
describe_instances now correctly handles filters
with a single instance id. E.g.

```
AWS[:compute].describe_instances('instance-id' => 'i-12345678')
```
