### PR TITLE
Should actually use the attachment_aliases hash.

### DIFF
--- a/lib/fog/compute/requests/aws/describe_volumes.rb
+++ b/lib/fog/compute/requests/aws/describe_volumes.rb
@@ -74,7 +74,7 @@ module Fog
           }
           for filter_key, filter_value in filters
             if attachment_key = filter_key.split('attachment.')[1]
-              aliased_key = permission_aliases[filter_key]
+              aliased_key = attachment_aliases[filter_key]
               volume_set = volume_set.reject{|volume| !volume['attachmentSet'].detect {|attachment| [*filter_value].include?(attachment[aliased_key])}}
             else
               aliased_key = aliases[filter_key]

--- a/tests/compute/requests/aws/volume_tests.rb
+++ b/tests/compute/requests/aws/volume_tests.rb
@@ -78,6 +78,10 @@ Shindo.tests('Fog::Compute[:aws] | volume requests', ['aws']) do
 
     Fog::Compute[:aws].volumes.get(@volume_id).wait_for { state == 'in-use' }
 
+    tests("#describe_volume('attachment.device' => '/dev/sdh')").formats(@volumes_format) do
+      Fog::Compute[:aws].describe_volumes('attachment.device' => '/dev/sdh').body
+    end
+
     tests("#detach_volume('#{@volume_id}')").formats(@volume_attachment_format) do
       Fog::Compute[:aws].detach_volume(@volume_id).body
     end


### PR DESCRIPTION
Looks like a copy and paste from describe_security_groups, but forgot to replace the local var name.
