### PR TITLE
Public API for force_detach on Fog::Compute::AWS::Volume.

### DIFF
--- a/lib/fog/compute/models/aws/volume.rb
+++ b/lib/fog/compute/models/aws/volume.rb
@@ -62,6 +62,10 @@ module Fog
           connection.snapshots(:volume => self)
         end
 
+        def force_detach
+          detach(true)
+        end
+
         private
 
         def attachmentSet=(new_attachment_set)
@@ -81,24 +85,14 @@ module Fog
           end
         end
 
-        def detach
+        def detach(force = false)
           @server = nil
           self.server_id = nil
           unless new_record?
-            connection.detach_volume(id)
+            connection.detach_volume(id, 'Force' => force)
             reload
           end
         end
-
-        def force_detach
-          @server = nil
-          self.server_id = nil
-          unless new_record?
-            connection.detach_volume(id, 'Force' => true)
-            reload
-          end
-        end
-
 
       end
 

--- a/tests/compute/models/aws/volume_tests.rb
+++ b/tests/compute/models/aws/volume_tests.rb
@@ -17,6 +17,13 @@ Shindo.tests("Fog::Compute[:aws] | volume", ['aws']) do
       @instance.server = nil
     end
 
+    @instance.server = @server
+    @instance.wait_for { state == 'in-use' }
+
+    tests('#force_detach').succeeds do
+      @instance.force_detach
+    end
+
     @instance.wait_for { ready? }
 
   end


### PR DESCRIPTION
The other possible API is checking if #server = receives more than just a nil value for detachment, but that seems ugly.
