### PR TITLE
fixed one small thing in the docs

### DIFF
--- a/docs/about/getting_started.markdown
+++ b/docs/about/getting_started.markdown
@@ -22,10 +22,10 @@ Now we can start writing our script, first off we should require fog.
 
 Now in order to play with our data we need to setup a storage connection.
 
-    storage = Fog::Storage.new(
+    storage = Fog::Storage.new({
       :local_root => '~/fog',
       :provider   => 'Local',
-    )
+    })
 
 `storage` will now contain our storage object, configured to use the Local provider from our specified directory.
 
@@ -70,11 +70,11 @@ Using the same interface you can also practice working against a real provider (
 This time we will turn on mocking and then, just like before, we will need to make a connection.
 
     Fog.mock!
-    storage = Fog::Storage.new(
+    storage = Fog::Storage.new({
       :aws_access_key_id      => 'fake_access_key_id',
       :aws_secret_access_key  => 'fake_secret_access_key',
       :provider               => 'AWS'
-    )
+    })
 
 You may notice that we used bogus credentials, this is fine since we are just simulating things.  To use real S3 you can simply omit `Fog.mock!` and swap in your real credentials.
 

--- a/docs/about/structure.markdown
+++ b/docs/about/structure.markdown
@@ -33,11 +33,11 @@ As an example, we'll try initializing and persisting a Rackspace Cloud server:
 
     require 'fog'
 
-    compute = Fog::Compute.new(
+    compute = Fog::Compute.new({
       :provider           => 'Rackspace',
       :rackspace_api_key  => key,
       :rackspace_username => username
-    )
+    })
 
     # boot a gentoo server (flavor 1 = 256, image 3 = gentoo 2008.0)
     server = compute.servers.create(:flavor_id => 1, :image_id => 3, :name => 'my_server')

--- a/docs/compute/index.markdown
+++ b/docs/compute/index.markdown
@@ -25,11 +25,11 @@ First, create a connection with your new account:
     require 'fog'
 
     # create a connection
-    connection = Fog::Compute.new(
+    connection = Fog::Compute.new({
       :provider                 => 'AWS',
       :aws_secret_access_key    => YOUR_SECRET_ACCESS_KEY,
       :aws_access_key_id        => YOUR_SECRET_ACCESS_KEY_ID
-    )
+    })
 
 With that in hand we are ready to start making EC2 calls!
 
@@ -75,11 +75,11 @@ These return an array of results, where each has stdout, stderr and status value
 Rackspace has <a href="http://www.rackspacecloud.com/cloud_hosting_products/servers">Cloud Servers</a> and you can sign up <a href="https://www.rackspacecloud.com/signup">here</a> and get your credentials <a href="https://manage.rackspacecloud.com/APIAccess.do">here</a>.
 
     # create a connection
-    connection = Fog::Compute.new(
+    connection = Fog::Compute.new({
       :provider           => 'Rackspace',
       :rackspace_username => RACKSPACE_USERNAME,
       :rackspace_api_key  => RACKSPACE_API_KEY
-    )
+    })
 
 We will skip over learning how to do this the 'Rackspace Way' and instead jump right to using bootstrap to get their smallest Ubuntu 10.04 LTS server.
 

--- a/docs/dns/index.markdown
+++ b/docs/dns/index.markdown
@@ -21,7 +21,7 @@ For this first example we will use Zerigo (see below for how to use other provid
       :provider     => 'Zerigo',
       :zerigo_email => ZERIGO_EMAIL,
       :zerigo_token => ZERIGO_TOKEN
-    }
+    })
 
 ## Getting in the Zone
 
@@ -68,11 +68,11 @@ You can add more specifics if you need to, but reasonable defaults make it just 
 
 If you already have an account with another service you can just as easily use this same code with different credentials. fog currently supports <a href="http://aws.amazon.com/route53/">AWS Route 53</a>, <a href="http://bluebox.net">Blue Box</a>, <a href="http://dnsimple.com">DNSimple</a>, <a href="http://www.linode.com">Linode</a>, <a href="http://www.slicehost.com">Slicehost</a> and <a href="http://www.zerigo.com/managed-dns">Zerigo</a>; so you can have your pick.  As an example you can connect to AWS instead of Zerigo:
 
