### PR TITLE
Mock enhancements for Rackspace provider and SSH commands.

### DIFF
--- a/lib/fog/compute/rackspace.rb
+++ b/lib/fog/compute/rackspace.rb
@@ -58,6 +58,7 @@ module Fog
         end
 
         def initialize(options={})
+          require 'json'
           @rackspace_username = options[:rackspace_username]
         end
 


### PR DESCRIPTION
This is my first commit to fog, so let me know any feedback.  I didn't add any tests because it is just changing the mocks, but I am open to any ideas.

Notes on the changes:
- Rackspace server model requires JSON, so the mock and real compute implementation need to require it.
- For SSH I figured just printing the commands was enough.  This still allows users to mock the command with mocha or other mocking framework, while making Fog work from the command line as well.
