### PR TITLE
Fix warning about whitespace before parentheses in dns.rb.

### DIFF
--- a/lib/fog/rackspace/dns.rb
+++ b/lib/fog/rackspace/dns.rb
@@ -91,7 +91,7 @@ module Fog
 
         def validate_path_fragment(name, fragment)
           if fragment.nil? or fragment.to_s.empty?
-            raise ArgumentError.new ("#{name} cannot be null or empty")
+            raise ArgumentError.new("#{name} cannot be null or empty")
           end
         end
       end


### PR DESCRIPTION
Saw this on startup of "fog interactive".
