### PR TITLE
[aws|compute] fixed spot_instance_request reply parsing when the original request contained a device mapping.

### DIFF
--- a/lib/fog/aws/parsers/compute/spot_instance_requests.rb
+++ b/lib/fog/aws/parsers/compute/spot_instance_requests.rb
@@ -6,7 +6,7 @@ module Fog
         class SpotInstanceRequests < Fog::Parsers::Base
 
           def reset
-            @block_device_mapping = []
+            @block_device_mapping = {}
             @context = []
             @contexts = ['blockDeviceMapping', 'groupSet']
             @spot_instance_request = { 'launchSpecification' => { 'blockDeviceMapping' => [], 'groupSet' => [] } }
@@ -42,7 +42,7 @@ module Fog
             when 'item'
               case @context.last
               when 'blockDeviceMapping'
-                @instance['blockDeviceMapping'] << @block_device_mapping
+                @spot_instance_request['launchSpecification']['blockDeviceMapping'] << @block_device_mapping
                 @block_device_mapping = {}
               when nil
                 @response['spotInstanceRequestSet'] << @spot_instance_request


### PR DESCRIPTION
The spot_instance_requests reply parser failed if the original request contained any block device mappings. This patch fixes that.
