### PR TITLE
Change to only do a 'head' on the file that we've copied directly in S3

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -50,7 +50,7 @@ module Fog
           requires :directory, :key
           connection.copy_object(directory.key, key, target_directory_key, target_file_key, options)
           target_directory = connection.directories.new(:key => target_directory_key)
-          target_directory.files.get(target_file_key)
+          target_directory.files.head(target_file_key)
         end
 
         def destroy


### PR DESCRIPTION
I operate on files of several gigabytes in size, and it's not good if my server tries to load all that stuff into RAM, so a 'head' is much better then a 'get'.