-    dns = Fog::DNS.new(
+    dns = Fog::DNS.new({
       :provider               => 'AWS',
       :aws_access_key_id      => AWS_ACCESS_KEY_ID,
       :aws_secret_access_key  => AWS_SECRET_ACCESS_KEY
-    )
+    })
 
 ## Go Forth and Resolve
 

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -31,11 +31,11 @@ Now type 'fog' to try stuff, confident that fog will let you know what to do. He
 Play around and use the console to explore or check out the [getting started guide](/about/getting_started.html) for more details. Once you are reading to start scripting fog, here is a quick hint on how to make connections without the command line thing to help you.
 
     # create a compute connection
-    compute = Fog::Compute.new(:provider => 'AWS', :aws_access_key_id => ACCESS_KEY_ID, :aws_secret_access_key => SECRET_ACCESS_KEY)
+    compute = Fog::Compute.new({:provider => 'AWS', :aws_access_key_id => ACCESS_KEY_ID, :aws_secret_access_key => SECRET_ACCESS_KEY})
     # compute operations go here
 
     # create a storage connection
-    storage = Fog::Storage.new(:provider => 'AWS', :aws_access_key_id => ACCESS_KEY_ID, :aws_secret_access_key => SECRET_ACCESS_KEY)
+    storage = Fog::Storage.new({:provider => 'AWS', :aws_access_key_id => ACCESS_KEY_ID, :aws_secret_access_key => SECRET_ACCESS_KEY})
     # storage operations go here
 
 geemus says: "That should give you everything you need to get started, but let me know if there is anything I can do to help!"

--- a/docs/storage/index.markdown
+++ b/docs/storage/index.markdown
@@ -33,11 +33,11 @@ First, create a connection with your new account:
     require 'fog'
 
     # create a connection
-    connection = Fog::Storage.new(
+    connection = Fog::Storage.new({
       :provider                 => 'AWS',
       :aws_secret_access_key    => YOUR_SECRET_ACCESS_KEY,
       :aws_access_key_id        => YOUR_SECRET_ACCESS_KEY_ID
-    )
+    })
 
     # First, a place to contain the glorious details
     directory = connection.directories.create(
@@ -72,11 +72,11 @@ directory = connection.directories.get("proclamations1234567890")
     file.save
 
     # also, create(attributes) is just new(attributes).save, so you can also do:
-    file = directory.files.new(
+    file = directory.files.new({
       :key    => 'resume.html',
       :body   => 'improvements',
       :public => true
-    )
+    })
     file.save
 
 ## Backing up your files
@@ -129,21 +129,21 @@ More clouds? How much extra stuff will you have to do for these services!?! Hard
 
 Sign up <a href="http://gs-signup-redirect.appspot.com/">here</a> and get your credentials <a href="https://sandbox.google.com/storage/m/">here</a>.
 
-    connection = Fog::Storage.new(
+    connection = Fog::Storage.new({
       :provider                         => 'Google',
       :google_storage_secret_access_key => YOUR_SECRET_ACCESS_KEY,
       :google_storage_access_key_id     => YOUR_SECRET_ACCESS_KEY_ID
-    )
+    })
 
 ## Rackspace CloudFiles
 
 Rackspace has <a href="http://www.rackspacecloud.com/cloud_hosting_products/files">Cloud Files</a> and you can sign up <a href="https://www.rackspacecloud.com/signup">here</a> and get your credentials <a href="https://manage.rackspacecloud.com/APIAccess.do">here</a>.
 
-    connection = Fog::Storage.new(
+    connection = Fog::Storage.new({
       :provider           => 'Rackspace',
       :rackspace_username => RACKSPACE_USERNAME,
       :rackspace_api_key  => RACKSPACE_API_KEY
-    )
+    })
 
 Then create, save, destroy as per fog-for-AWS. The `:public => true` option when creating directories (see above) is important for Rackspace; your folder and files won't be shared to Rackspace's CDN and hence your users without it.  Similarly the `:public =&gt; true` on files is important for AWS and Google or they will be private.
 
@@ -151,10 +151,10 @@ Then create, save, destroy as per fog-for-AWS. The `:public => true` option when
 
 While you are working out the kinks you might not want to do everything live though, ditto for while you are running tests, so you have a couple options to try before you buy.  First, you can use a local provider to store things in a directory on your machine.
 
-    connection = Fog::Storage.new(
+    connection = Fog::Storage.new({
       :provider   => 'Local',
       :local_root => '~/fog'
-    )
+    })
 
 ## Mocking out Cloud Storage
 


### PR DESCRIPTION
In the docs when setting up the new connections the curly braces were missing, just added them in.

connection = Fog::Storage.new({ <params> }) 
