### PR TITLE
[core] treat boolean values as a boolean

### DIFF
--- a/lib/fog/core/attributes.rb
+++ b/lib/fog/core/attributes.rb
@@ -25,9 +25,9 @@ module Fog
           class_eval <<-EOS, __FILE__, __LINE__
             def #{name}=(new_#{name})
               attributes[:#{name}] = case new_#{name}
-              when 'true'
+              when true,'true'
                 true
-              when 'false'
+              when false,'false'
                 false
               end
             end

--- a/tests/core/attribute_tests.rb
+++ b/tests/core/attribute_tests.rb
@@ -1,6 +1,7 @@
 class FogAttributeTestModel < Fog::Model
   attribute :key, :aliases => 'keys', :squash => "id"
   attribute :time, :type => :time
+  attribute :bool, :type => :boolean
 end
 
 Shindo.tests('Fog::Attributes', 'core') do
@@ -49,6 +50,34 @@ Shindo.tests('Fog::Attributes', 'core') do
       @model.time
     end
 
+  end
+
+  tests(':type => :boolean') do
+    tests(':bool => "true"').returns(true) do
+      @model.merge_attributes(:bool => 'true')
+      @model.bool
+    end
+
+    tests(':bool => true').returns(true) do
+      @model.merge_attributes(:bool => true)
+      @model.bool
+    end
+    
+    tests(':bool => "false"').returns(false) do
+      @model.merge_attributes(:bool => 'false')
+      @model.bool
+    end
+
+    tests(':bool => false').returns(false) do
+      @model.merge_attributes(:bool => false)
+      @model.bool
+    end
+
+    tests(':bool => "foo"').returns(nil) do
+      @model.merge_attributes(:bool => "foo")
+      @model.bool
+    end
+  
   end
 
 end


### PR DESCRIPTION
If an attribute should be of type boolean and the value passed is already a boolean, the value should not be discarded. This fixes this problems and add tests for the boolean type.

~pete
