### PR TITLE
Feature/master/robustness and similar to vsphere

### DIFF
--- a/lib/fog/vmfusion/models/compute/server.rb
+++ b/lib/fog/vmfusion/models/compute/server.rb
@@ -8,150 +8,209 @@ module Fog
 
         identity :name
 
-        attribute :name
-        attribute :state
+        attribute :ipaddress
+        attribute :power_state
+        attribute :mac_addresses
+        attribute :path
 
         attr_accessor :password
         attr_writer   :private_key, :private_key_path, :public_key, :public_key_path, :username
 
-        def initalize(attributes={})
-        end
-
+        # There is currently no documented model of creating VMs from scratch
+        # sans Fusion's wizard.
         def save
           raise Fog::Errors::Error.new('Creating a new vm is not yet supported')
         end
 
+        # Fussion doesn't have the concept of templates so one just clones
+        # regular VMs.
         def clone(name)
           requires :raw
 
-          ::Fission::VM.clone(@raw.name,name)
+          ::Fission::VM.clone(@raw[:fission].name,name)
           return connection.servers.get(name)
         end
 
-        def destroy(options={ :force => false})
+        # Destroy, deletes the VM from the local disk but only hard stops the VM
+        # before doing so if you set :force to true.
+        def destroy(options = { :force => false })
           requires :raw
 
-          if state=="running"
+          if ready?
             if options[:force]
-              @raw.stop
+              stop
             end
           end
 
-          ::Fission::VM.delete @raw.name
+          @raw[:fission].delete
         end
 
-        def start
+        # Start is pretty self explanatory...if you pass :headless as true you
+        # won't get a console on launch.
+        def start(options = { :headless => false })
           requires :raw
 
-          unless state=="running"
-            @raw.start
+          unless ready?
+            @raw[:fission].start(:headless => options[:headless])
             return true
           else
             return false
           end
         end
 
+        # We're covering a lot of bases here with the different ways one can
+        # stop a VM from running.
+
+        # Stop is a hard stop, like pulling out the power cord.
         def stop
           requires :raw
 
-          if state=="running"
-            @raw.stop
+          if ready?
+            @raw[:fission].stop(:hard => true)
             return true
           else
             return false
           end
         end
 
-        def reboot
-          requires :raw
-          if state=="running"
-            @raw.stop
-            wait_for { state!="running"}
-            @raw.start
-            return true
-          else
-            return false
-          end
-        end
-
+        # Halt and poweroff are just synonyms for stop.
         def halt
-          requires :raw
-          if state=="running"
-            @raw.halt
-            return true
-          else
-            return false
-          end
-
-        end
-
-        def poweroff
-          requires :raw
-          halt
-        end
-
-        def shutdown
-          requires :raw
           stop
         end
 
-        def resume
+        def poweroff
+          stop
+        end
+
+        # This is a graceful shutdown but Fusion is only capable of a graceful
+        # shutdown if tools are installed.  Fusion does the right thing though
+        # and if graceful can't be initiated it just does a hard stop.
+        def shutdown
           requires :raw
-          @raw.resume
+          if ready?
+            @raw[:fission].stop
+            return true
+          else
+            return false
+          end
+        end
+
+        # Attempt a graceful shutdown, wait for the VM to completely shutdown
+        # and then start it again.
+        def reboot
+          if ready?
+            shutdown
+            wait_for { ! ready? }
+            start
+            return true
+          else
+            return false
+          end
+        end
+
+        # Resuming from suspend is the same thing as start to Fusion.
+        def resume
+          start
         end
 
         def suspend
           requires :raw
-          @raw.suspend
+          if ready?
+            @raw[:fission].suspend
+            return true
+          else
+            return false
+          end
         end
 
-        def state
+        # Fusion VM Metadata.
+
+        # The power state of the VM is commonly going to be three values;
+        # running, not running, or suspended.
+        def power_state
           requires :raw
-          @raw.state
+          @raw[:fission].state.data
         end
 
         def ready?
-          state == "running"
+          requires :raw
+          @raw[:fission].running?.data
+        end
+
+        # Path to the VM's vmx file on the local disk.
+        def path
+          requires :raw
+          @raw[:fission].path
+        end
+
+        # We obtain the first ipaddress.  This should generally be a safe
+        # assumption for Fusion.  Even if an address is provided via NAT,
+        # bridge, or host only it will by accessible from the host machine the
+        # VM resides on.
+        def ipaddress
+          requires :raw
+          ip(@raw[:fission])
+        end
+
+        # Keeping these three methods around for API compatibility reasons.
+        # Makes the vmfusion provider function similar to cloud providers and
+        # the vsphere provider.  Future goal is to add an actual private and
+        # public concept.  Needs changes to fission and a determination what is
+        # a public or private address here; bridge, nat, host-only.
+        def public_ip_address
+          ipaddress
         end
 
         def private_ip_address
-          ip_address(:private)
+          ipaddress
         end
 
-        def public_ip_address
-          ip_address(:public)
+        def state
+          power_state
         end
 
