### PR TITLE
[core] avoid ArgumentError with Ruby 1.8.5 on CentOS.

### DIFF
--- a/lib/fog/core/credentials.rb
+++ b/lib/fog/core/credentials.rb
@@ -45,9 +45,9 @@ module Fog
   
   def self.symbolize_credentials(args)
     if args.is_a? Hash
-      Hash[ args.collect do |key, value|
+      Hash[ *args.collect do |key, value|
         [key.to_sym, self.symbolize_credentials(value)]
-      end ]
+      end.flatten ]
     else
       args
     end


### PR DESCRIPTION
I may be Doing It Wrong as I've not seen anyone else mention this as an issue, but I find symbolize_credentials barfs on CentOS 5 if a config file is present (including config files that work fine on other distros). Rephrasing as attached fixes it.
