### PR TITLE
add subnet and vpc info to instance gets

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -41,6 +41,7 @@ module Fog
         attribute :tenancy
         attribute :tags,                  :aliases => 'tagSet'
         attribute :user_data
+        attribute :vpc_id,                :aliases => 'vpcId'
 
         attr_accessor :password
         attr_writer   :private_key, :private_key_path, :public_key, :public_key_path, :username

--- a/lib/fog/aws/parsers/compute/describe_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_instances.rb
@@ -31,7 +31,7 @@ module Fog
             when 'architecture', 'clientToken', 'dnsName', 'imageId',
                   'instanceId', 'instanceType', 'ipAddress', 'kernelId',
                   'keyName', 'platform', 'privateDnsName', 'privateIpAddress', 'ramdiskId',
-                  'reason', 'rootDeviceType'
+                  'reason', 'rootDeviceType',  'subnetId', 'vpcId'
               @instance[name] = value
             when 'attachTime'
               @block_device_mapping[name] = Time.parse(value)


### PR DESCRIPTION
add in subnet_id and vpc_id info when running an Fog::Compute[:aws].servers.get(i-name)  
