### PR TITLE
[dnsmadeeasy|dns] Fix Fog::DNS::DNSMadeEasy::Record#save 

### DIFF
--- a/lib/fog/dnsmadeeasy/models/dns/record.rb
+++ b/lib/fog/dnsmadeeasy/models/dns/record.rb
@@ -58,11 +58,12 @@ module Fog
 
           if id.nil?
             data = connection.create_record(zone.domain, name, type, value, options).body
+            merge_attributes(data)
           else
-            data = connection.update_record(zone.domain, id, options).body
+            options.merge!(:name => name, :type => type, :data => value)
+            connection.update_record(zone.domain, id, options).body
           end
 
-          merge_attributes(data)
           true
         end
 


### PR DESCRIPTION
The update code path of `#save` was not passing the required parameters into the update request.
