### PR TITLE
add vm reconfiguration functions for memory cpu / generic spec for vsphere

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -23,6 +23,9 @@ module Fog
       request :vm_create
       request :vm_destroy
       request :datacenters
+      request :vm_reconfig_hardware
+      request :vm_reconfig_memory
+      request :vm_reconfig_cpus
 
       module Shared
 

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -35,6 +35,18 @@ module Fog
         attribute :mo_ref
         attribute :path
 
+        def vm_reconfig_memory(options = {})
+          requires :instance_uuid, :memory
+          connection.vm_reconfig_memory('instance_uuid' => instance_uuid, 'memory' => memory)
+        end
+        def vm_reconfig_cpus(options = {})
+          requires :instance_uuid, :cpus
+          connection.vm_reconfig_cpus('instance_uuid' => instance_uuid, 'cpus' => cpus)
+        end
+        def vm_reconfig_hardware(options = {})
+          requires :instance_uuid, :hardware_spec
+          connection.vm_reconfig_hardware('instance_uuid' => instance_uuid, 'hardware_spec' => hardware_spec)
+        end
         def start(options = {})
           requires :instance_uuid
           connection.vm_power_on('instance_uuid' => instance_uuid)

--- a/lib/fog/vsphere/requests/compute/vm_reconfig_cpus.rb
+++ b/lib/fog/vsphere/requests/compute/vm_reconfig_cpus.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def vm_reconfig_cpus(options = {})
+          raise ArgumentError, "cpus is a required parameter" unless options.has_key? 'cpus'
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.has_key? 'instance_uuid'
+          hardware_spec={'numCPUs' => options['cpus']}
+          vm_reconfig_hardware('instance_uuid' => options['instance_uuid'], 'hardware_spec' => hardware_spec )
+        end
+      end
+
+      class Mock
+        def vm_reconfig_cpus(options = {})
+          raise ArgumentError, "cpus is a required parameter" unless options.has_key? 'cpus'
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.has_key? 'instance_uuid'
+          hardware_spec={'numCPUs' => options['cpus']}
+          vm_reconfig_hardware('instance_uuid' => options['instance_uuid'], 'hardware_spec' => hardware_spec )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/vm_reconfig_hardware.rb
+++ b/lib/fog/vsphere/requests/compute/vm_reconfig_hardware.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def vm_reconfig_hardware(options = {})
+          raise ArgumentError, "hardware_spec is a required parameter" unless options.has_key? 'hardware_spec'
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.has_key? 'instance_uuid'
+          search_filter = { :uuid => options['instance_uuid'], 'vmSearch' => true, 'instanceUuid' => true }
+          vm_mob_ref = @connection.searchIndex.FindAllByUuid(search_filter).first
+          task = vm_mob_ref.ReconfigVM_Task(:spec => RbVmomi::VIM.VirtualMachineConfigSpec(options['hardware_spec']))
+          task.wait_for_completion
+           { 'task_state' => task.info.state }
+        end
+      end
+
+      class Mock
+        def vm_reconfig_hardware(options = {})
+          raise ArgumentError, "hardware_spec is a required parameter" unless options.has_key? 'hardware_spec'
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.has_key? 'instance_uuid'
+          { 'task_state' => 'success' }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/vm_reconfig_memory.rb
+++ b/lib/fog/vsphere/requests/compute/vm_reconfig_memory.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def vm_reconfig_memory(options = {})
+          raise ArgumentError, "memory is a required parameter" unless options.has_key? 'memory'
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.has_key? 'instance_uuid'
+          hardware_spec={'memoryMB' => options['memory']}
+          vm_reconfig_hardware('instance_uuid' => options['instance_uuid'], 'hardware_spec' => hardware_spec )
+        end
+      end
+
+      class Mock
+        def vm_reconfig_memory(options = {})
+          raise ArgumentError, "memory is a required parameter" unless options.has_key? 'memory'
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.has_key? 'instance_uuid'
+          hardware_spec={'memoryMB' => options['memory']}
+          vm_reconfig_hardware('instance_uuid' => options['instance_uuid'], 'hardware_spec' => hardware_spec )
+        end
+      end
+    end
+  end
+end

