### PR TITLE
Pass hostname to create_block request if provided.

### DIFF
--- a/lib/fog/compute/models/bluebox/server.rb
+++ b/lib/fog/compute/models/bluebox/server.rb
@@ -102,6 +102,7 @@ module Fog
           end
 
           options['username'] = username
+          options['hostname'] = hostname if @hostname
           data = connection.create_block(flavor_id, image_id, options)
           merge_attributes(data.body)
           true


### PR DESCRIPTION
Should be able to specify a hostname as described here under "Optional fields":

https://boxpanel.bluebox.net/public/the_vault/index.php/Blocks_API#POST_.2Fapi.2Fblocks
