### PR TITLE
[aws|compute] Fixed failing instance tests. 

### DIFF
--- a/lib/fog/compute/requests/aws/describe_instances.rb
+++ b/lib/fog/compute/requests/aws/describe_instances.rb
@@ -187,7 +187,7 @@ module Fog
                 'ownerId'       => instance['ownerId'],
                 'reservationId' => instance['reservationId']
               }
-              reservation_set[instance['reservationId']]['instancesSet'] << instance.reject{|key,value| !['amiLaunchIndex', 'architecture', 'blockDeviceMapping', 'clientToken', 'dnsName', 'imageId', 'instanceId', 'instanceState', 'instanceType', 'ipAddress', 'kernelId', 'keyName', 'launchTime', 'monitoring', 'placement', 'privateDnsName', 'privateIpAddress', 'productCodes', 'ramdiskId', 'reason', 'rootDeviceType', 'stateReason', 'tagSet'].include?(key)}
+              reservation_set[instance['reservationId']]['instancesSet'] << instance.reject{|key,value| !['amiLaunchIndex', 'architecture', 'blockDeviceMapping', 'clientToken', 'dnsName', 'imageId', 'instanceId', 'instanceState', 'instanceType', 'ipAddress', 'kernelId', 'keyName', 'launchTime', 'monitoring', 'placement', 'platform', 'privateDnsName', 'privateIpAddress', 'productCodes', 'ramdiskId', 'reason', 'rootDeviceType', 'stateReason', 'tagSet'].include?(key)}
             end
           end
 

--- a/tests/compute/requests/aws/instance_tests.rb
+++ b/tests/compute/requests/aws/instance_tests.rb
@@ -44,6 +44,7 @@ Shindo.tests('Fog::Compute[:aws] | instance requests', ['aws']) do
         'architecture'      => String,
         'dnsName'           => Fog::Nullable::String,
         'ipAddress'         => Fog::Nullable::String,
+        'platform'          => Fog::Nullable::String,
         'privateDnsName'    => Fog::Nullable::String,
         'privateIpAddress'  => Fog::Nullable::String,
         'stateReason'       => Hash,


### PR DESCRIPTION
This fixes the failing aws instance tests.  There are still two broken tests: volume and address.
