### PR TITLE
[vsphere] Add vsphere_server connection attribute

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -26,6 +26,8 @@ module Fog
 
         attr_reader :vsphere_is_vcenter
         attr_reader :vsphere_rev
+        attr_reader :vsphere_server
+        attr_reader :vsphere_username
 
         # Utility method to convert a VMware managed object into an attribute hash.
         # This should only really be necessary for the real class.
@@ -125,6 +127,7 @@ module Fog
           end
 
           @vsphere_is_vcenter = @connection.serviceContent.about.apiType == "VirtualCenter"
+          @vsphere_rev = @connection.rev
 
           authenticate
         end

--- a/tests/vsphere/compute_tests.rb
+++ b/tests/vsphere/compute_tests.rb
@@ -34,7 +34,7 @@ Shindo.tests('Fog::Compute[:vsphere]', ['vsphere']) do
   end
 
   tests("Compute attributes") do
-    %w{ vsphere_is_vcenter vsphere_rev }.each do |attr|
+    %w{ vsphere_is_vcenter vsphere_rev vsphere_username vsphere_server }.each do |attr|
       test("it should respond to #{attr}") { compute.respond_to? attr }
     end
   end


### PR DESCRIPTION
Without this patch it was difficult to figure out from the outside what
vSphere server Fog connected to.  The application using Fog should be
able to easily print out the connection information without breaking the
encapsulation Fog provides.

This patch makes the connected vSphere server hostname and API username
an attribute of the connection instance.

The tests have been updated to validate these attribute accessor
methods.
