### PR TITLE
fix a typo in the vsphere vm_clone.rb file

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -41,7 +41,7 @@ module Fog
           template_dc = path_elements.shift
           # If the first path element contains "vm" this denotes the vmFolder
           # and needs to be shifted out
-          path_elements.shift if path_elements[0] = 'vm'
+          path_elements.shift if path_elements[0] == 'vm'
           # The template name.  The remaining elements are the folders in the
           # datacenter.
           template_name = path_elements.pop


### PR DESCRIPTION
git commit -a -m "fixed a conditional that was assigining = rather than evaluating == in vsphere clone routine.  This resulted in cloning from folders always failing"
