### PR TITLE
Add snapshot method to aws volume model

### DIFF
--- a/lib/fog/aws/models/compute/volume.rb
+++ b/lib/fog/aws/models/compute/volume.rb
@@ -68,6 +68,11 @@ module Fog
           connection.snapshots(:volume => self)
         end
 
+        def snapshot(description)
+          requires :id
+          connection.create_snapshot(id, description)
+        end
+
         def force_detach
           detach(true)
         end


### PR DESCRIPTION
Used when iterating through volumes

``` ruby
volumes.each do |v|
  v.snapshot "Batch snapshot"
end
```

Using it for nightly snapshots, might be useful to others.
