### PR TITLE
[core] `@credential` should always be a symbol

### DIFF
--- a/lib/fog/core/credentials.rb
+++ b/lib/fog/core/credentials.rb
@@ -8,12 +8,12 @@ module Fog
   #   @ return [String, Symbol] name of the new credential
   def self.credential=(new_credential)
     @credentials = nil
-    @credential = new_credential
+    @credential = new_credential.to_sym
   end
 
   # @return [String, Symbol] The credential to use in Fog
   def self.credential
-    @credential ||= ENV["FOG_CREDENTIAL"] || :default
+    @credential ||= ENV["FOG_CREDENTIAL"].to_sym || :default
   end
 
   # @return [String] The path for configuration_file

--- a/tests/core/credential_tests.rb
+++ b/tests/core/credential_tests.rb
@@ -18,12 +18,12 @@ Shindo.tests do
   tests('credential') do
     returns(:default, "is :default") { Fog.credential }
 
-    returns("foo", "can be set directly") do
+    returns(:foo, "can be set directly") do
       Fog.credential = "foo"
       Fog.credential
     end
 
-    returns("bar", "can be set with environment variable") do
+    returns(:bar, "can be set with environment variable") do
       ENV["FOG_CREDENTIAL"] = "bar"
       Fog.credential
     end


### PR DESCRIPTION
Similar to #504, say your ~/.fog had multiple stanzas:

``` yaml
:default:
  :aws_access_key_id: aaa
test:
  :aws_access_key_id: bbb
:prod:
  :aws_access_key_id: ccc
```

By default, fog will look for either the credential _symbol_ `:default` or for the _string_ stored in `FOG_CREDENTIAL` (in `lib/fog/core/credentials.rb` method `self.credential`). When the fog credentials file given above is read in, it’s passed through `self.symbolize_credentials` which makes _symbols_ out of all the keys (so `prod`, `test`, and `default` will all be symbols) and saves the list to credentials then looks for `credentials[credential]` which is indexing a string in a hash of symbols.

Any value that `@credential` is set to should be a symbol, because the hash keys will only be symbols.
