### PR TITLE
Add Amazon API reference link to requests' documentation

### DIFF
--- a/lib/fog/compute/requests/aws/allocate_address.rb
+++ b/lib/fog/compute/requests/aws/allocate_address.rb
@@ -12,6 +12,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'publicIp'<~String> - The acquired address
         #     * 'requestId'<~String> - Id of the request
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-AllocateAddress.html]
         def allocate_address
           request(
             'Action'  => 'AllocateAddress',

--- a/lib/fog/compute/requests/aws/associate_address.rb
+++ b/lib/fog/compute/requests/aws/associate_address.rb
@@ -16,6 +16,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-AssociateAddress.html]
         def associate_address(instance_id, public_ip)
           request(
             'Action'      => 'AssociateAddress',

--- a/lib/fog/compute/requests/aws/attach_volume.rb
+++ b/lib/fog/compute/requests/aws/attach_volume.rb
@@ -21,6 +21,8 @@ module Fog
         #     * 'requestId'<~String> - Id of request
         #     * 'status'<~String> - Status of volume
         #     * 'volumeId'<~String> - Reference to volume
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-AttachVolume.html]
         def attach_volume(instance_id, volume_id, device)
           request(
             'Action'      => 'AttachVolume',

--- a/lib/fog/compute/requests/aws/authorize_security_group_ingress.rb
+++ b/lib/fog/compute/requests/aws/authorize_security_group_ingress.rb
@@ -24,6 +24,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-AuthorizeSecurityGroupIngress.html]
         def authorize_security_group_ingress(group_name, options = {})
           if group_name.is_a?(Hash)
             location = caller.first

--- a/lib/fog/compute/requests/aws/create_image.rb
+++ b/lib/fog/compute/requests/aws/create_image.rb
@@ -18,7 +18,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'imageId'<~String> - The ID of the created AMI.
         #     * 'requestId'<~String> - Id of request.
-        
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateImage.html]
         def create_image(instance_id, name, description, no_reboot = false)
           request(
             'Action'            => 'CreateImage',

--- a/lib/fog/compute/requests/aws/create_key_pair.rb
+++ b/lib/fog/compute/requests/aws/create_key_pair.rb
@@ -17,6 +17,8 @@ module Fog
         #     * 'keyMaterial'<~String> - Unencrypted encoded PEM private key
         #     * 'keyName'<~String> - Name of key
         #     * 'requestId'<~String> - Id of request
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateKeyPair.html]
         def create_key_pair(key_name)
           request(
             'Action'  => 'CreateKeyPair',

--- a/lib/fog/compute/requests/aws/create_security_group.rb
+++ b/lib/fog/compute/requests/aws/create_security_group.rb
@@ -16,6 +16,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateSecurityGroup.html]
         def create_security_group(name, description)
           request(
             'Action'            => 'CreateSecurityGroup',

--- a/lib/fog/compute/requests/aws/create_snapshot.rb
+++ b/lib/fog/compute/requests/aws/create_snapshot.rb
@@ -19,6 +19,8 @@ module Fog
         #     * 'startTime'<~Time> - timestamp when snapshot was initiated
         #     * 'status'<~String> - state of snapshot
         #     * 'volumeId'<~String> - id of volume snapshot targets
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateSnapshot.html]
         def create_snapshot(volume_id, description = nil)
           request(
             'Action'      => 'CreateSnapshot',

--- a/lib/fog/compute/requests/aws/create_tags.rb
+++ b/lib/fog/compute/requests/aws/create_tags.rb
@@ -16,6 +16,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateTags.html]
         def create_tags(resources, tags)
           resources = [*resources]
           for key, value in tags

