### PR TITLE
[core] Allow FOG_CREDENTIAL variable for config

### DIFF
--- a/lib/fog/core/credentials.rb
+++ b/lib/fog/core/credentials.rb
@@ -13,7 +13,7 @@ module Fog
 
   # @return [String, Symbol] The credential to use in Fog
   def self.credential
-    @credential ||= :default
+    @credential ||= ENV["FOG_CREDENTIAL"] || :default
   end
 
   # @return [String] The path for configuration_file

--- a/tests/core/credential_tests.rb
+++ b/tests/core/credential_tests.rb
@@ -2,12 +2,29 @@ Shindo.tests do
   before do
     @old_home = ENV['HOME']
     @old_rc   = ENV['FOG_RC']
+    @old_credential = ENV['FOG_CREDENTIAL']
     Fog.instance_variable_set('@credential_path', nil) # kill memoization
+    Fog.instance_variable_set('@credential', nil) # kill memoization
   end
 
   after do
     ENV['HOME'] = @old_home
-    ENV['FOG_RC'] = @ld_rc
+    ENV['FOG_RC'] = @old_rc
+    ENV['FOG_CREDENTIAL'] = @old_credential
+  end
+
+  tests('credential') do
+    returns(:default, "is :default") { Fog.credential }
+
+    returns("foo", "can be set directly") do
+      Fog.credential = "foo"
+      Fog.credential
+    end
+
+    returns("bar", "can be set with environment variable") do
+      ENV["FOG_CREDENTIAL"] = "bar"
+      Fog.credential
+    end
   end
 
   tests('credentials_path') do


### PR DESCRIPTION
Say your ~/.fog had multiple stanzas:
    :default:
      :aws_access_key_id: aaa
    test:
      :aws_access_key_id: bbb
    prod:
      :aws_access-key_id: ccc

Choose a stanza with an environment variable:
   $ FOG_CREDENTIAL=prod fog
