### PR TITLE
enable_metrics_collection requires a granularity argument

### DIFF
--- a/lib/fog/aws/models/auto_scaling/group.rb
+++ b/lib/fog/aws/models/auto_scaling/group.rb
@@ -65,9 +65,9 @@ module Fog
           reload
         end
 
-        def enable_metrics_collection(metrics = {})
+        def enable_metrics_collection(granularity = '1Minute', metrics = {})
           requires :id
-          connection.enable_metrics_collection(id, 'Metrics' => metrics)
+          connection.enable_metrics_collection(id, granularity, 'Metrics' => metrics)
           reload
         end
 


### PR DESCRIPTION
The request requires a granularity argument, but the corresponding model method doesn't supply one. Defaulting it to  '1Minute' because that is currently the only legal value