--- a/lib/fog/compute/requests/aws/create_volume.rb
+++ b/lib/fog/compute/requests/aws/create_volume.rb
@@ -21,6 +21,8 @@ module Fog
         #     * 'snapshotId'<~String> - Snapshot volume was created from, if any
         #     * 'status's<~String> - State of volume
         #     * 'volumeId'<~String> - Reference to volume
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-CreateVolume.html]
         def create_volume(availability_zone, size, snapshot_id = nil)
           request(
             'Action'            => 'CreateVolume',

--- a/lib/fog/compute/requests/aws/delete_key_pair.rb
+++ b/lib/fog/compute/requests/aws/delete_key_pair.rb
@@ -15,6 +15,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteKeyPair.html]
         def delete_key_pair(key_name)
           request(
             'Action'    => 'DeleteKeyPair',

--- a/lib/fog/compute/requests/aws/delete_security_group.rb
+++ b/lib/fog/compute/requests/aws/delete_security_group.rb
@@ -15,6 +15,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteSecurityGroup.html]
         def delete_security_group(name)
           request(
             'Action'    => 'DeleteSecurityGroup',

--- a/lib/fog/compute/requests/aws/delete_snapshot.rb
+++ b/lib/fog/compute/requests/aws/delete_snapshot.rb
@@ -15,6 +15,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteSnapshot.html]
         def delete_snapshot(snapshot_id)
           request(
             'Action'      => 'DeleteSnapshot',

--- a/lib/fog/compute/requests/aws/delete_tags.rb
+++ b/lib/fog/compute/requests/aws/delete_tags.rb
@@ -16,6 +16,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteTags.html]
         def delete_tags(resources, tags)
           resources = [*resources]
           params = {}

--- a/lib/fog/compute/requests/aws/delete_volume.rb
+++ b/lib/fog/compute/requests/aws/delete_volume.rb
@@ -15,6 +15,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeleteVolume.html]
         def delete_volume(volume_id)
           request(
             'Action'    => 'DeleteVolume',

--- a/lib/fog/compute/requests/aws/deregister_image.rb
+++ b/lib/fog/compute/requests/aws/deregister_image.rb
@@ -15,6 +15,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'return'<~Boolean> - Returns true if deregistration succeeded
         #     * 'requestId'<~String> - Id of request
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DeregisterImage.html]
         def deregister_image(image_id)
           request(
             'Action'      => 'DeregisterImage',

--- a/lib/fog/compute/requests/aws/describe_addresses.rb
+++ b/lib/fog/compute/requests/aws/describe_addresses.rb
@@ -17,6 +17,8 @@ module Fog
         #     * 'addressesSet'<~Array>:
         #       * 'instanceId'<~String> - instance for ip address
         #       * 'publicIp'<~String> - ip address for instance
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeAddresses.html]
         def describe_addresses(filters = {})
           unless filters.is_a?(Hash)
             Formatador.display_line("[yellow][WARN] describe_addresses with #{filters.class} param is deprecated, use describe_addresses('public-ip' => []) instead[/] [light_black](#{caller.first})[/]")

--- a/lib/fog/compute/requests/aws/describe_availability_zones.rb
+++ b/lib/fog/compute/requests/aws/describe_availability_zones.rb
@@ -18,6 +18,8 @@ module Fog
         #       * 'regionName'<~String> - Name of region
         #       * 'zoneName'<~String> - Name of zone
         #       * 'zoneState'<~String> - State of zone
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeAvailabilityZones.html]
         def describe_availability_zones(filters = {})
           unless filters.is_a?(Hash)
             Formatador.display_line("[yellow][WARN] describe_availability_zones with #{filters.class} param is deprecated, use describe_availability_zones('zone-name' => []) instead[/] [light_black](#{caller.first})[/]")

--- a/lib/fog/compute/requests/aws/describe_images.rb
+++ b/lib/fog/compute/requests/aws/describe_images.rb
@@ -36,6 +36,8 @@ module Fog
         #       * 'rootDeviceName'<~String> - Root device name, e.g. /dev/sda1
         #       * 'rootDeviceType'<~String> - Root device type, ebs or instance-store
         #       * 'virtualizationType'<~String> - Type of virtualization
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImages.html]
         def describe_images(filters = {})
           options = {}
           for key in ['ExecutableBy', 'ImageId', 'Owner']

--- a/lib/fog/compute/requests/aws/describe_instances.rb
+++ b/lib/fog/compute/requests/aws/describe_instances.rb
@@ -50,6 +50,8 @@ module Fog
         #           * 'rootDeviceType'<~String> - root device type used by AMI in [ebs, instance-store]
         #           * 'ramdiskId'<~String> - Id of ramdisk used to launch instance
         #           * 'reason'<~String> - reason for most recent state transition, or blank
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstances.html]
         def describe_instances(filters = {})
           unless filters.is_a?(Hash)
             Formatador.display_line("[yellow][WARN] describe_instances with #{filters.class} param is deprecated, use describe_instances('instance-id' => []) instead[/] [light_black](#{caller.first})[/]")

