### PR TITLE
DescribeInstances InstanceId param should have index according to AWS Docs

### DIFF
--- a/lib/fog/aws/requests/compute/describe_instances.rb
+++ b/lib/fog/aws/requests/compute/describe_instances.rb
@@ -58,9 +58,12 @@ module Fog
             filters = {'instance-id' => [*filters]}
           end
           params = {}
-          # when seeking single instance id, old param style provides more accurate data sooner
-          if filters['instance-id'] && !filters['instance-id'].is_a?(Array)
-            params.merge!('InstanceId' => filters.delete('instance-id'))
+          if filters['instance-id']
+            instance_ids = filters.delete('instance-id')
+            instance_ids = [instance_ids] unless instance_ids.is_a?(Array)
+            instance_ids.each_with_index do |id, index|
+              params.merge!("InstanceId.#{index}" => id)
+            end
           end
           params.merge!(Fog::AWS.indexed_filters(filters))
 


### PR DESCRIPTION
Even if there is only one InstanceId, the docs seem to indicate we should include an index on the InstanceId param. OpenStack's EC2 API expects the index in all cases so this will fix compatibility there as well.

Tested this against EC2 and OpenStack.

FWIW, the Boto Python library follows this convention as well.

http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/index.html?ApiReference-query-DescribeInstances.html

OpenStack compatibility issues: 
http://tickets.opscode.com/browse/KNIFE_OPENSTACK-1?focusedCommentId=19336&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-19336