--- a/tests/vsphere/requests/compute/vm_reconfig_cpus_tests.rb
+++ b/tests/vsphere/requests/compute/vm_reconfig_cpus_tests.rb
@@ -1,0 +1,19 @@
+Shindo.tests('Fog::Compute[:vsphere] | vm_reconfig_cpus request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+  reconfig_target = '50137835-88a1-436e-768e-9b2677076e67'
+  reconfig_spec = 2
+
+  tests('The response should') do
+    response = compute.vm_reconfig_cpus('instance_uuid' => reconfig_target, 'cpus' => reconfig_spec)
+    test('be a kind of Hash') { response.kind_of? Hash }
+    test('should have a task_state key') { response.has_key? 'task_state' }
+  end
+
+  tests('The expected options') do
+    raises(ArgumentError, 'raises ArgumentError when instance_uuid option is missing') { compute.vm_reconfig_cpus('cpus' => reconfig_spec) }
+    raises(ArgumentError, 'raises ArgumentError when cpus option is missing') { compute.vm_reconfig_cpus('instance_uuid' => reconfig_target) }
+  end
+
+end

--- a/tests/vsphere/requests/compute/vm_reconfig_hardware_tests.rb
+++ b/tests/vsphere/requests/compute/vm_reconfig_hardware_tests.rb
@@ -1,0 +1,19 @@
+Shindo.tests('Fog::Compute[:vsphere] | vm_reconfig_hardware request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+  reconfig_target = '50137835-88a1-436e-768e-9b2677076e67'
+  reconfig_spec = {'guestId' => 'rhel5_64Guest'}
+
+  tests('The response should') do
+    response = compute.vm_reconfig_hardware('instance_uuid' => reconfig_target, 'hardware_spec' => reconfig_spec)
+    test('be a kind of Hash') { response.kind_of? Hash }
+    test('should have a task_state key') { response.has_key? 'task_state' }
+  end
+
+  tests('The expected options') do
+    raises(ArgumentError, 'raises ArgumentError when instance_uuid option is missing') { compute.vm_reconfig_hardware('hardware_spec' => reconfig_spec) }
+    raises(ArgumentError, 'raises ArgumentError when hardware_spec option is missing') { compute.vm_reconfig_hardware('instance_uuid' => reconfig_target) }
+  end
+
+end

--- a/tests/vsphere/requests/compute/vm_reconfig_memory_tests.rb
+++ b/tests/vsphere/requests/compute/vm_reconfig_memory_tests.rb
@@ -1,0 +1,19 @@
+Shindo.tests('Fog::Compute[:vsphere] | vm_reconfig_memory request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+  reconfig_target = '50137835-88a1-436e-768e-9b2677076e67'
+  reconfig_spec = 4096
+
+  tests('The response should') do
+    response = compute.vm_reconfig_memory('instance_uuid' => reconfig_target, 'memory' => reconfig_spec)
+    test('be a kind of Hash') { response.kind_of? Hash }
+    test('should have a task_state key') { response.has_key? 'task_state' }
+  end
+
+  tests('The expected options') do
+    raises(ArgumentError, 'raises ArgumentError when instance_uuid option is missing') { compute.vm_reconfig_memory('memory' => reconfig_spec) }
+    raises(ArgumentError, 'raises ArgumentError when memory option is missing') { compute.vm_reconfig_memory('instance_uuid' => reconfig_target) }
+  end
+
+end


### PR DESCRIPTION
This patch adds the ability to perform a reconfigVmTask on a VM given its UUID.  The patch includes two specific functions for modifying memory and cpu, and a generic hardware modification spec. 
