### PR TITLE
Security groups parser fix

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_security_groups.rb
+++ b/lib/fog/aws/parsers/compute/describe_security_groups.rb
@@ -40,9 +40,9 @@ module Fog
               end
             when 'groups'
               @in_groups = false
-            when 'groupDescription', 'ownerId', 'groupId', 'vpcId'
+            when 'groupDescription', 'ownerId', 'vpcId'
               @security_group[name] = value
-            when 'groupName'
+            when 'groupId','groupName'
               if @in_groups
                 @group[name] = value
               else


### PR DESCRIPTION
the security groups parser was not handling groupid correctly.  It seems it never has :/
