### PR TITLE
[aws|compute] Allow mock tagging to work across accounts.

### DIFF
--- a/lib/fog/aws/requests/compute/create_snapshot.rb
+++ b/lib/fog/aws/requests/compute/create_snapshot.rb
@@ -33,13 +33,13 @@ module Fog
       end
 
       class Mock
-        
+
         #
         # Usage
         #
         # AWS[:compute].create_snapshot("vol-f7c23423", "latest snapshot")
         #
-        
+
         def create_snapshot(volume_id, description = nil)
           response = Excon::Response.new
           if volume = self.data[:volumes][volume_id]
@@ -59,7 +59,6 @@ module Fog
             response.body = {
               'requestId' => Fog::AWS::Mock.request_id
             }.merge!(data)
-            self.data[:snapshots][snapshot_id]['tagSet'] = {}
           else
             response.status = 400
             raise(Excon::Errors.status_error({:expects => 200}, response))

--- a/lib/fog/aws/requests/compute/create_tags.rb
+++ b/lib/fog/aws/requests/compute/create_tags.rb
@@ -53,7 +53,7 @@ module Fog
             when /^vol\-[a-z0-9]{8}$/i
               'volume'
             end
-            if type && self.data[:"#{type}s"][resource_id]
+            if type && ((type == 'image' && visible_images[resource_id]) || self.data[:"#{type}s"][resource_id])
               { 'resourceId' => resource_id, 'resourceType' => type }
             else
               raise(Fog::Service::NotFound.new("The #{type} ID '#{resource_id}' does not exist"))
@@ -64,8 +64,10 @@ module Fog
             self.data[:tags][key] ||= {}
             self.data[:tags][key][value] ||= []
             self.data[:tags][key][value] |= tagged
-            
-            tagged.each {|resource| self.data[:"#{resource['resourceType']}s"][resource['resourceId']]['tagSet'][key] = value}
+
+            tagged.each do |resource|
+              self.data[:tag_sets][resource['resourceId']][key] = value
+            end
           end
 
           response = Excon::Response.new

--- a/lib/fog/aws/requests/compute/create_volume.rb
+++ b/lib/fog/aws/requests/compute/create_volume.rb
@@ -60,7 +60,6 @@ module Fog
               'size'              => size,
               'snapshotId'        => snapshot_id,
               'status'            => 'creating',
-              'tagSet'            => {},
               'volumeId'          => volume_id
             }
             self.data[:volumes][volume_id] = data

--- a/lib/fog/aws/requests/compute/delete_tags.rb
+++ b/lib/fog/aws/requests/compute/delete_tags.rb
@@ -53,7 +53,7 @@ module Fog
             when /^vol\-[a-z0-9]{8}$/i
               'volume'
             end
-            if type && self.data[:"#{type}s"][resource_id]
+            if type && ((type == 'image' && visible_images[resource_id]) || self.data[:"#{type}s"][resource_id])
               { 'resourceId' => resource_id, 'resourceType' => type }
             else
               raise(Fog::Service::NotFound.new("The #{type} ID '#{resource_id}' does not exist"))
@@ -65,9 +65,8 @@ module Fog
           end
 
           tagged.each do |resource|
-            object = self.data[:"#{resource['resourceType']}s"][resource['resourceId']]
             tags.each do |key, value|
-              tagset = object['tagSet']
+              tagset = self.data[:tag_sets][resource['resourceId']]
               tagset.delete(key) if tagset.has_key?(key) && (value.nil? || tagset[key] == value)
             end
           end

--- a/lib/fog/aws/requests/compute/describe_instances.rb
+++ b/lib/fog/aws/requests/compute/describe_instances.rb
@@ -88,7 +88,7 @@ module Fog
           response = Excon::Response.new
 
           instance_set = self.data[:instances].values
-          instance_set = apply_tag_filters(instance_set, filters)
+          instance_set = apply_tag_filters(instance_set, filters, 'instanceId')
 
           aliases = {
             'architecture'      => 'architecture',
@@ -196,7 +196,7 @@ module Fog
                 'ownerId'       => instance['ownerId'],
                 'reservationId' => instance['reservationId']
               }
-              reservation_set[instance['reservationId']]['instancesSet'] << instance.reject{|key,value| !['amiLaunchIndex', 'architecture', 'blockDeviceMapping', 'clientToken', 'dnsName', 'imageId', 'instanceId', 'instanceState', 'instanceType', 'ipAddress', 'kernelId', 'keyName', 'launchTime', 'monitoring', 'placement', 'platform', 'privateDnsName', 'privateIpAddress', 'productCodes', 'ramdiskId', 'reason', 'rootDeviceType', 'stateReason', 'tagSet'].include?(key)}
+              reservation_set[instance['reservationId']]['instancesSet'] << instance.reject{|key,value| !['amiLaunchIndex', 'architecture', 'blockDeviceMapping', 'clientToken', 'dnsName', 'imageId', 'instanceId', 'instanceState', 'instanceType', 'ipAddress', 'kernelId', 'keyName', 'launchTime', 'monitoring', 'placement', 'platform', 'privateDnsName', 'privateIpAddress', 'productCodes', 'ramdiskId', 'reason', 'rootDeviceType', 'stateReason'].include?(key)}.merge('tagSet' => self.data[:tag_sets][instance['instanceId']])
             end
           end
 

--- a/lib/fog/aws/requests/compute/describe_snapshots.rb
+++ b/lib/fog/aws/requests/compute/describe_snapshots.rb
@@ -72,7 +72,7 @@ module Fog
             Fog::Logger.warning("describe_snapshots with RestorableBy other than 'self' (wanted #{restorable_by.inspect}) is not mocked [light_black](#{caller.first})[/]")
           end
 
