### PR TITLE
Send power parameter in GoGrid's grid_server_power request

### DIFF
--- a/lib/fog/go_grid/requests/compute/grid_server_power.rb
+++ b/lib/fog/go_grid/requests/compute/grid_server_power.rb
@@ -16,7 +16,7 @@ module Fog
         def grid_server_power(server, power)
           request(
             :path     => 'grid/server/power',
-            :query    => {'server' => server}
+            :query    => {'server' => server, 'power' => power}
           )
         end
 


### PR DESCRIPTION
The grid_server_power request fails because it does not send the power command to execute. I have modified it to include it as a parameter, and manually tested it to check it works. 

I know the policy is to make shindo tests for the changes in the project, but I am at a loss at how to start: I am not very familiar with shindo and the tests for existing requests for other providers seem rather complicated.

I hope this is of use anyway.
