### PR TITLE
Optimize vSphere convert_vm_mob_ref_to_attr_hash

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -29,36 +29,36 @@ module Fog
         attr_reader :vsphere_server
         attr_reader :vsphere_username
 
+        ATTR_TO_PROP = {
+          :id => 'config.instanceUuid',
+          :name => 'name',
+          :uuid => 'config.uuid',
+          :instance_uuid => 'config.instanceUuid',
+          :hostname => 'summary.guest.hostName',
+          :operatingsystem => 'summary.guest.guestFullName',
+          :ipaddress => 'guest.ipAddress',
+          :power_state => 'runtime.powerState',
+          :connection_state => 'runtime.connectionState',
+          :host => 'runtime.host',
+          :tools_state => 'guest.toolsStatus',
+          :tools_version => 'guest.toolsVersionStatus',
+          :is_a_template => 'config.template',
+        }
+
         # Utility method to convert a VMware managed object into an attribute hash.
         # This should only really be necessary for the real class.
         # This method is expected to be called by the request methods
         # in order to massage VMware Managed Object References into Attribute Hashes.
         def convert_vm_mob_ref_to_attr_hash(vm_mob_ref)
           return nil unless vm_mob_ref
-          # A cloning VM doesn't have a configuration yet.  Unfortuantely we just get
-          # a RunTime exception.
-          begin
-            is_ready = vm_mob_ref.config ? true : false
-          rescue RuntimeError
-            is_ready = nil
+
+          props = vm_mob_ref.collect! *ATTR_TO_PROP.values.uniq
+          Hash[ATTR_TO_PROP.map { |k,v| [k.to_s, props[v]] }].tap do |attrs|
+            attrs['id'] ||= vm_mob_ref._ref
+            attrs['mo_ref'] = vm_mob_ref._ref
+            attrs['hypervisor'] = attrs['host'].name
+            attrs['mac_addresses'] = vm_mob_ref.macs
           end
-          {
-            'id'               => is_ready ? vm_mob_ref.config.instanceUuid : vm_mob_ref._ref,
-            'mo_ref'           => vm_mob_ref._ref,
-            'name'             => vm_mob_ref.name,
-            'uuid'             => is_ready ? vm_mob_ref.config.uuid : nil,
-            'instance_uuid'    => is_ready ? vm_mob_ref.config.instanceUuid : nil,
-            'hostname'         => vm_mob_ref.summary.guest.hostName,
-            'operatingsystem'  => vm_mob_ref.summary.guest.guestFullName,
-            'ipaddress'        => vm_mob_ref.summary.guest.ipAddress,
-            'power_state'      => vm_mob_ref.runtime.powerState,
-            'connection_state' => vm_mob_ref.runtime.connectionState,
-            'hypervisor'       => vm_mob_ref.runtime.host ? vm_mob_ref.runtime.host.name : nil,
-            'tools_state'      => vm_mob_ref.summary.guest.toolsStatus,
-            'tools_version'    => vm_mob_ref.summary.guest.toolsVersionStatus,
-            'mac_addresses'    => is_ready ? vm_mob_ref.macs : nil,
-            'is_a_template'    => is_ready ? vm_mob_ref.config.template : nil
-          }
         end
 
       end


### PR DESCRIPTION
This patch reduces the number of round trips to the vSphere API by
using the `collect!` method on the ManagedObject, vm_mob_ref, which
retrieves most of the properties in one request.

For the remaining properties: hypervisor and mac_addresses, we still
need to make additional requests.

Overall this patch provides a nice speed improvement for the
`convert_vm_mob_ref_to_attr_hash` method.
