### PR TITLE
[OpenStack|compute] default metadata to empy hash

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -27,6 +27,7 @@ module Fog
 
         def initialize(attributes={})
           @connection = attributes[:connection]
+          attributes[:metadata] = {}
           super
         end
 


### PR DESCRIPTION
Calling metadata.each in the `save` method will make a spurious request to
the nova endpoint, unless metadata has been initialized to an empty hash.
