### PR TITLE
Better URL escaping for Rackspace Cloud Files.

### DIFF
--- a/lib/fog/rackspace.rb
+++ b/lib/fog/rackspace.rb
@@ -70,5 +70,12 @@ module Fog
         !['X-Server-Management-Url', 'X-Storage-Url', 'X-CDN-Management-Url', 'X-Auth-Token'].include?(key)
       end
     end
+
+    # CGI.escape, but without special treatment on spaces
+    def self.escape(str,extra_exclude_chars = '')
+      str.gsub(/([^a-zA-Z0-9_.-#{extra_exclude_chars}]+)/) do
+        '%' + $1.unpack('H2' * $1.bytesize).join('%').upcase
+      end
+    end
   end
 end

--- a/lib/fog/rackspace/requests/storage/delete_container.rb
+++ b/lib/fog/rackspace/requests/storage/delete_container.rb
@@ -12,7 +12,7 @@ module Fog
           request(
             :expects  => 204,
             :method   => 'DELETE',
-            :path     => URI.escape(name)
+            :path     => Fog::Rackspace.escape(name)
           )
         end
 

--- a/lib/fog/rackspace/requests/storage/delete_object.rb
+++ b/lib/fog/rackspace/requests/storage/delete_object.rb
@@ -13,7 +13,7 @@ module Fog
           request(
             :expects  => 204,
             :method   => 'DELETE',
-            :path     => "#{URI.escape(container)}/#{URI.escape(object)}"
+            :path     => "#{Fog::Rackspace.escape(container)}/#{Fog::Rackspace.escape(object)}"
           )
         end
 

--- a/lib/fog/rackspace/requests/storage/get_container.rb
+++ b/lib/fog/rackspace/requests/storage/get_container.rb
@@ -33,7 +33,7 @@ module Fog
           request(
             :expects  => 200,
             :method   => 'GET',
-            :path     => URI.escape(container),
+            :path     => Fog::Rackspace.escape(container),
             :query    => {'format' => 'json'}.merge!(options)
           )
         end

--- a/lib/fog/rackspace/requests/storage/get_object.rb
+++ b/lib/fog/rackspace/requests/storage/get_object.rb
@@ -14,7 +14,7 @@ module Fog
             :block    => block,
             :expects  => 200,
             :method   => 'GET',
-            :path     => "#{URI.escape(container)}/#{URI.escape(object)}"
+            :path     => "#{Fog::Rackspace.escape(container)}/#{Fog::Rackspace.escape(object)}"
           }, false, &block)
         end
 

--- a/lib/fog/rackspace/requests/storage/head_container.rb
+++ b/lib/fog/rackspace/requests/storage/head_container.rb
@@ -17,7 +17,7 @@ module Fog
           request(
             :expects  => 204,
             :method   => 'HEAD',
-            :path     => URI.escape(container),
+            :path     => Fog::Rackspace.escape(container),
             :query    => {'format' => 'json'}
           )
         end

--- a/lib/fog/rackspace/requests/storage/head_object.rb
+++ b/lib/fog/rackspace/requests/storage/head_object.rb
@@ -13,7 +13,7 @@ module Fog
           request({
             :expects  => 200,
             :method   => 'HEAD',
-            :path     => "#{URI.escape(container)}/#{URI.escape(object)}"
+            :path     => "#{Fog::Rackspace.escape(container)}/#{Fog::Rackspace.escape(object)}"
           }, false)
         end
 

--- a/lib/fog/rackspace/requests/storage/put_container.rb
+++ b/lib/fog/rackspace/requests/storage/put_container.rb
@@ -12,7 +12,7 @@ module Fog
           request(
             :expects  => [201, 202],
             :method   => 'PUT',
-            :path     => URI.escape(name)
+            :path     => Fog::Rackspace.escape(name)
           )
         end
 

--- a/lib/fog/rackspace/requests/storage/put_object.rb
+++ b/lib/fog/rackspace/requests/storage/put_object.rb
@@ -19,7 +19,7 @@ module Fog
             :expects  => 201,
             :headers  => headers,
             :method   => 'PUT',
-            :path     => "#{URI.escape(container)}/#{URI.escape(object)}"
+            :path     => "#{Fog::Rackspace.escape(container)}/#{Fog::Rackspace.escape(object)}"
           )
         end
 

--- a/lib/fog/rackspace/requests/storage/put_object_manifest.rb
+++ b/lib/fog/rackspace/requests/storage/put_object_manifest.rb
@@ -10,7 +10,7 @@ module Fog
         # * object<~String> - Name for object
         #
         def put_object_manifest(container, object)
-          path = "#{URI.escape(container)}/#{URI.escape(object)}"
+          path = "#{Fog::Rackspace.escape(container)}/#{Fog::Rackspace.escape(object)}"
           request(
             :expects  => 201,
             :headers  => {'X-Object-Manifest' => path},

--- a/tests/rackspace/url_encoding_tests.rb
+++ b/tests/rackspace/url_encoding_tests.rb
@@ -1,0 +1,3 @@
+Shindo.tests('Rackspace | url_encoding', ['rackspace']) do
+  returns( Fog::Rackspace.escape( "is this my file?.jpg" ) ) { "is%20this%20my%20file%3F.jpg" }
+end


### PR DESCRIPTION
URI.escape doesn't encode question marks properly, CGI.escape doesn't encode
spaces properly.  So we create an escape class method for Fog::Rackspace that
does the CGI.escape methods, only additionally encoding spaces as %20.

This makes things work properly with Rackspace Cloud Files.
