### PR TITLE
Simple bug in saving metric_statistic model

### DIFF
--- a/lib/fog/aws/models/cloud_watch/metric_statistic.rb
+++ b/lib/fog/aws/models/cloud_watch/metric_statistic.rb
@@ -25,7 +25,6 @@ module Fog
 
           put_opts = {'MetricName' => metric_name, 'Unit' => unit}
           put_opts.merge!('Dimensions' => dimensions) if dimensions
-          put_opts.merge!('Timestamp' => dimensions) if timestamp
           if value
             put_opts.merge!('Value' => value)
           else


### PR DESCRIPTION
Bug fix is removing this line ... looks like a WIP:

```
      put_opts.merge!('Timestamp' => dimensions) if timestamp
```

It sends a bad request to the API, the 'Timestamp' key is replaced with dimensions. The test for this is marked as 'pending', but it's easy to show it is broken in fog/master and that this one liner fixes it:

Symptom with fog master:

fog#> instanceid = "i-xxxxxxx"
fog#> params = { :timestamp => Time.now.iso8601, :minimum => 0, :maximum => 60, :sum => 100, :average => 3, :sample_count => 10, :namespace => "hom_custom", :metric_name => "PassengerQueue", :value => 10, :unit => 'None', 'Dimensions' => [{'Name' => 'InstanceId', 'Value' => instanceid}]}
fog#> Fog::AWS::CloudWatch.new(:region => "us-west-1").metric_statistics.new(params).save

response => #<Excon::Response:0x000008046d28b8 @body="<ErrorResponse xmlns=\"http://monitoring.amazonaws.com/doc/2010-08-01/\">\n  <Error>\n    <Type>Sender</Type>\n    <Code>MalformedInput</Code>\n    <Message>timestamp must follow ISO8601</Message>\n  </Error>\n  <RequestId>d47bdedf-25c8-11e1-bbe6-419fabbfd753</RequestId>\n</ErrorResponse>\n", @headers={"x-amzn-RequestId"=>"d47bdedf-25c8-11e1-bbe6-419fabbfd753", "Content-Type"=>"text/xml", "Content-Length"=>"281", "Date"=>"Tue, 13 Dec 2011 20:27:08 GMT"}, @status=400>
