### PR TITLE
Rackspace does not accept integer-like strings, need to cast before send...

### DIFF
--- a/lib/fog/rackspace/requests/compute/create_server.rb
+++ b/lib/fog/rackspace/requests/compute/create_server.rb
@@ -36,8 +36,8 @@ module Fog
         def create_server(flavor_id, image_id, options = {})
           data = {
             'server' => {
-              'flavorId'  => flavor_id,
-              'imageId'   => image_id
+              'flavorId'  => flavor_id.to_i,
+              'imageId'   => image_id.to_i
             }
           }
           if options['metadata']


### PR DESCRIPTION
Rackspace doesn't accept integer-strings. Since imageId and flavorId isn't being validated before being included into the model, fog should probably cast them into integers before sending them on.
