### PR TITLE
[rackspace/compute] Add 30GB (30720) compute size

### DIFF
--- a/lib/fog/rackspace/models/compute/flavor.rb
+++ b/lib/fog/rackspace/models/compute/flavor.rb
@@ -34,6 +34,8 @@ module Fog
             1/2.0
           when 15872
             1
+          when 30720
+            2
           end
         end
 


### PR DESCRIPTION
Rackspace has [30GB compute nodes](http://www.rackspace.com/cloud/cloud_hosting_products/servers/pricing/). If you've got these nodes on your
account and try to do a flavor.cores you an exception like:

```
TypeError: nil can't be coerced into Fixnum
    from /Users/philkates/.rvm/gems/ruby-1.9.3-p0/gems/fog-1.1.2/lib/fog/rackspace/models/compute/flavor.rb:37:in `*'
    from /Users/philkates/.rvm/gems/ruby-1.9.3-p0/gems/fog-1.1.2/lib/fog/rackspace/models/compute/flavor.rb:37:in `cores'
    from (irb):6:in `<main>'
    from ./bin/fog:52:in `block in <main>'
    from ./bin/fog:52:in `catch'
    from ./bin/fog:52:in `<main>'
```

This is my incredibly simplistic fix.
