### PR TITLE
Removed puts of element name

### DIFF
--- a/lib/fog/aws/parsers/cdn/get_invalidation_list.rb
+++ b/lib/fog/aws/parsers/cdn/get_invalidation_list.rb
@@ -15,7 +15,6 @@ module Fog
           end
 
           def end_element(name)
-            puts name
             case name
             when 'InvalidationSummary'
               @response['InvalidationSummary'] << @invalidation_summary


### PR DESCRIPTION
Found this `puts` call in `Fog::Parsers::CDN::AWS::GetInvalidationList`. I removed it as I guess it's some debug stuff thats been accidentally left in there? Kinda annoying when doing command line utils =)

Let me know what you think.