--- a/lib/fog/compute/requests/aws/describe_key_pairs.rb
+++ b/lib/fog/compute/requests/aws/describe_key_pairs.rb
@@ -17,6 +17,8 @@ module Fog
         #     * 'keySet'<~Array>:
         #       * 'keyName'<~String> - Name of key
         #       * 'keyFingerprint'<~String> - Fingerprint of key
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeKeyPairs.html]
         def describe_key_pairs(filters = {})
           unless filters.is_a?(Hash)
             Formatador.display_line("[yellow][WARN] describe_key_pairs with #{filters.class} param is deprecated, use describe_key_pairs('key-name' => []) instead[/] [light_black](#{caller.first})[/]")

--- a/lib/fog/compute/requests/aws/describe_regions.rb
+++ b/lib/fog/compute/requests/aws/describe_regions.rb
@@ -17,6 +17,8 @@ module Fog
         #     * 'regionInfo'<~Array>:
         #       * 'regionName'<~String> - Name of region
         #       * 'regionEndpoint'<~String> - Service endpoint for region
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeRegions.html]
         def describe_regions(filters = {})
           unless filters.is_a?(Hash)
             Formatador.display_line("[yellow][WARN] describe_regions with #{filters.class} param is deprecated, use describe_regions('region-name' => []) instead[/] [light_black](#{caller.first})[/]")

--- a/lib/fog/compute/requests/aws/describe_reserved_instances.rb
+++ b/lib/fog/compute/requests/aws/describe_reserved_instances.rb
@@ -25,6 +25,8 @@ module Fog
         #       * 'start'<~Time> - start time for reservation
         #       * 'state'<~String> - state of reserved instance purchase, in .[pending-payment, active, payment-failed, retired]
         #       * 'usagePrice"<~Float> - usage price of reserved instances, per hour
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeReservedInstances.html]
         def describe_reserved_instances(filters = {})
           unless filters.is_a?(Hash)
             Formatador.display_line("[yellow][WARN] describe_reserved_instances with #{filters.class} param is deprecated, use describe_reserved_instances('reserved-instances-id' => []) instead[/] [light_black](#{caller.first})[/]")

--- a/lib/fog/compute/requests/aws/describe_reserved_instances_offerings.rb
+++ b/lib/fog/compute/requests/aws/describe_reserved_instances_offerings.rb
@@ -22,6 +22,8 @@ module Fog
         #       * 'productDescription'<~String> - description of offering
         #       * 'reservedInstancesOfferingId'<~String> - id of offering
         #       * 'usagePrice'<~Float> - usage price of offering, per hour
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeReservedInstancesOfferings.html]
         def describe_reserved_instances_offerings(filters = {})
           params = AWS.indexed_filters(filters)
           request({

--- a/lib/fog/compute/requests/aws/describe_security_groups.rb
+++ b/lib/fog/compute/requests/aws/describe_security_groups.rb
@@ -27,6 +27,8 @@ module Fog
         #           * 'cidrIp'<~String> - CIDR range
         #         * 'toPort'<~Integer> - End of port range (or -1 for ICMP wildcard)
         #       * 'ownerId'<~String> - AWS Access Key Id of the owner of the security group
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeSecurityGroups.html]
         def describe_security_groups(filters = {})
           unless filters.is_a?(Hash)
             Formatador.display_line("[yellow][WARN] describe_security_groups with #{filters.class} param is deprecated, use describe_security_groups('group-name' => []) instead[/] [light_black](#{caller.first})[/]")

--- a/lib/fog/compute/requests/aws/describe_snapshots.rb
+++ b/lib/fog/compute/requests/aws/describe_snapshots.rb
@@ -23,6 +23,8 @@ module Fog
         #       * 'startTime'<~Time>: Timestamp of when snapshot was initiated
         #       * 'status'<~String>: Snapshot state, in ['pending', 'completed']
         #       * 'volumeId'<~String>: Id of volume that snapshot contains
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeSnapshots.html]
         def describe_snapshots(filters = {}, options = {})
           unless filters.is_a?(Hash)
             Formatador.display_line("[yellow][WARN] describe_snapshots with #{filters.class} param is deprecated, use describe_snapshots('snapshot-id' => []) instead[/] [light_black](#{caller.first})[/]")

