### PR TITLE
[aws|compute] Mock modify_image_attribute add/remove users.

### DIFF
--- a/lib/fog/aws/requests/compute/describe_images.rb
+++ b/lib/fog/aws/requests/compute/describe_images.rb
@@ -100,6 +100,14 @@ module Fog
 
           image_set = self.data[:images].values
 
+          self.class.data[@region].each do |aws_access_key_id, data|
+            data[:image_launch_permissions].each do |image_id, list|
+              if list[:users].include?(self.data[:owner_id])
+                image_set << data[:images][image_id]
+              end
+            end
+          end
+
           for filter_key, filter_value in filters
             if tag_key = filter_key.split('tag:')[1]
               image_set = image_set.reject{|image| ![*filter_value].include?(image['tagSet'][tag_key])}

--- a/lib/fog/aws/requests/compute/modify_image_attribute.rb
+++ b/lib/fog/aws/requests/compute/modify_image_attribute.rb
@@ -37,6 +37,38 @@ module Fog
         end
 
       end
+
+      class Mock
+
+        def modify_image_attribute(image_id, attributes)
+          raise ArgumentError.new("image_id is required") unless image_id
+
+          unless self.data[:images][image_id]
+            raise Fog::Compute::AWS::NotFound.new("The AMI ID '#{image_id}' does not exist")
+          end
+
+          (attributes['Add.UserId'] || []).each do |user_id|
+            if image_launch_permissions = self.data[:image_launch_permissions][image_id]
+              image_launch_permissions[:users].push(user_id)
+            end
+          end
+
+          (attributes['Remove.UserId'] || []).each do |user_id|
+            if image_launch_permissions = self.data[:image_launch_permissions][image_id]
+              image_launch_permissions[:users].delete(user_id)
+            end
+          end
+
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            'return'        => true,
+            'requestId'     => Fog::AWS::Mock.request_id
+          }
+          response
+        end
+
+      end
     end
   end
 end


### PR DESCRIPTION
Images can be shared with other accounts/users/owners when mocking.

With the way the mock data is structured each access key is effectively an account. I did tweak the `owner_id` generation so it's now unique for each mock compute object but it has no real effect on operation since no previous request mocks go outside their access key-specific data.
