### PR TITLE
Use autoload instead of require in #initialize methods

### DIFF
--- a/lib/fog/aws/auto_scaling.rb
+++ b/lib/fog/aws/auto_scaling.rb
@@ -69,8 +69,6 @@ module Fog
         # ==== Returns
         # * AutoScaling object with connection to AWS.
         def initialize(options={})
-          require 'fog/core/parser'
-
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]
           @hmac       = Fog::HMAC.new('sha256', @aws_secret_access_key)

--- a/lib/fog/aws/cdn.rb
+++ b/lib/fog/aws/cdn.rb
@@ -41,7 +41,6 @@ module Fog
         end
 
         def initialize(options={})
-          require 'mime/types'
           @aws_access_key_id  = options[:aws_access_key_id]
           @region             = options[:region]
         end
@@ -80,8 +79,6 @@ module Fog
         # ==== Returns
         # * cdn object with connection to aws.
         def initialize(options={})
-          require 'fog/core/parser'
-
           @aws_access_key_id = options[:aws_access_key_id]
           @aws_secret_access_key = options[:aws_secret_access_key]
           @connection_options = options[:connection_options] || {}

--- a/lib/fog/aws/cloud_formation.rb
+++ b/lib/fog/aws/cloud_formation.rb
@@ -45,9 +45,6 @@ module Fog
         # ==== Returns
         # * CloudFormation object with connection to AWS.
         def initialize(options={})
-          require 'fog/core/parser'
-          require 'multi_json'
-
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]
           @hmac       = Fog::HMAC.new('sha256', @aws_secret_access_key)

--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -253,8 +253,6 @@ module Fog
         # ==== Returns
         # * EC2 object with connection to aws.
         def initialize(options={})
-          require 'fog/core/parser'
-
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]
           @connection_options     = options[:connection_options] || {}

--- a/lib/fog/aws/dns.rb
+++ b/lib/fog/aws/dns.rb
@@ -40,7 +40,6 @@ module Fog
         end
 
         def initialize(options={})
-          require 'mime/types'
           @aws_access_key_id  = options[:aws_access_key_id]
           @region             = options[:region]
         end
@@ -78,8 +77,6 @@ module Fog
         # ==== Returns
         # * dns object with connection to aws.
         def initialize(options={})
-          require 'fog/core/parser'
-
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]
           @connection_options     = options[:connection_options] || {}

--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -99,8 +99,6 @@ module Fog
         # ==== Returns
         # * ELB object with connection to AWS.
         def initialize(options={})
-          require 'fog/core/parser'
-
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]
           @connection_options     = options[:connection_options] || {}

--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -107,9 +107,6 @@ module Fog
         # ==== Returns
         # * IAM object with connection to AWS.
         def initialize(options={})
-          require 'fog/core/parser'
-          require 'multi_json'
-
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]
           @connection_options     = options[:connection_options] || {}

--- a/lib/fog/aws/ses.rb
+++ b/lib/fog/aws/ses.rb
@@ -45,8 +45,6 @@ module Fog
         # ==== Returns
         # * SES object with connection to AWS.
         def initialize(options={})
-          require 'fog/core/parser'
-
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]
           @connection_options     = options[:connection_options] || {}

--- a/lib/fog/aws/simpledb.rb
+++ b/lib/fog/aws/simpledb.rb
@@ -66,8 +66,6 @@ module Fog
         # ==== Returns
         # * SimpleDB object with connection to aws.
         def initialize(options={})
-          require 'fog/core/parser'
-
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]
           @connection_options     = options[:connection_options] || {}

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -183,8 +183,6 @@ module Fog
         end
 
         def initialize(options={})
-          require 'mime/types'
-          require 'multi_json'
           @aws_access_key_id = options[:aws_access_key_id]
           @aws_secret_access_key = options[:aws_secret_access_key]
           options[:region] ||= 'us-east-1'
@@ -241,9 +239,6 @@ module Fog
         # ==== Returns
         # * S3 object with connection to aws.
         def initialize(options={})
-          require 'fog/core/parser'
-          require 'mime/types'
-
           @aws_access_key_id = options[:aws_access_key_id]
           @aws_secret_access_key = options[:aws_secret_access_key]
           @connection_options     = options[:connection_options] || {}

--- a/lib/fog/core.rb
+++ b/lib/fog/core.rb
@@ -28,7 +28,6 @@ require 'fog/core/json'
 require 'fog/core/logger'
 require 'fog/core/model'
 require 'fog/core/mock'
-require 'fog/core/parser' # FIXME: would be better to only load when nokogiri is required
 require 'fog/core/provider'
 require 'fog/core/service'
 require 'fog/core/ssh'
@@ -36,3 +35,15 @@ require 'fog/core/scp'
 require 'fog/core/time'
 require 'fog/core/timeout'
 require 'fog/core/wait_for'
