### PR TITLE
[compute|aws] When mocking, instances don't show up right away.

### DIFF
--- a/lib/fog/aws/requests/compute/describe_instances.rb
+++ b/lib/fog/aws/requests/compute/describe_instances.rb
@@ -160,7 +160,11 @@ module Fog
           instance_set.each do |instance|
             case instance['instanceState']['name']
             when 'pending'
-              if Time.now - instance['launchTime'] >= Fog::Mock.delay
+              if Time.now - instance['launchTime'] < Fog::Mock.delay * 2
+                raise Fog::Compute::AWS::NotFound.new("The instance ID '#{instance['instanceId']}' does not exist")
+              end
+
+              if Time.now - instance['launchTime'] >= Fog::Mock.delay * 2
                 instance['ipAddress']         = Fog::AWS::Mock.ip_address
                 instance['originalIpAddress'] = instance['ipAddress']
                 instance['dnsName']           = Fog::AWS::Mock.dns_name_for(instance['ipAddress'])


### PR DESCRIPTION
This relates to #491.

Now that fog uses the possibly eventually consistent filtered-param API in `describe_instances`, there is the chance that initial calls to `describe_instances` with an instance id just returned by `run_instances` might yield a 404.

This change mimics that in the `describe_instances` mocking.
