### PR TITLE
Checking path for nil

### DIFF
--- a/lib/fog/storage.rb
+++ b/lib/fog/storage.rb
@@ -60,7 +60,7 @@ module Fog
       metadata[:body] = data
       metadata[:headers]['Content-Length'] = get_body_size(data)
       
-      if data.respond_to?(:path)
+      if data.respond_to?(:path) and !data.path.nil?
         filename = ::File.basename(data.path)
         unless (mime_types = MIME::Types.of(filename)).empty?
           metadata[:headers]['Content-Type'] = mime_types.first.content_type


### PR DESCRIPTION
Hello!
I have a gem for backup files to S3 and I use your gem(thank you for that).
When I work with S3, fog raise exception when path equal to nil.

> gem: https://github.com/reflow/encbs

Best regards, Timothy.
