### PR TITLE
Fix ::AWS[] syntax that's only valid in Fog tests when bin/aws.rb is load

### DIFF
--- a/lib/fog/aws/requests/elb/create_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer.rb
@@ -57,7 +57,7 @@ module Fog
 
           raise Fog::AWS::ELB::IdentifierTaken if self.data[:load_balancers].has_key? lb_name
 
-          certificate_ids = ::AWS[:iam].list_server_certificates.body['Certificates'].collect { |c| c['Arn'] }
+          certificate_ids = Fog::AWS::IAM.new.list_server_certificates.body['Certificates'].collect { |c| c['Arn'] }
 
           listeners = [*listeners].map do |listener|
             if listener['SSLCertificateId'] and !certificate_ids.include? listener['SSLCertificateId']

--- a/lib/fog/aws/requests/elb/create_load_balancer_listeners.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer_listeners.rb
@@ -52,7 +52,7 @@ module Fog
           if load_balancer = self.data[:load_balancers][lb_name]
             response = Excon::Response.new
 
-            certificate_ids = ::AWS[:iam].list_server_certificates.body['Certificates'].collect { |c| c['Arn'] }
+            certificate_ids = Fog::AWS::IAM.new.list_server_certificates.body['Certificates'].collect { |c| c['Arn'] }
 
             listeners.each do |listener|
               if listener['SSLCertificateId'] and !certificate_ids.include? listener['SSLCertificateId']


### PR DESCRIPTION
Prevent AWS Undefined exceptions when using Fog Mocks outside of Fog tests.
