### PR TITLE
Add force stop functionality to AWS Instance

### DIFF
--- a/lib/fog/compute/models/aws/server.rb
+++ b/lib/fog/compute/models/aws/server.rb
@@ -222,9 +222,9 @@ module Fog
           true
         end
 
-        def stop
+        def stop(force = false)
           requires :id
-          connection.stop_instances(id)
+          connection.stop_instances(id, force)
           true
         end
 

--- a/lib/fog/compute/requests/aws/stop_instances.rb
+++ b/lib/fog/compute/requests/aws/stop_instances.rb
@@ -17,8 +17,9 @@ module Fog
         #     * TODO: fill in the blanks
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-StopInstances.html]
-        def stop_instances(instance_id)
+        def stop_instances(instance_id, force = false)
           params = Fog::AWS.indexed_param('InstanceId', instance_id)
+          params.merge!('Force' => 'true') if force
           request({
             'Action'    => 'StopInstances',
             :idempotent => true,


### PR DESCRIPTION
AWS allows you to add a force option to the stop request. This performs
the equivalent of a power off, rather thank asking the OS to shutdown.
