### PR TITLE
Rackspace create_image request - pass all options

### DIFF
--- a/lib/fog/rackspace/requests/compute/create_image.rb
+++ b/lib/fog/rackspace/requests/compute/create_image.rb
@@ -21,9 +21,7 @@ module Fog
               'serverId' => server_id
             }
           }
-          if options['name']
-            data['image']['name'] = options['name']
-          end
+          data['image'].merge!(options)
           request(
             :body     => MultiJson.encode(data),
             :expects  => 202,


### PR DESCRIPTION
Pass in all options provided on a Rackspace create_image request.  We needed to pass in undocumented flags.

Sorry, this is based on v1.1.2 release tag.
