### PR TITLE
Fix regression in Rakefile introduced in 70e7ea1

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -72,11 +72,11 @@ def tests(mocked)
   start = Time.now.to_i
   threads = []
   Thread.main[:results] = []
-  Fog.providers.each do |provider|
+  Fog.providers.each do |key, value|
     threads << Thread.new do
       Thread.main[:results] << {
-        :provider => provider,
-        :success  => sh("export FOG_MOCK=#{mocked} && bundle exec shindont +#{provider.downcase}")
+        :provider => value,
+        :success  => sh("export FOG_MOCK=#{mocked} && bundle exec shindont +#{key}")
       }
     end
   end


### PR DESCRIPTION
Commit 70e7ea133b5be629ec54bd26b2a456cb45abfd89 changed the format of Fog.providers from an array to a hash using symbols as keys and strings as values.  Thus Fog.providers.each yielded two-element arrays rather than a string scalar as it did before.  The tests themselves were fine but portions of the Rakefile were expecting the old format.  

With this pach "bundle exec rake" works once again.
