### PR TITLE
[dns] Made model tests use uniq domain names

### DIFF
--- a/tests/dns/models/record_tests.rb
+++ b/tests/dns/models/record_tests.rb
@@ -3,17 +3,19 @@ for provider, config in dns_providers
   # FIXME: delay/timing breaks things :(
   next if [:dnsmadeeasy].include?(provider)
 
+  domain_name = uniq_id + '.com'
+
   Shindo.tests("Fog::DNS[:#{provider}] | record", [provider.to_s]) do
 
     record_attributes = {
-      :name   => 'www.fogrecordtests.com',
+      :name   => 'www.' + domain_name,
       :type   => 'A',
       :value  => '1.2.3.4'
     }.merge!(config[:record_attributes] || {})
 
     if !Fog.mocking? || config[:mocked]
       zone_attributes = {
-        :domain => 'fogrecordtests.com'
+        :domain => domain_name
       }.merge(config[:zone_attributes] || {})
 
       @zone = Fog::DNS[provider].zones.create(zone_attributes)

--- a/tests/dns/models/records_tests.rb
+++ b/tests/dns/models/records_tests.rb
@@ -3,17 +3,19 @@ for provider, config in dns_providers
   # FIXME: delay/timing breaks things :(
   next if [:dnsmadeeasy].include?(provider)
 
+  domain_name = uniq_id + '.com'
+
   Shindo.tests("Fog::DNS[:#{provider}] | records", [provider.to_s]) do
 
     record_attributes = {
-      :name   => 'www.fogrecordstests.com',
+      :name   => 'www.' + domain_name,
       :type   => 'A',
       :value  => '1.2.3.4'
     }.merge!(config[:record_attributes] || {})
 
     if !Fog.mocking? || config[:mocked]
       zone_attributes = {
-        :domain => 'fogrecordstests.com'
+        :domain => domain_name
       }.merge(config[:zone_attributes] || {})
 
       @zone = Fog::DNS[provider].zones.create(zone_attributes)

--- a/tests/dns/models/zone_tests.rb
+++ b/tests/dns/models/zone_tests.rb
@@ -3,10 +3,12 @@ for provider, config in dns_providers
   # FIXME: delay/timing breaks things :(
   next if [:dnsmadeeasy].include?(provider)
 
+  domain_name = uniq_id + '.com'
+
   Shindo.tests("Fog::DNS[:#{provider}] | zone", [provider.to_s]) do
 
     zone_attributes = {
-      :domain => 'fogzonetests.com'
+      :domain => domain_name
     }.merge!(config[:zone_attributes] || {})
 
     model_tests(Fog::DNS[provider].zones, zone_attributes, config[:mocked])

--- a/tests/dns/models/zones_tests.rb
+++ b/tests/dns/models/zones_tests.rb
@@ -3,10 +3,12 @@ for provider, config in dns_providers
   # FIXME: delay/timing breaks things :(
   next if [:dnsmadeeasy].include?(provider)
 
+  domain_name = uniq_id + '.com'
+
   Shindo.tests("Fog::DNS[:#{provider}] | zones", [provider.to_s]) do
 
     zone_attributes = {
-      :domain => 'fogzonestests.com'
+      :domain => domain_name
     }.merge!(config[:zone_attributes] || {})
 
     collection_tests(Fog::DNS[provider].zones, zone_attributes, config[:mocked])


### PR DESCRIPTION
Not using unique hostnames could cause conflicts across accounts if names aren't cleaned up appropriately.  This was done because of how the Rackspace provider works, so I don't know how it might affect other providers
