### PR TITLE
Add support for specifying a CDN CNAME when getting a Rackspace Cloud Files directory

### DIFF
--- a/lib/fog/storage/models/rackspace/directories.rb
+++ b/lib/fog/storage/models/rackspace/directories.rb
@@ -14,9 +14,13 @@ module Fog
           load(data)
         end
 
+        # Supply the :cdn_cname option to use the Rackspace CDN CNAME functionality on the public_url.
+        #
+        # > fog.directories.get('video', :cdn_cname => 'http://cdn.lunenburg.org').files.first.public_url
+        # => 'http://cdn.lunenburg.org/hayley-dancing.mov'
         def get(key, options = {})
           data = connection.get_container(key, options)
-          directory = new(:key => key)
+          directory = new(:key => key, :cdn_cname => options[:cdn_cname])
           for key, value in data.headers
             if ['X-Container-Bytes-Used', 'X-Container-Object-Count'].include?(key)
               directory.merge_attributes(key => value)

--- a/lib/fog/storage/models/rackspace/directory.rb
+++ b/lib/fog/storage/models/rackspace/directory.rb
@@ -11,6 +11,7 @@ module Fog
 
         attribute :bytes, :aliases => 'X-Container-Bytes-Used'
         attribute :count, :aliases => 'X-Container-Object-Count'
+        attribute :cdn_cname
 
         def destroy
           requires :key
@@ -42,7 +43,7 @@ module Fog
                 if connection.rackspace_cdn_ssl == true
                   response.headers['X-CDN-SSL-URI']
                 else
-                  response.headers['X-CDN-URI']
+                  cdn_cname || response.headers['X-CDN-URI']
                 end
               end
             rescue Fog::Service::NotFound


### PR DESCRIPTION
This patch allows you to specify a :cdn_cname => 'http://my.url.com/' option when getting a directory via the Rackspace Cloud Files driver.  Cloud Files allows you to set up a CNAME for the URLs that the Cloud Files CDN normally returns.

http://www.rackspace.com/cloud/blog/2011/04/27/it%E2%80%99s-here-cloud-files-now-supports-cnames-for-cdn-enabled-content/

If there's a better way to do this, let me know!
