### PR TITLE
server method for Fog::Compute::AWS::Volume to easily get the server instance.

### DIFF
--- a/lib/fog/compute/models/aws/volume.rb
+++ b/lib/fog/compute/models/aws/volume.rb
@@ -49,6 +49,11 @@ module Fog
           true
         end
 
+        def server
+          requires :server_id
+          connection.servers('instance-id' => server_id)
+        end
+
         def server=(new_server)
           if new_server
             attach(new_server)

--- a/tests/compute/models/aws/volume_tests.rb
+++ b/tests/compute/models/aws/volume_tests.rb
@@ -13,6 +13,10 @@ Shindo.tests("Fog::Compute[:aws] | volume", ['aws']) do
 
     @instance.wait_for { state == 'in-use' }
 
+    tests('#server').succeeds do
+      @instance.server
+    end
+
     tests('#server = nil').succeeds do
       @instance.server = nil
     end


### PR DESCRIPTION
Just a little helper to make it easier to get the server it is attached to. Unless I missed something in the underlying classes, @volume.server wasn't working for me.