-          snapshot_set = apply_tag_filters(snapshot_set, filters)
+          snapshot_set = apply_tag_filters(snapshot_set, filters, 'snapshotId')
 
           aliases = {
             'description' => 'description',
@@ -105,6 +105,8 @@ module Fog
               end
             end
           end
+
+          snapshot_set = snapshot_set.map {|snapshot| snapshot.merge('tagSet' => self.data[:tag_sets][snapshot['snapshotId']]) }
 
           response.status = 200
           response.body = {

--- a/lib/fog/aws/requests/compute/describe_volumes.rb
+++ b/lib/fog/aws/requests/compute/describe_volumes.rb
@@ -55,8 +55,8 @@ module Fog
           response = Excon::Response.new
 
           volume_set = self.data[:volumes].values
-          volume_set = apply_tag_filters(volume_set, filters)
-          
+          volume_set = apply_tag_filters(volume_set, filters, 'volumeId')
+
           aliases = {
             'availability-zone' => 'availabilityZone',
             'create-time' => 'createTime',
@@ -102,6 +102,7 @@ module Fog
             end
           end
           volume_set = volume_set.reject {|volume| !self.data[:volumes][volume['volumeId']]}
+          volume_set = volume_set.map {|volume| volume.merge('tagSet' => self.data[:tag_sets][volume['volumeId']]) }
 
           response.status = 200
           response.body = {

--- a/lib/fog/aws/requests/compute/register_image.rb
+++ b/lib/fog/aws/requests/compute/register_image.rb
@@ -86,7 +86,6 @@ module Fog
               'rootDeviceName' => '',
               'blockDeviceMapping' => [],
               'virtualizationType' => 'paravirtual',
-              'tagSet' => {},
               'hypervisor' => 'xen',
               'registered' => Time.now
             }

--- a/lib/fog/aws/requests/compute/run_instances.rb
+++ b/lib/fog/aws/requests/compute/run_instances.rb
@@ -157,8 +157,7 @@ module Fog
               'ownerId'             => self.data[:owner_id],
               'privateIpAddress'    => nil,
               'reservationId'       => reservation_id,
-              'stateReason'         => {},
-              'tagSet'              => {}
+              'stateReason'         => {}
             })
           end
           response.body = {

--- a/tests/aws/requests/compute/tag_tests.rb
+++ b/tests/aws/requests/compute/tag_tests.rb
@@ -13,12 +13,52 @@ Shindo.tests('Fog::Compute[:aws] | tag requests', ['aws']) do
   @volume.wait_for { ready? }
 
   tests('success') do
+    if Fog.mocking?
+      @other_account = Fog::Compute::AWS.new(:aws_access_key_id => 'other', :aws_secret_access_key => 'account')
+      @image_id = Fog::Compute[:aws].register_image('image', 'image', '/dev/sda1').body['imageId']
+    end
+
     tests("#create_tags('#{@volume.identity}', 'foo' => 'bar')").formats(AWS::Compute::Formats::BASIC) do
       Fog::Compute[:aws].create_tags(@volume.identity, 'foo' => 'bar').body
     end
 
+    if Fog.mocking?
+      tests("#create_tags('#{@image_id}', 'foo' => 'baz')").formats(AWS::Compute::Formats::BASIC) do
+        Fog::Compute[:aws].create_tags(@image_id, 'foo' => 'baz').body
+      end
+    end
+
     tests('#describe_tags').formats(@tags_format) do
       Fog::Compute[:aws].describe_tags.body
+    end
+
+    expected_identities = Fog.mocking? ? [@volume.identity, @image_id] : [@volume.identity]
+    tests('#describe_tags').succeeds do
+      (expected_identities - Fog::Compute[:aws].describe_tags.body['tagSet'].map {|t| t['resourceId'] }).empty?
+    end
+
+    tests("#describe_tags('key' => 'foo', 'value' => 'bar')").returns([@volume.identity]) do
+      Fog::Compute[:aws].describe_tags('key' => 'foo', 'value' => 'bar').body['tagSet'].map {|t| t['resourceId'] }
+    end
+
+    if Fog.mocking?
+      tests("#describe_tags('key' => 'foo', 'value' => 'baz')").returns([@image_id]) do
+        Fog::Compute[:aws].describe_tags('key' => 'foo', 'value' => 'baz').body['tagSet'].map {|t| t['resourceId'] }
+      end
+
+      Fog::Compute[:aws].modify_image_attribute(@image_id, 'Add.UserId' => [@other_account.data[:owner_id]])
+
+      tests("other_account#describe_tags('key' => 'foo', 'value' => 'baz')").returns([]) do
+        @other_account.describe_tags('key' => 'foo', 'value' => 'baz').body['tagSet'].map {|t| t['resourceId'] }
+      end
+
+      tests("other_account#create_tags('#{@image_id}', 'foo' => 'quux')").formats(AWS::Compute::Formats::BASIC) do
+        @other_account.create_tags(@image_id, 'foo' => 'quux').body
+      end
+
+      tests("other_account#describe_tags('key' => 'foo', 'value' => 'quux')").returns([@image_id]) do
+        @other_account.describe_tags('key' => 'foo', 'value' => 'quux').body['tagSet'].map {|t| t['resourceId'] }
+      end
     end
 
     tests("#delete_tags('#{@volume.identity}', 'foo' => 'bar')").formats(AWS::Compute::Formats::BASIC) do


### PR DESCRIPTION
This moves tag_sets out of individual resources and up to a top-level item in each mock account's hash. Starting with images, this allows other mock accounts to create and use their own tags on images they have launchPermission on.
