### PR TITLE
[core] Cast Fog.wait_for interval to float.

### DIFF
--- a/lib/fog/core/wait_for.rb
+++ b/lib/fog/core/wait_for.rb
@@ -4,7 +4,7 @@ module Fog
     duration = 0
     start = Time.now
     until yield || duration > timeout
-      sleep(interval)
+      sleep(interval.to_f)
       duration = Time.now - start
     end
     if duration > timeout


### PR DESCRIPTION
sleep() is strict. Allow more liberal values like
ActiveSupport::Durations:

   Fog.wait(1.hour, 10.seconds) { … }
