### PR TITLE
[storage|aws] clean up multi-region directory creation

### DIFF
--- a/lib/fog/storage/aws.rb
+++ b/lib/fog/storage/aws.rb
@@ -70,7 +70,16 @@ module Fog
           query << "Expires=#{params[:headers]['Date']}"
           "https://#{@host}/#{params[:path]}?#{query.join('&')}"
         end
-
+        
+        def host
+          @host
+        end
+        
+        def region
+          region = @region || host.split('.').first.gsub(/s3-?/, '')
+          region.empty? ? 'us-east-1' : region
+        end
+        
       end
 
       class Mock

--- a/lib/fog/storage/models/aws/directory.rb
+++ b/lib/fog/storage/models/aws/directory.rb
@@ -86,9 +86,7 @@ module Fog
           if @acl
             options['x-amz-acl'] = @acl
           end
-          if @location
-            options['LocationConstraint'] = @location
-          end
+          options['LocationConstraint'] = @location || self.connection.region
           connection.put_bucket(key, options)
           true
         end


### PR DESCRIPTION
if creating an s3 directory (bucket), one needs to pass in :location as well as have the aws connection set to the correct region...   This fixes that issue
