### PR TITLE
[OpenStack|compute] add zone awareness

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -20,6 +20,7 @@ module Fog
         attribute :progress
         attribute :accessIPv4
         attribute :accessIPv6
+        attribute :availability_zone
         attribute :state,       :aliases => 'status'
 
         attr_reader :password
@@ -152,7 +153,8 @@ module Fog
             'metadata'    => meta_hash,
             'personality' => personality,
             'accessIPv4' => accessIPv4,
-            'accessIPv6' => accessIPv6
+            'accessIPv6' => accessIPv6,
+            'availability_zone' => availability_zone
           }
           options = options.reject {|key, value| value.nil?}
           data = connection.create_server(name, image_ref, flavor_ref, options)

--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -30,6 +30,9 @@ module Fog
               }
             end
           end
+          if options['availability_zone']
+            data['server']['availability_zone'] = options['availability_zone']
+          end
           request(
             :body     => MultiJson.encode(data),
             :expects  => [200, 202],


### PR DESCRIPTION
Nova has a `ZoneScheduler` that can run instances on a particular set of
hardware.  This attribute hasn't been documented in the api spec, but is
effective at setting the availability_zone and letting ZoneScheduler work.