+        # Collecting all mac_addresses the VM has...mostly just because we are
+        # doing the same thing for the vSphere provider.
+        def mac_addresses
+          requires :raw
+          macs(@raw[:fission])
+        end
+
+        # Sets up a conveinent way to SSH into a Fusion VM using credentials
+        # stored in your .fog file.
 
         def username
           @username ||= 'root'
         end
 
+        # Simply spawn an SSH session.
         def ssh(commands)
-          requires :public_ip_address, :username
+          requires :ipaddress, :username
 
           #requires :password, :private_key
           ssh_options={}
           ssh_options[:password] = password unless password.nil?
           ssh_options[:key_data] = [private_key] if private_key
 
-          Fog::SSH.new(public_ip_address, @username, ssh_options).run(commands)
+          Fog::SSH.new(ipaddress, @username, ssh_options).run(commands)
 
         end
 
+        # SCP something to our VM.
         def scp(local_path, remote_path, upload_options = {})
-          requires :public_ip_address, :username
+          requires :ipaddress, :username
 
           scp_options = {}
           scp_options[:password] = password unless self.password.nil?
           scp_options[:key_data] = [private_key] if self.private_key
 
-          Fog::SCP.new(public_ip_address, username, scp_options).upload(local_path, remote_path, upload_options)
+          Fog::SCP.new(ipaddress, username, scp_options).upload(local_path, remote_path, upload_options)
         end
 
-        # Sets up a new key
+        # Sets up a new SSH key on the VM so one doesn't need to use a password
+        # ever again.
         def setup(credentials = {})
-          requires :public_key, :public_ip_address, :username
+          requires :public_key, :ipaddress, :username
 
           credentials[:password] = password unless self.password.nil?
           credentails[:key_data] = [private_key] if self.private_key
@@ -167,7 +226,7 @@ module Fog
           Timeout::timeout(360) do
             begin
               Timeout::timeout(8) do
-                Fog::SSH.new(public_ip_address, username, credentials.merge(:timeout => 4)).run('pwd')
+                Fog::SSH.new(ipaddress, username, credentials.merge(:timeout => 4)).run('pwd')
               end
             rescue Errno::ECONNREFUSED
               sleep(2)
@@ -176,9 +235,11 @@ module Fog
               retry
             end
           end
-          Fog::SSH.new(public_ip_address, username, credentials).run(commands)
+          Fog::SSH.new(ipaddress, username, credentials).run(commands)
         end
 
+        # Just setting local versions of some variables that were going to use
+        # for SSH operations.
         def private_key_path
           @private_key_path ||= Fog.credentials[:private_key_path]
           @private_key_path &&= File.expand_path(@private_key_path)
@@ -198,8 +259,13 @@ module Fog
         end
 
         private
-        def ip_address(key)
-          @raw.ip_address
+        def ip(fission)
+          first_int = fission.network_info.data.keys.first
+          fission.network_info.data[first_int]['ip_address']
+        end
+
+        def macs(fission)
+          fission.mac_addresses.data
         end
 
         def raw
@@ -210,13 +276,15 @@ module Fog
           @raw = new_raw
 
           raw_attributes = {
-            :name => new_raw.name,
-            :state => new_raw.state
+            :name            => new_raw[:fission].name,
+            :power_state     => new_raw[:state],
+            :ipaddress       => ip(new_raw[:fission]),
+            :mac_addresses   => macs(new_raw[:fission]),
+            :path            => new_raw[:fission].path
           }
 
           merge_attributes(raw_attributes)
         end
-
       end
     end
   end

--- a/lib/fog/vmfusion/models/compute/servers.rb
+++ b/lib/fog/vmfusion/models/compute/servers.rb
@@ -9,18 +9,22 @@ module Fog
 
         model Fog::Compute::Vmfusion::Server
 
-        def all(filter=nil)
+        def all(filter = nil)
 
-          data=[]
+          data = []
 
-          filter={} if filter.nil?
+          states = ::Fission::VM.all_with_status.data
+
+          filter = {} if filter.nil?
           unless filter.has_key?(:name)
-            vms=::Fission::VM.all
+            vms=::Fission::VM.all.data
             vms.each do |vm|
-              data << { :raw => vm}
+              data << { :raw =>  { :fission => vm,
+                                   :state   => states[vm.name] } }
             end
           else
-            data << { :raw => ::Fission::VM.new(filter[:name])}
+            data << { :raw => { :fission => ::Fission::VM.new(filter[:name]),
+                                :state   => states[filter[:name]] } }
           end
 
           load(data)
@@ -28,7 +32,7 @@ module Fog
         end
 
         def get(name)
-          self.all(:name =>name).first
+          self.all(:name => name).first
         end
 
       end


### PR DESCRIPTION
 This patch has several purposes.  Firstly this patch brings the Fog vmfusion provider in line with the recently released v0.4.0 version of the Fission project by aligning various method names.  During this sync up servers.rb was modified to obtain all VM states and passing them to the raw object instead of doing so when attributes are obtained inside server.rb.  This improves performance a lot since it reduces the need to run vmrun for every VM on the system.  Other changes being made to the provider are so that it returns data and acts more similar to the vsphere provider while still keeping backward compatibility with the original implementation; which was to be more similar to various cloud providers.
