### PR TITLE
[compute|aws] Allow image mocks to support state (except failed).

### DIFF
--- a/lib/fog/compute/models/aws/image.rb
+++ b/lib/fog/compute/models/aws/image.rb
@@ -37,6 +37,10 @@ module Fog
           end
         end
 
+        def ready?
+          state == 'available'
+        end
+
       end
 
     end

--- a/lib/fog/compute/requests/aws/describe_images.rb
+++ b/lib/fog/compute/requests/aws/describe_images.rb
@@ -109,6 +109,16 @@ module Fog
             end
           end
 
+          image_set = image_set.map do |image|
+            case image['imageState']
+            when 'pending'
+              if Time.now - image['registered'] >= Fog::Mock.delay
+                image['imageState'] = 'available'
+              end
+            end
+            image.reject { |key, value| ['registered'].include?(key) }
+          end
+
           response.status = 200
           response.body = {
             'requestId' => Fog::AWS::Mock.request_id,

--- a/lib/fog/compute/requests/aws/register_image.rb
+++ b/lib/fog/compute/requests/aws/register_image.rb
@@ -69,7 +69,7 @@ module Fog
             image = {
               'imageId' => Fog::AWS::Mock.image_id,
               'imageLocation' => '',
-              'imageState' => 'available',
+              'imageState' => 'pending',
               'imageOwnerId' => self.data[:owner_id],
               'isPublic' => false,
               'productCodes' => [],
@@ -87,7 +87,8 @@ module Fog
               'blockDeviceMapping' => [],
               'virtualizationType' => 'paravirtual',
               'tagSet' => {},
-              'hypervisor' => 'xen'
+              'hypervisor' => 'xen',
+              'registered' => Time.now
             }
 
             if location[/^\/dev\/sd[a-p]\d{0,2}$/]

--- a/tests/compute/requests/aws/image_tests.rb
+++ b/tests/compute/requests/aws/image_tests.rb
@@ -44,9 +44,14 @@ Shindo.tests('Fog::Compute[:aws] | image requests', ['aws']) do
       end
 
       @image_id = @image['imageId']
+      sleep 1
 
       tests("#describe_images('Owner' => 'self')").formats(@describe_images_format) do
         Fog::Compute[:aws].describe_images('Owner' => 'self').body
+      end
+
+      tests("#describe_images('state' => 'available')").formats(@describe_images_format) do
+        Fog::Compute[:aws].describe_images('state' => 'available').body
       end
     end
 


### PR DESCRIPTION
Using a registered member to track the time so we can have faked state like instances.
