### PR TITLE
Please pull this tiny documentation update.

### DIFF
--- a/lib/fog/aws/requests/auto_scaling/put_scaling_policy.rb
+++ b/lib/fog/aws/requests/auto_scaling/put_scaling_policy.rb
@@ -34,7 +34,7 @@ module Fog
         #   * body<~Hash>:
         #     * 'ResponseMetadata'<~Hash>:
         #       * 'RequestId'<~String> - Id of request
-        #     * 'PutScalingPolicyResponse'<~Hash>:
+        #     * 'PutScalingPolicyResult'<~Hash>:
         #       * 'PolicyARN'<~String> - A policy's Amazon Resource Name (ARN).
         #
         # ==== See Also


### PR DESCRIPTION
Fix documentation. The resulting hash has no entry "PutScalingPolicyResponse", but a "...Result".
