### PR TITLE
Add recursive argument to server scp methods.

### DIFF
--- a/lib/fog/compute/models/aws/server.rb
+++ b/lib/fog/compute/models/aws/server.rb
@@ -200,12 +200,14 @@ module Fog
           Fog::SSH.new(public_ip_address, username, options).run(commands)
         end
 
-        def scp(local_path, remote_path, recursive = false)
+        def scp(local_path, remote_path, options = {})
           requires :public_ip_address, :username
 
-          options = {}
+          upload_options = options.dup
+          #don't want to pass recursive to constructor
+          options.delete(:recursive)
           options[:key_data] = [private_key] if private_key
-          Fog::SCP.new(public_ip_address, username, options).upload(local_path, remote_path, recursive)
+          Fog::SCP.new(public_ip_address, username, options).upload(local_path, remote_path, upload_options)
         end
 
         def start

--- a/lib/fog/compute/models/bluebox/server.rb
+++ b/lib/fog/compute/models/bluebox/server.rb
@@ -128,12 +128,14 @@ module Fog
           Fog::SSH.new(ips.first['address'], username, options).run(commands)
         end
 
-        def scp(local_path, remote_path, recursive = false)
+        def scp(local_path, remote_path, options = {})
           requires :ips, :username
 
-          options = {}
+          upload_options = options.dup
+          #don't want to pass recursive to constructor
+          options.delete(:recursive)
           options[:key_data] = [private_key] if private_key
-          Fog::SCP.new(ips.first['address'], username, options).upload(local_path, remote_path, recursive)
+          Fog::SCP.new(ips.first['address'], username, options).upload(local_path, remote_path, upload_options)
         end
 
         def username

--- a/lib/fog/compute/models/go_grid/server.rb
+++ b/lib/fog/compute/models/go_grid/server.rb
@@ -78,12 +78,14 @@ module Fog
           Fog::SSH.new(ip['ip'], username, options).run(commands)
         end
 
-        def scp(local_path, remote_path, recursive = false)
+        def scp(local_path, remote_path, options = {})
           requires :ip, :username
 
-          options = {}
+          upload_options = options.dup
+          #don't want to pass recursive to constructor
+          options.delete(:recursive)
           options[:key_data] = [private_key] if private_key
-          Fog::SCP.new(ip['ip'], username, options).upload(local_path, remote_path, recursive)
+          Fog::SCP.new(ip['ip'], username, options).upload(local_path, remote_path, upload_options)
         end
 
         def setup(credentials = {})

--- a/lib/fog/compute/models/rackspace/server.rb
+++ b/lib/fog/compute/models/rackspace/server.rb
@@ -120,12 +120,14 @@ module Fog
           Fog::SSH.new(public_ip_address, username, options).run(commands)
         end
 
-        def scp(local_path, remote_path, recursive = false)
+        def scp(local_path, remote_path, options = {})
           requires :public_ip_address, :username
 
-          options = {}
+          upload_options = options.dup
+          #don't want to pass recursive to constructor
+          options.delete(:recursive)
           options[:key_data] = [private_key] if private_key
-          Fog::SCP.new(public_ip_address, username, options).upload(local_path, remote_path, recursive)
+          Fog::SCP.new(public_ip_address, username, options).upload(local_path, remote_path, upload_options)
         end
 
         def username

--- a/lib/fog/compute/models/slicehost/server.rb
+++ b/lib/fog/compute/models/slicehost/server.rb
@@ -110,12 +110,14 @@ module Fog
           Fog::SSH.new(addresses.first, username, options).run(commands)
         end
 
-        def scp(local_path, remote_path, recursive = false)
+        def scp(local_path, remote_path, options = {})
           requires :addresses, :username
 
-          options = {}
+          upload_options = options.dup
+          #don't want to pass recursive to constructor
+          options.delete(:recursive)
           options[:key_data] = [private_key] if private_key
-          Fog::SCP.new(addresses.first, username, options).upload(local_path, remote_path, recursive)
+          Fog::SCP.new(addresses.first, username, options).upload(local_path, remote_path, upload_options)
         end
 
         def username

--- a/lib/fog/compute/models/virtual_box/server.rb
+++ b/lib/fog/compute/models/virtual_box/server.rb
@@ -151,7 +151,7 @@ module Fog
           end
         end
 
-        def scp(local_path, remote_path, recursive = false)
+        def scp(local_path, remote_path, options = {})
           raise 'Not Implemented'
           # requires :addresses, :username
           # 

--- a/lib/fog/core/scp.rb
+++ b/lib/fog/core/scp.rb
@@ -23,7 +23,7 @@ module Fog
         @options  = options
       end
 
-      def upload(local_path, remote_path, recursive = false )
+      def upload(local_path, remote_path, options = {} )
         Fog::Mock.not_implemented
       end
 
@@ -45,10 +45,10 @@ module Fog
         @options  = { :paranoid => false }.merge(options)
       end
 
-      def upload(local_path, remote_path, recursive = false )
+      def upload(local_path, remote_path, options = {} )
         begin
           Net::SCP.start(@address, @username, @options) do |scp|
-            scp.upload!(local_path, remote_path, :recursive => recursive ) do |ch, name, sent, total|
+            scp.upload!(local_path, remote_path, options ) do |ch, name, sent, total|
               # TODO: handle progress display?
             end
           end


### PR DESCRIPTION
Have added recursive option to server scp methods so can scp up directories.
Is set to false by default.
Have tested on an AWS server.
