### PR TITLE
[OpenStack|compute] fix v2.0 auth endpoints

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -88,12 +88,13 @@ module Fog
 
       response = connection.request({
         :expects  => [200, 204],
-        :body  => req_body,
+        :headers => {'Content-Type' => 'application/json'},
+        :body  => MultiJson.encode(req_body),
         :host     => uri.host,
-        :method   => 'GET',
+        :method   => 'POST',
         :path     =>  (uri.path and not uri.path.empty?) ? uri.path : 'v2.0'
       })
-      body=response.body
+      body=MultiJson.decode(response.body)
      
       if body['auth']['serviceCatalog'] and body['auth']['serviceCatalog'][@compute_service_name] and body['auth']['serviceCatalog'][@compute_service_name][0] then
         mgmt_url = body['auth']['serviceCatalog'][@compute_service_name][0]['publicURL']


### PR DESCRIPTION
This fixes how paths and regexps work for less common cases (eg: having
and auth endpoint that is /v2.0/tokens.json).

Serialization to/from json and setting content-type header are added.

No longer silently converts nova api endpoints to 1.1, but errors instead.  You
should be using keystone's service catalog in conjunction with
@openstack_compute_service_name.