+
+module Fog
+  module Parsers
+    autoload 'Base',         'fog/core/parser'
+  end
+  autoload 'ToHashDocument', 'fog/core/parser'
+end
+
+autoload 'Nokogiri',  'nokogiri'
+autoload 'MIME',      'mime/types'
+autoload 'Builder',   'builder'
+autoload 'MultiJson', 'multi_json'

--- a/lib/fog/dnsmadeeasy/dns.rb
+++ b/lib/fog/dnsmadeeasy/dns.rb
@@ -79,9 +79,6 @@ module Fog
         # ==== Returns
         # * dns object with connection to aws.
         def initialize(options={})
-          require 'fog/core/parser'
-          require 'multi_json'
-
           @dnsmadeeasy_api_key = options[:dnsmadeeasy_api_key]
           @dnsmadeeasy_secret_key = options[:dnsmadeeasy_secret_key]
           @connection_options = options[:connection_options] || {}

--- a/lib/fog/dynect.rb
+++ b/lib/fog/dynect.rb
@@ -1,7 +1,4 @@
-require 'nokogiri'
-
 require(File.expand_path(File.join(File.dirname(__FILE__), 'core')))
-require 'fog/core/parser'
 
 module Fog
   module Dynect

--- a/lib/fog/ecloud/compute.rb
+++ b/lib/fog/ecloud/compute.rb
@@ -1066,9 +1066,6 @@ module Fog
         end
 
         def initialize(options = {})
-          require 'builder'
-          require 'fog/core/parser'
-
           @versions_uri = URI.parse('https://vcloud.fakey.com/api/versions')
         end
 
@@ -1136,9 +1133,6 @@ module Fog
         end
 
         def initialize(options = {})
-          require 'builder'
-          require 'fog/core/parser'
-
           @connections = {}
           @connection_options = options[:connection_options] || {}
           @versions_uri = URI.parse(options[:ecloud_versions_uri])

--- a/lib/fog/google/storage.rb
+++ b/lib/fog/google/storage.rb
@@ -144,7 +144,6 @@ module Fog
         end
 
         def initialize(options={})
-          require 'mime/types'
           @google_storage_access_key_id = options[:google_storage_access_key_id]
         end
 
@@ -184,9 +183,6 @@ module Fog
         # ==== Returns
         # * Storage object with connection to google.
         def initialize(options={})
-          require 'fog/core/parser'
-          require 'mime/types'
-
           @google_storage_access_key_id = options[:google_storage_access_key_id]
           @google_storage_secret_access_key = options[:google_storage_secret_access_key]
           @connection_options = options[:connection_options] || {}

--- a/lib/fog/new_servers/compute.rb
+++ b/lib/fog/new_servers/compute.rb
@@ -48,8 +48,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'fog/core/parser'
-
           @new_servers_password = options[:new_servers_password]
           @new_servers_username = options[:new_servers_username]
           @connection_options = options[:connection_options] || {}

--- a/lib/fog/slicehost/compute.rb
+++ b/lib/fog/slicehost/compute.rb
@@ -57,8 +57,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'fog/core/parser'
-
           @slicehost_password = options[:slicehost_password]
           @connection_options = options[:connection_options] || {}
           @host       = options[:host]        || "api.slicehost.com"

--- a/lib/fog/slicehost/dns.rb
+++ b/lib/fog/slicehost/dns.rb
@@ -53,8 +53,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'fog/core/parser'
-
           @slicehost_password = options[:slicehost_password]
           @connection_options     = options[:connection_options] || {}
           @host       = options[:host]        || "api.slicehost.com"

--- a/lib/fog/vcloud/compute.rb
+++ b/lib/fog/vcloud/compute.rb
@@ -158,9 +158,6 @@ module Fog
         end
 
         def initialize(options = {})
-          require 'builder'
-          require 'fog/core/parser'
-
           @connections = {}
           @connection_options = options[:connection_options] || {}
           @persistent = options[:persistent]

--- a/lib/fog/zerigo/dns.rb
+++ b/lib/fog/zerigo/dns.rb
@@ -71,8 +71,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'fog/core/parser'
-
           @zerigo_email  = options[:zerigo_email]
           @zerigo_token  = options[:zerigo_token]
           @connection_options = options[:connection_options] || {}


### PR DESCRIPTION
`Kernel#require` is quite slow and can be taxing when creating a lot of instances. This patch removes these calls and replace them by adding autoload statements in fog/core.rb. 

This patch is preliminary as the shindo test suite is badly broken on my computer but I though of at least starting a conversation on that issue. When mocking is disabled, I only have an AWS account and even there some tests are failing. When mocking is enabled, I get some uninplemented issues and halts on the vsphere tests because of malformed YAML (they are indented and shouldn't). I don't have the time right now to fix the test suite unfortunately.
