### PR TITLE
[aws|mock] Dig into mock data instead of instantiating new service object

### DIFF
--- a/lib/fog/aws/requests/compute/purchase_reserved_instances_offering.rb
+++ b/lib/fog/aws/requests/compute/purchase_reserved_instances_offering.rb
@@ -37,7 +37,7 @@ module Fog
 
           # Need to implement filters in the mock to find this there instead of here
           # Also there's no information about what to do when the specified reserved_instances_offering_id doesn't exist
-          raise unless reserved_instance_offering = Compute[:aws].describe_reserved_instances_offerings.body["reservedInstancesOfferingsSet"].find { |offering| offering["reservedInstancesOfferingId"] == reserved_instances_offering_id }
+          raise unless reserved_instance_offering = describe_reserved_instances_offerings.body["reservedInstancesOfferingsSet"].find { |offering| offering["reservedInstancesOfferingId"] == reserved_instances_offering_id }
 
           reserved_instances_id = Fog::AWS::Mock.reserved_instances_id
           reserved_instance_offering.delete('reservedInstancesOfferingId')

--- a/lib/fog/aws/requests/elb/create_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer.rb
@@ -56,7 +56,7 @@ module Fog
 
           raise Fog::AWS::ELB::IdentifierTaken if self.data[:load_balancers].has_key? lb_name
 
-          certificate_ids = Fog::AWS::IAM.new.list_server_certificates.body['Certificates'].collect { |c| c['Arn'] }
+          certificate_ids = Fog::AWS::IAM::Mock.data[@aws_access_key_id][:server_certificates].map {|n, c| c['Arn'] }
 
           listeners = [*listeners].map do |listener|
             if listener['SSLCertificateId'] and !certificate_ids.include? listener['SSLCertificateId']

--- a/lib/fog/aws/requests/elb/create_load_balancer_listeners.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer_listeners.rb
@@ -52,7 +52,7 @@ module Fog
           if load_balancer = self.data[:load_balancers][lb_name]
             response = Excon::Response.new
 
-            certificate_ids = Fog::AWS::IAM.new.list_server_certificates.body['Certificates'].collect { |c| c['Arn'] }
+            certificate_ids = Fog::AWS::IAM::Mock.data[@aws_access_key_id][:server_certificates].map {|n, c| c['Arn'] }
 
             listeners.each do |listener|
               if listener['SSLCertificateId'] and !certificate_ids.include? listener['SSLCertificateId']

--- a/lib/fog/aws/requests/elb/deregister_instances_from_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/deregister_instances_from_load_balancer.rb
@@ -37,7 +37,7 @@ module Fog
           raise Fog::AWS::ELB::NotFound unless load_balancer = self.data[:load_balancers][lb_name]
           instance_ids = [*instance_ids]
           instance_ids.each do |instance|
-            raise Fog::AWS::ELB::InvalidInstance unless Compute[:aws].servers.get(instance)
+            raise Fog::AWS::ELB::InvalidInstance unless Fog::Compute::AWS::Mock.data[@region][@aws_access_key_id][:instances][instance]
           end
 
           response = Excon::Response.new

--- a/lib/fog/aws/requests/elb/describe_instance_health.rb
+++ b/lib/fog/aws/requests/elb/describe_instance_health.rb
@@ -40,13 +40,13 @@ module Fog
           instance_ids = [*instance_ids]
           instance_ids = load_balancer['Instances'].collect { |i| i['InstanceId'] } unless instance_ids.any?
           data = instance_ids.map do |id|
-            unless instance = Compute[:aws].servers.get(id)
+            unless Fog::Compute::AWS::Mock.data[@region][@aws_access_key_id][:instances][instance]
               raise Fog::AWS::ELB::InvalidInstance
             end
 
             {
               'Description' => "",
-              'InstanceId' => instance.id,
+              'InstanceId' => id,
               'ReasonCode' => "",
               'State' => 'OutOfService'
             }

--- a/lib/fog/aws/requests/elb/register_instances_with_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/register_instances_with_load_balancer.rb
@@ -37,7 +37,7 @@ module Fog
           raise Fog::AWS::ELB::NotFound unless load_balancer = self.data[:load_balancers][lb_name]
           instance_ids = [*instance_ids]
           instances = instance_ids.map do |instance|
-            raise Fog::AWS::ELB::InvalidInstance unless Compute[:aws].servers.get(instance)
+            raise Fog::AWS::ELB::InvalidInstance unless Fog::Compute::AWS::Mock.data[@region][@aws_access_key_id][:instances][instance]
             {'InstanceId' => instance}
           end
 


### PR DESCRIPTION
Using things like `IAM.new` and `Compute[:aws]` assumes credentials are available via `Fog.credentials` which might not always be the case.
