### PR TITLE
Add a link to fog's Rubydocs.

### DIFF
--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -61,6 +61,7 @@ Wonder how you can get a lovely fog shirt? Look no further!
 Enjoy, and let me know what I can do to continue improving fog!
 
 * Work through the [fog tutorial](https://github.com/downloads/geemus/learn_fog/learn_fog.tar.gz)
+* Read fog's [API documentation](/latest/rdoc)
 * Stay up to date by following [@fog](http://twitter.com/fog) and/or [@geemus](http://twitter.com/geemus) on Twitter.
 * Get and give help on the [#ruby-fog](irc://irc.freenode.net/ruby-fog) irc channel on Freenode
 * Follow release notes and discussions on the [mailing list](http://groups.google.com/group/ruby-fog)


### PR DESCRIPTION
A tiny pull request to add the rdocs to fog's website.

Planning on adding some more doco examples on e.g. using fog with EC2, but my brain stopped functioning for tonight I'm afraid.
