### PR TITLE
Tweak to escape the Cloud Files filename before passing to public_url.

### DIFF
--- a/lib/fog/rackspace/models/storage/file.rb
+++ b/lib/fog/rackspace/models/storage/file.rb
@@ -50,7 +50,7 @@ module Fog
 
         def public_url
           requires :key
-          self.collection.get_url(Fog::Rackspace.escape(self.key, '/'))
+          self.collection.get_url(self.key)
         end
 
         def save(options = {})

--- a/lib/fog/rackspace/models/storage/files.rb
+++ b/lib/fog/rackspace/models/storage/files.rb
@@ -67,7 +67,7 @@ module Fog
         def get_url(key)
           requires :directory
           if self.directory.public_url
-            "#{self.directory.public_url}/#{key}"
+            "#{self.directory.public_url}/#{Fog::Rackspace.escape(key, '/')}"
           end
         end
 


### PR DESCRIPTION
Previously, a Rackspace Cloud Files storage object with a name like
"my_files/1234/original/picture #1.jpg" would generate a public URL like:

http://c21641.r41.cf1.rackcdn.com/user_files/1313284/thumb/IMG_4034 #1.jpg

The # character in the URL would get interpreted by Cloud Files as an
anchor marker, and the file would not load.  This change does the
Fog::Rackspace.escape on the key (excluding the / path separator character)
to generate a working URL of the form:

http://c21641.r41.cf1.rackcdn.com/user_files/1313284/thumb/IMG_4034%20%231.jpg

Which is correctly interpreted by Cloud Files and pulls up.

Both of those URLs are live to demonstrate the issue.