--- a/lib/fog/compute/requests/aws/describe_tags.rb
+++ b/lib/fog/compute/requests/aws/describe_tags.rb
@@ -19,6 +19,8 @@ module Fog
         #       * 'resourceType'<~String> - type of resource tag belongs to
         #       * 'key'<~String> - Tag's key
         #       * 'value'<~String> - Tag's value
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeTags.html]
         def describe_tags(filters = {})
           params = AWS.indexed_filters(filters)
           request({

--- a/lib/fog/compute/requests/aws/describe_volumes.rb
+++ b/lib/fog/compute/requests/aws/describe_volumes.rb
@@ -27,6 +27,8 @@ module Fog
         #         * 'instanceId'<~String> - Reference to attached instance
         #         * 'status'<~String> - Attachment state
         #         * 'volumeId'<~String> - Reference to volume
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeVolumes.html]
         def describe_volumes(filters = {})
           unless filters.is_a?(Hash)
             Formatador.display_line("[yellow][WARN] describe_volumes with #{filters.class} param is deprecated, use describe_volumes('volume-id' => []) instead[/] [light_black](#{caller.first})[/]")

--- a/lib/fog/compute/requests/aws/detach_volume.rb
+++ b/lib/fog/compute/requests/aws/detach_volume.rb
@@ -23,6 +23,8 @@ module Fog
         #     * 'requestId'<~String> - Id of request
         #     * 'status'<~String> - Status of volume
         #     * 'volumeId'<~String> - Reference to volume
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DetachVolume.html]
         def detach_volume(volume_id, options = {})
           request({
             'Action'    => 'DetachVolume',

--- a/lib/fog/compute/requests/aws/disassociate_address.rb
+++ b/lib/fog/compute/requests/aws/disassociate_address.rb
@@ -15,6 +15,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DisassociateAddress.html]
         def disassociate_address(public_ip)
           request(
             'Action'    => 'DisassociateAddress',

--- a/lib/fog/compute/requests/aws/get_console_output.rb
+++ b/lib/fog/compute/requests/aws/get_console_output.rb
@@ -17,6 +17,8 @@ module Fog
         #     * 'output'<~String> - Console output
         #     * 'requestId'<~String> - Id of request
         #     * 'timestamp'<~Time> - Timestamp of last update to output
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-GetConsoleOutput.html]
         def get_console_output(instance_id)
           request(
             'Action'      => 'GetConsoleOutput',

--- a/lib/fog/compute/requests/aws/get_password_data.rb
+++ b/lib/fog/compute/requests/aws/get_password_data.rb
@@ -19,6 +19,8 @@ module Fog
         #     * 'timestamp'<~Time> - Timestamp of last update to output
         #
         # See http://docs.amazonwebservices.com/AWSEC2/2010-08-31/APIReference/index.html?ApiReference-query-GetPasswordData.html
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-GetPasswordData.html]
         def get_password_data(instance_id)
           request(
             'Action'      => 'GetPasswordData',

--- a/lib/fog/compute/requests/aws/import_key_pair.rb
+++ b/lib/fog/compute/requests/aws/import_key_pair.rb
@@ -17,6 +17,8 @@ module Fog
         #     * 'keyFingerprint'<~String> - SHA-1 digest of DER encoded private key
         #     * 'keyName'<~String> - Name of key
         #     * 'requestId'<~String> - Id of request
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-ImportKeyPair.html]
         def import_key_pair(key_name, public_key_material)
           request(
             'Action'  => 'ImportKeyPair',

--- a/lib/fog/compute/requests/aws/modify_image_attributes.rb
+++ b/lib/fog/compute/requests/aws/modify_image_attributes.rb
@@ -12,6 +12,10 @@ module Fog
         # * attribute<~String> - Attribute to modify, in ['launchPermission', 'productCodes']
         # * operation_type<~String> - Operation to perform on attribute, in ['add', 'remove']
         #
+        #
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-ModifyImageAttribute.html]
+        #
         def modify_image_attributes(image_id, attribute, operation_type, options = {})
           params = {}
           params.merge!(AWS.indexed_param('UserId', options['UserId']))

--- a/lib/fog/compute/requests/aws/modify_snapshot_attribute.rb
+++ b/lib/fog/compute/requests/aws/modify_snapshot_attribute.rb
@@ -12,6 +12,10 @@ module Fog
         # * attribute<~String> - Attribute to modify, in ['createVolumePermission']
         # * operation_type<~String> - Operation to perform on attribute, in ['add', 'remove']
         #
+        #
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-ModifySnapshotAttribute.html]
+        #
         def modify_snapshot_attribute(snapshot_id, attribute, operation_type, options = {})
           params = {}
           params.merge!(AWS.indexed_param('UserId', options['UserId']))

