### PR TITLE
[aws|compute] Security groups parser fix

### DIFF
--- a/lib/fog/compute/parsers/aws/describe_security_groups.rb
+++ b/lib/fog/compute/parsers/aws/describe_security_groups.rb
@@ -8,8 +8,9 @@ module Fog
           def reset
             @group = {}
             @ip_permission = { 'groups' => [], 'ipRanges' => []}
+            @ip_permission_egress = { 'groups' => [], 'ipRanges' => []}
             @ip_range = {}
-            @security_group = { 'ipPermissions' => [] }
+            @security_group = { 'ipPermissions' => [], 'ipPermissionsEgress' => [] }
             @response = { 'securityGroupInfo' => [] }
           end
 
@@ -20,6 +21,8 @@ module Fog
               @in_groups = true
             when 'ipPermissions'
               @in_ip_permissions = true
+            when 'ipPermissionsEgress'
+              @in_ip_permissions_egress = true
             when 'ipRanges'
               @in_ip_ranges = true
             end
@@ -30,7 +33,11 @@ module Fog
             when 'cidrIp'
               @ip_range[name] = value
             when 'fromPort', 'toPort'
-              @ip_permission[name] = value.to_i
+              if @in_ip_permissions_egress
+                @ip_permission_egress[name] = value.to_i              
+              else
+                @ip_permission[name] = value.to_i
+              end
             when 'groups'
               @in_groups = false
             when 'groupDescription', 'ownerId'
@@ -43,23 +50,40 @@ module Fog
               end
             when 'ipPermissions'
               @in_ip_permissions = false
+            when 'ipPermissionsEgress'
+              @in_ip_permissions_egress = false
             when 'ipProtocol'
-              @ip_permission[name] = value
+              if @in_ip_permissions_egress
+                @ip_permission_egress[name] = value
+              else
+                @ip_permission[name] = value
+              end
             when 'ipRanges'
               @in_ip_ranges = false
             when 'item'
               if @in_groups
-                @ip_permission['groups'] << @group
+                if @in_ip_permissions_egress
+                  @ip_permission_egress['group'] << @group
+                else
+                  @ip_permission['groups'] << @group
+                end
                 @group = {}
               elsif @in_ip_ranges
-                @ip_permission['ipRanges'] << @ip_range
+                if @in_ip_permissions_egress
+                  @ip_permission_egress['ipRanges'] << @ip_range
+                else
+                  @ip_permission['ipRanges'] << @ip_range
+                end
                 @ip_range = {}
               elsif @in_ip_permissions
                 @security_group['ipPermissions'] << @ip_permission
                 @ip_permission = { 'groups' => [], 'ipRanges' => []}
-               else
+              elsif @in_ip_permissions_egress
+                @security_group['ipPermissionsEgress'] << @ip_permission_egress
+                @ip_permission_egress = { 'groups' => [], 'ipRanges' => []}
+              else
                 @response['securityGroupInfo'] << @security_group
-                @security_group = { 'ipPermissions' => [] }
+                @security_group = { 'ipPermissions' => [], 'ipPermissionsEgress' => [] }
               end
             when 'requestId'
               @response[name] = value


### PR DESCRIPTION
"describe security groups" parser was not taking into account ipPermissionsEgress and therefore returning unexpected results when the account had VPC groups.
