### PR TITLE
Added a fast way to add your current machine to an RDS security group.

### DIFF
--- a/lib/fog/aws/models/rds/security_group.rb
+++ b/lib/fog/aws/models/rds/security_group.rb
@@ -1,4 +1,5 @@
 require 'fog/core/model'
+require 'fog/core/current_machine'
 
 module Fog
   module AWS
@@ -41,6 +42,16 @@ module Fog
 
         def authorize_cidrip(cidrip)
           authorize_ingress({'CIDRIP' => cidrip})
+        end
+
+        # Add the current machine to the RDS security group.
+        def authorize_me
+          authorize_ip_address(Fog::CurrentMachine.ip_address)
+        end
+
+        # Add the ip address to the RDS security group.
+        def authorize_ip_address(ip)
+          authorize_cidrip("#{ip}/32")
         end
 
         def authorize_ingress(opts)

--- a/lib/fog/core/current_machine.rb
+++ b/lib/fog/core/current_machine.rb
@@ -1,0 +1,38 @@
+require 'net/http'
+require 'uri'
+
+module Fog
+  class CurrentMachine
+    @@lock = Mutex.new
+    AMAZON_AWS_CHECK_IP = 'http://checkip.amazonaws.com'
+
+    def self.ip_address= ip_address
+      @@lock.synchronize do
+        @@ip_address = ip_address
+      end
+    end
+
+    # Get the ip address of the machine from which this command is run. It is
+    # recommended that you surround calls to this function with a timeout block
+    # to ensure optimum performance in the case where the amazonaws checkip
+    # service is unavailable.
+    #
+    # @example Get the current ip address
+    #   begin
+    #     Timeout::timeout(5) do
+    #       puts "Your ip address is #{Fog::CurrentMachine.ip_address}"
+    #     end
+    #   rescue Timeout::Error
+    #     puts "Service timeout"
+    #   end
+    #
+    # @raise [Net::HTTPExceptions] if the net/http request fails.
+    def self.ip_address
+      @@lock.synchronize do
+        @@ip_address ||= Net::HTTP \
+          .get_response(URI.parse(AMAZON_AWS_CHECK_IP)) \
+          .body.chomp
+      end
+    end
+  end
+end

--- a/spec/core/current_machine_spec.rb
+++ b/spec/core/current_machine_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'fog/core/current_machine'
+
+describe Fog::CurrentMachine do
+  context '#ip_address' do
+    before(:each){ described_class.ip_address = nil }
+
+    it 'should be threadsafe' do
+      Net::HTTP.should_receive(:get_response).once{ Struct.new(:body).new('') }
+
+      (1..10).map {
+        Thread.new { described_class.ip_address }
+      }.each{ |t| t.join }
+    end
+
+    it 'should remove trailing endline characters' do
+      Net::HTTP.stub(:get_response){ Struct.new(:body).new("192.168.0.1\n") }
+
+      described_class.ip_address.should == '192.168.0.1'
+    end
+  end
+end


### PR DESCRIPTION
You can now call #authorize_me on an RDS::SecurityGroup which will add your current machine IP address to the security group.  This makes it very easy to develop against RDS and add new machines to a security group in production. This function depends on Fog::CurrentMachine#ip_address which is a threadsafe way to get the current machine's ip address using amazon's checkip website. I've included a spec file for this function as well. Hopefully others will find this useful!
