### PR TITLE
Fixed the escaping in Fog::AWS.escape

### DIFF
--- a/lib/fog/providers/aws.rb
+++ b/lib/fog/providers/aws.rb
@@ -46,9 +46,9 @@ module Fog
     end
 
     def self.escape(string)
-      string.gsub(/([^ a-zA-Z0-9_.\-~]+)/) {
+      string.gsub(/([^a-zA-Z0-9_.\-~]+)/) {
         "%" + $1.unpack("H2" * $1.bytesize).join("%").upcase
-      }.tr(" ", "+")
+      }
     end
 
     def self.signed_params(params, options = {})

--- a/tests/aws/signed_params_tests.rb
+++ b/tests/aws/signed_params_tests.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
 Shindo.tests('AWS | signed_params', ['aws']) do
-  returns( Fog::AWS.escape( "'Stöp!' said Fred_-~." ) ) { "%27St%C3%B6p%21%27+said+Fred_-~." }
+  returns( Fog::AWS.escape( "'Stöp!' said Fred_-~." ) ) { "%27St%C3%B6p%21%27%20said%20Fred_-~." }
 end


### PR DESCRIPTION
The method now correctly escapes multibyte strings and behaves exactly like
CGI.escape except that the tilde char is not escaped. Previously spaces where escaped as '%20' where Amazon requires '+' and multibyte characters were not escaped with their correct byte size.   
