### PR TITLE
[bluebox|compute] Expect correct status code for template create

### DIFF
--- a/lib/fog/bluebox/requests/compute/create_template.rb
+++ b/lib/fog/bluebox/requests/compute/create_template.rb
@@ -14,7 +14,7 @@ module Fog
         # TODO
         def create_template(block_id, options={})
           request(
-            :expects  => 200,
+            :expects  => 202,
             :method   => 'POST',
             :path     => "api/block_templates.json",
             :query    => {'id' => block_id}.merge!(options)


### PR DESCRIPTION
As per our API documentation, a success will return '202': https://boxpanel.bluebox.net/public/the_vault/index.php/Blocks_API#POST_.2Fapi.2Fblock_templates
