### PR TITLE
Fix Fog::Mock.reset

### DIFF
--- a/lib/fog/core/mock.rb
+++ b/lib/fog/core/mock.rb
@@ -64,13 +64,15 @@ module Fog
     end
 
     def self.reset
-      providers = Fog.providers.map{|p| eval("Fog::#{p}")}
-      services = providers.map{|p| p.constants.map{|s| eval("#{p}::#{s}")}}.flatten
-      services = services.select {|s| s.constants.include?(:Mock)}
+      providers = Fog.providers.map {|p| Fog.const_get(p) }
+      possible_service_constants = providers.map {|p| p.constants.map {|c| p.const_get(c) } }.flatten
+      # c.to_sym is 1.8.7 / 1.9.2 compat
+      services = possible_service_constants.select {|s| s.constants.map {|c| c.to_sym }.include?(:Mock) }
+      service_mocks = services.map {|s| s.const_get(:Mock) }
 
-      services.each do |service|
-        next unless service::Mock.respond_to?(:reset)
-        service::Mock.reset
+      service_mocks.each do |service_mock|
+        next unless service_mock.respond_to?(:reset)
+        service_mock.reset
       end
     end
 


### PR DESCRIPTION
Use `const_get` instead of `eval`, symbolize returned constants for 1.8.7/1.9.2 compat.
