### PR TITLE
Documentation fix

### DIFF
--- a/lib/fog/compute/models/aws/volumes.rb
+++ b/lib/fog/compute/models/aws/volumes.rb
@@ -13,7 +13,7 @@ module Fog
         model Fog::AWS::Compute::Volume
 
         # Used to create a volume.  There are 3 arguments and availability_zone and size are required.  You can generate a new key_pair as follows:
-        # AWS.volumes.create(:availability_zone => 'us-east-1a', :size => 't1.micro')
+        # AWS.volumes.create(:availability_zone => 'us-east-1a', :size => 10)
         #
         # ==== Returns
         #


### PR DESCRIPTION
:size should be a number in GB, not an instance size (e.g. 't1.micro')
