### PR TITLE
[docs] Update GitHub repository references from geemus/fog to fog/fog.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -108,7 +108,7 @@ geemus says: "That should give you everything you need to get started, but let m
 * Find something you would like to work on. For suggestions look for the `easy`, `medium` and `hard` tags in the {issues}[http://github.com/fog/fog/issues]
 * Fork the project and do your work in a topic branch.
 * Add shindo tests to prove your code works and run all the tests using `bundle exec rake`.
-* Rebase your branch against geemus/fog to make sure everything is up to date.
+* Rebase your branch against fog/fog to make sure everything is up to date.
 * Commit your changes and send a pull request.
 
 == Additional Resources

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -35,7 +35,7 @@
       <dl>
         <dt>version</dt><dd>vX.Y.Z</dd>
         <dt>install</dt><dd><code>gem install fog</code></dd>
-        <dt>source</dt><dd><a href="http://github.com/fog/fog">geemus/fog</a></dd>
+        <dt>source</dt><dd><a href="http://github.com/fog/fog">fog/fog</a></dd>
       </dl>
     </header>
 

--- a/docs/index.markdown
+++ b/docs/index.markdown
@@ -45,7 +45,7 @@ geemus says: "That should give you everything you need to get started, but let m
 * Find something you would like to work on. For suggestions look for the `easy`, `medium` and `hard` tags in the [issues](http://github.com/fog/fog/issues)
 * Fork the project and do your work in a topic branch.
 * Add shindo tests to prove your code works and run all the tests using `bundle exec rake`.
-* Rebase your branch against geemus/fog to make sure everything is up to date.
+* Rebase your branch against fog/fog to make sure everything is up to date.
 * Commit your changes and send a pull request.
 
 ## Resources


### PR DESCRIPTION
While the URLs were updated in e3dfde84, references to the GitHub repository still say geemus/fog while linking to fog/fog.

This commit updates those references to the new fog/fog repository.
