### PR TITLE
Fixed Fog::AWS::SimpleDB#delete_attributes in Fog.mock! mode.

### DIFF
--- a/lib/fog/aws/requests/simpledb/delete_attributes.rb
+++ b/lib/fog/aws/requests/simpledb/delete_attributes.rb
@@ -38,11 +38,21 @@ module Fog
         def delete_attributes(domain_name, item_name, attributes = nil)
           response = Excon::Response.new
           if self.data[:domains][domain_name]
-            if attributes
-              for key, value in attributes
-                if self.data[:domains][domain_name][key]
-                  self.data[:domains][domain_name][key].delete('value')
+            if self.data[:domains][domain_name][item_name]
+              if attributes
+                for key, value in attributes
+                  if self.data[:domains][domain_name][item_name][key]
+                    if value.nil? || value.empty?
+                      self.data[:domains][domain_name][item_name].delete(key)
+                    else
+                      for v in value
+                        self.data[:domains][domain_name][item_name][key].delete(v)
+                      end
+                    end
+                  end
                 end
+              else
+                self.data[:domains][domain_name][item_name].clear
               end
             end
             response.status = 200

--- a/tests/aws/requests/simpledb/attributes_tests.rb
+++ b/tests/aws/requests/simpledb/attributes_tests.rb
@@ -36,12 +36,28 @@ Shindo.tests('AWS::SimpleDB | attributes requests', ['aws']) do
       AWS[:sdb].put_attributes(@domain_name, 'conditional', { 'version' => '2' }, :expect => { 'version' => '1' }, :replace => ['version']).body
     end
 
+    # Verify that we can delete individual attributes.
+    tests("#delete_attributes('#{@domain_name}', 'a', {'d' => []})").succeeds do
+      AWS[:sdb].delete_attributes(@domain_name, 'a', {'d' => []}).body
+    end
+
+    # Verify that individually deleted attributes are actually removed.
+    tests("#get_attributes('#{@domain_name}', 'a', ['d']).body['Attributes']").returns({'d' => nil}) do
+      AWS[:sdb].get_attributes(@domain_name, 'a', ['d']).body['Attributes']
+    end
+
     tests("#delete_attributes('#{@domain_name}', 'a').body").formats(AWS::SimpleDB::Formats::BASIC) do
       AWS[:sdb].delete_attributes(@domain_name, 'a').body
     end
 
+    # Verify that we can delete entire domain, item combinations.
     tests("#delete_attributes('#{@domain_name}', 'a').body").succeeds do
       AWS[:sdb].delete_attributes(@domain_name, 'a').body
+    end
+
+    # Verify that deleting a domain, item combination removes all related attributes.
+    tests("#get_attributes('#{@domain_name}', 'a').body['Attributes']").returns({}) do
+      AWS[:sdb].get_attributes(@domain_name, 'a').body['Attributes']
     end
 
   end


### PR DESCRIPTION
Deleting attributes was not working in mock mode. There were two bugs in this function.The first was that attributes were being deleted from the domain as opposed to the item. The second was that when no attributes were passed, which should delete all attributes, no attributes were actually being deleted. I've written tests that recreate these bugs and I have included a fix as well.
