### PR TITLE
Rackspace Response seems to have changed

### DIFF
--- a/lib/fog/rackspace/models/dns/record.rb
+++ b/lib/fog/rackspace/models/dns/record.rb
@@ -51,7 +51,7 @@ module Fog
           }
 
           response = wait_for_job connection.add_records(@zone.identity, [options]).body['jobId']
-          merge_attributes(response.body['records'].first)
+          merge_attributes(response.body['request']['records'].first)
           true
         end
 


### PR DESCRIPTION
Hey Guys,

Seems like rackspace now wraps this inside another object. 

This isn't what's specified at: http://docs.rackspace.com/cdns/api/v1.0/cdns-devguide/content/Add_Records-d1e4895.html#d6e2108. 

Apologies for the utter and complete lack of test changes etc. If y'all want to point me in the right direction I'll be only too happy to add them. 

Nik
