### PR TITLE
[AWS|ELB] fix bug that was causing availability zones to not parse proper

### DIFF
--- a/lib/fog/aws/models/elb/load_balancer.rb
+++ b/lib/fog/aws/models/elb/load_balancer.rb
@@ -14,7 +14,7 @@ module Fog
         attribute :source_group,          :aliases => 'SourceSecurityGroup'
 
         def initialize(attributes={})
-          attributes[:availability_zones] ||= %w(us-east-1a us-east-1b us-east-1c us-east-1d)
+          attributes[:availability_zones] ||= attributes['AvailabilityZones'] || %w(us-east-1a us-east-1b us-east-1c us-east-1d)
           attributes['ListenerDescriptions'] ||= [{
             'Listener' => {'LoadBalancerPort' => 80, 'InstancePort' => 80, 'Protocol' => 'HTTP'},
             'PolicyNames' => []


### PR DESCRIPTION
Before this patch, availability zones were always loading to all zones, regardless of how the ELB was created.