--- a/lib/fog/compute/requests/aws/monitor_instances.rb
+++ b/lib/fog/compute/requests/aws/monitor_instances.rb
@@ -17,6 +17,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'instancesSet': http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-ItemType-MonitorInstancesResponseSetItemType.html
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-MonitorInstances.html]
         def monitor_instances(instance_ids)
           params = AWS.indexed_param('InstanceId', instance_ids)
           request({

--- a/lib/fog/compute/requests/aws/reboot_instances.rb
+++ b/lib/fog/compute/requests/aws/reboot_instances.rb
@@ -15,6 +15,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-RebootInstances.html]
         def reboot_instances(instance_id = [])
           params = AWS.indexed_param('InstanceId', instance_id)
           request({

--- a/lib/fog/compute/requests/aws/register_image.rb
+++ b/lib/fog/compute/requests/aws/register_image.rb
@@ -31,6 +31,10 @@ module Fog
         #   * body<~Hash>:
         #     * 'imageId'<~String> - Id of newly created AMI
 
+        #
+
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-RegisterImage.html]
+
         def register_image(name, description, location, block_devices=[], options={})
           common_options = {
             'Action'      => 'RegisterImage',

--- a/lib/fog/compute/requests/aws/release_address.rb
+++ b/lib/fog/compute/requests/aws/release_address.rb
@@ -12,6 +12,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-ReleaseAddress.html]
         def release_address(public_ip)
           request(
             'Action'    => 'ReleaseAddress',

--- a/lib/fog/compute/requests/aws/revoke_security_group_ingress.rb
+++ b/lib/fog/compute/requests/aws/revoke_security_group_ingress.rb
@@ -23,6 +23,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'return'<~Boolean> - success?
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-RevokeSecurityGroupIngress.html]
         def revoke_security_group_ingress(group_name, options = {})
           if group_name.is_a?(Hash)
             location = caller.first

--- a/lib/fog/compute/requests/aws/run_instances.rb
+++ b/lib/fog/compute/requests/aws/run_instances.rb
@@ -79,6 +79,8 @@ module Fog
         #     * 'ownerId'<~String> - Id of owner
         #     * 'requestId'<~String> - Id of request
         #     * 'reservationId'<~String> - Id of reservation
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-RunInstances.html]
         def run_instances(image_id, min_count, max_count, options = {})
           if block_device_mapping = options.delete('BlockDeviceMapping')
             block_device_mapping.each_with_index do |mapping, index|

--- a/lib/fog/compute/requests/aws/start_instances.rb
+++ b/lib/fog/compute/requests/aws/start_instances.rb
@@ -15,6 +15,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * TODO: fill in the blanks
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-StartInstances.html]
         def start_instances(instance_id)
           params = AWS.indexed_param('InstanceId', instance_id)
           request({

--- a/lib/fog/compute/requests/aws/stop_instances.rb
+++ b/lib/fog/compute/requests/aws/stop_instances.rb
@@ -15,6 +15,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * TODO: fill in the blanks
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-StopInstances.html]
         def stop_instances(instance_id)
           params = AWS.indexed_param('InstanceId', instance_id)
           request({

--- a/lib/fog/compute/requests/aws/terminate_instances.rb
+++ b/lib/fog/compute/requests/aws/terminate_instances.rb
@@ -22,6 +22,8 @@ module Fog
         #       * 'shutdownState'<~Hash>: shutdown state of instance
         #         * 'code'<~Integer> - current status code
         #         * 'name'<~String> - name of current state
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-TerminateInstances.html]
         def terminate_instances(instance_id)
           params = AWS.indexed_param('InstanceId', instance_id)
           request({

--- a/lib/fog/compute/requests/aws/unmonitor_instances.rb
+++ b/lib/fog/compute/requests/aws/unmonitor_instances.rb
@@ -17,6 +17,8 @@ module Fog
         #   * body<~Hash>:
         #     * 'requestId'<~String> - Id of request
         #     * 'instancesSet': http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-ItemType-MonitorInstancesResponseSetItemType.html
+        #
+        # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-UnmonitorInstances.html]
         def unmonitor_instances(instance_ids)
           params = AWS.indexed_param('InstanceId', instance_ids)
           request({


### PR DESCRIPTION
I find links back to the amazon api reference useful. YMMV. Generated with a few lines of script, so if you think this is useful but don't like the format it can easily be changed.
