### PR TITLE
Add support for non-strict validations, and nullable arrays/hashes.

### DIFF
--- a/tests/helpers/formats_helper.rb
+++ b/tests/helpers/formats_helper.rb
@@ -9,6 +9,8 @@ module Fog
     module String; end
     module Time; end
     module Float; end
+    module Hash; end
+    module Array; end
   end
 end
 [FalseClass, TrueClass].each {|klass| klass.send(:include, Fog::Boolean)}
@@ -17,21 +19,23 @@ end
 [NilClass, Time].each {|klass| klass.send(:include, Fog::Nullable::Time)}
 [Integer, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Integer)}
 [Float, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Float)}
+[Hash, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Hash)}
+[Array, NilClass].each {|klass| klass.send(:include, Fog::Nullable::Array)}
 
 module Shindo
   class Tests
 
-    def formats(format)
+    def formats(format, strict=true)
       raise ArgumentError, 'format is nil' unless format
 
       test('has proper format') do
-        formats_kernel(instance_eval(&Proc.new), format)
+        formats_kernel(instance_eval(&Proc.new), format, true, strict)
       end
     end
 
     private
 
-    def formats_kernel(original_data, original_format, original = true)
+    def formats_kernel(original_data, original_format, original = true, strict = true)
       valid = true
       data = original_data.dup
       format = original_format.dup
@@ -49,7 +53,7 @@ module Shindo
             for element in datum
               type = value.first
               if type.is_a?(Hash)
-                valid &&= formats_kernel({:element => element}, {:element => type}, false)
+                valid &&= formats_kernel({:element => element}, {:element => type}, false, strict)
               else
                 valid &&= element.is_a?(type)
               end
@@ -57,7 +61,7 @@ module Shindo
           end
         when Hash
           valid &&= datum.is_a?(Hash) || p("#{key.inspect} not Hash: #{datum.inspect}")
-          valid &&= formats_kernel(datum, value, false)
+          valid &&= formats_kernel(datum, value, false, strict)
         else
           p "#{key.inspect} not #{value.inspect}: #{datum.inspect}" unless datum.is_a?(value)
           valid &&= datum.is_a?(value)
@@ -65,7 +69,11 @@ module Shindo
       end
       p data unless data.empty?
       p format unless format.empty?
-      valid &&= data.empty? && format.empty?
+      if strict
+        valid &&= data.empty? && format.empty?
+      else
+        valid &&= format.empty?
+      end
       if !valid && original
         @message = "#{original_data.inspect} does not match #{original_format.inspect}"
       end

--- a/tests/helpers/formats_helper_tests.rb
+++ b/tests/helpers/formats_helper_tests.rb
@@ -20,6 +20,10 @@ Shindo.tests('test_helper', 'meta') do
         formats_kernel([{:a => :b}], [{:a => Symbol}])
       end
 
+      test('non strict extra data') do
+        formats_kernel({:a => :b, :b => :c}, {:a => Symbol}, true, false)
+      end
+
     end
 
     tests('returns false') do
@@ -34,6 +38,10 @@ Shindo.tests('test_helper', 'meta') do
 
       test('when some keys do not appear') do
         !formats_kernel({}, {:a => String})
+      end
+
+      test('non strict extra data') do
+        !formats_kernel({:a => :b, :b => :c}, {:z => Symbol}, true, false)
       end
 
     end


### PR DESCRIPTION
This branch gives me the ability to do this in my tests:

```
tests('#get_flavor_details(1)').formats(@flavor_format, false) do
  Fog::Compute[:openstack].get_flavor_details("1").body['flavor']
end
```

*\* notice the extra 'false' option on the formats helper call.

The issue I'm having with real tests is that the OpenStack API allows extensions. This seems like a reasonable addition to our formats validation function to validate that core things exist while ignoring the extra data.
