### PR TITLE
uninitialized constant Fog::Rackspace::Storage::NotFound

### DIFF
--- a/lib/fog/rackspace/cdn.rb
+++ b/lib/fog/rackspace/cdn.rb
@@ -82,7 +82,7 @@ module Fog
           rescue Excon::Errors::HTTPStatusError => error
             raise case error
             when Excon::Errors::NotFound
-              Fog::Rackspace::Storage::NotFound.slurp(error)
+              Fog::Storage::Rackspace::NotFound.slurp(error)
             else
               error
             end


### PR DESCRIPTION
This is not covered by any existing test, but the namespace is correct now.
