### PR TITLE
[core] Extends SSH and SCP mocks.

### DIFF
--- a/lib/fog/core/scp.rb
+++ b/lib/fog/core/scp.rb
@@ -24,7 +24,7 @@ module Fog
       end
 
       def upload(local_path, remote_path, upload_options = {})
-        Fog::Mock.not_implemented
+        [local_path, remote_path, upload_options]
       end
 
     end

--- a/lib/fog/core/ssh.rb
+++ b/lib/fog/core/ssh.rb
@@ -24,9 +24,19 @@ module Fog
       end
 
       def run(commands)
-        Fog::Mock.not_implemented
+        commands.collect do |command|
+          Result.new(command)
+        end
       end
 
+      class Result
+        attr_accessor :command, :stderr, :stdout, :status
+        def initialize(command)
+          @command = command
+          @stderr = command
+          @stdout = command
+        end
+      end
     end
 
     class Real


### PR DESCRIPTION
Extends mocking support for SSH and SCP
by adding the respective methods run and
upload.

I created some rspec tests as well that use the new mock methods, but I was not sure where they would go in the project.

  it 'should be able to mock ssh run' do
    Fog::SSH.new('address', 'username').run('foo')[0].stdout.should == 'foo'
  end 
  it 'should be able to mock scp upload' do
    Fog::SCP.new('address', 'username', {}).upload('local', 'remote').should == ['local', 'remote', {}]
  end
