### PR TITLE
requires_one

### DIFF
--- a/lib/fog/compute/models/aws/volume.rb
+++ b/lib/fog/compute/models/aws/volume.rb
@@ -38,7 +38,8 @@ module Fog
 
         def save
           raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
-          requires :availability_zone, :size
+          requires :availability_zone
+          requires_one :size, :snapshot_id
 
           data = connection.create_volume(availability_zone, size, snapshot_id).body
           new_attributes = data.reject {|key,value| key == 'requestId'}

--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -156,22 +156,32 @@ module Fog
 
       # check that the attributes specified in args exist and is not nil
       def requires(*args)
+        missing = missing_attributes(args)
+        if missing.length == 1
+          raise(ArgumentError, "#{missing.first} is required for this operation")
+        elsif missing.any?
+          raise(ArgumentError, "#{missing[0...-1].join(", ")} and #{missing[-1]} are required for this operation")
+        end
+      end
+
+      def requires_one(*args)
+        missing = missing_attributes(args)
+        if missing.length == args.length
+          raise(ArgumentError, "#{missing[0...-1].join(", ")} or #{missing[-1]} are required for this operation")
+        end
+      end
+
+      protected
+
+      def missing_attributes(args)
         missing = []
         for arg in [:connection] | args
           unless send("#{arg}") || attributes.has_key?(arg)
             missing << arg
           end
         end
-        unless missing.empty?
-          if missing.length == 1
-            raise(ArgumentError, "#{missing.first} is required for this operation")
-          else
-            raise(ArgumentError, "#{missing[0...-1].join(", ")} and #{missing[-1]} are required for this operation")
-          end
-        end
+        missing
       end
-
-      protected
 
       def dup_attributes!
         @attributes = @attributes.dup


### PR DESCRIPTION
Allows you to require at least one of the specified attributes. As per the AWS documentation snapshot_id and size are both conditional arguments for creating a volume.
