### PR TITLE
add region option to aws sns service recognizes method

### DIFF
--- a/lib/fog/aws/sns.rb
+++ b/lib/fog/aws/sns.rb
@@ -5,7 +5,7 @@ module Fog
     class SNS < Fog::Service
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :host, :path, :port, :scheme, :persistent
+      recognizes :host, :path, :port, :scheme, :persistent, :region
 
       request_path 'fog/aws/requests/sns'
       request :add_permission


### PR DESCRIPTION
aws sns service should recognize region option during intialization. this was probably left out whilst sns was in beta and only available in a single region
