### PR TITLE
added support for server-side encryption on s3

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -21,6 +21,7 @@ module Fog
         attribute :metadata
         attribute :owner,               :aliases => 'Owner'
         attribute :storage_class,       :aliases => ['x-amz-storage-class', 'StorageClass']
+        attribute :encryption,          :aliases => 'x-amz-server-side-encryption'
 
         def acl=(new_acl)
           valid_acls = ['private', 'public-read', 'public-read-write', 'authenticated-read']
@@ -115,6 +116,7 @@ module Fog
           options['Expires'] = expires if expires
           options.merge!(metadata)
           options['x-amz-storage-class'] = storage_class if storage_class
+          options['x-amz-server-side-encryption'] = encryption if encryption
 
           data = connection.put_object(directory.key, key, body, options)
           data.headers['ETag'].gsub!('"','')


### PR DESCRIPTION
Adds an "encryption" attribute to Fog::Storage::AWS::File to enable S3's server-side encryption.
