### PR TITLE
Add 2.8 support

### DIFF
--- a/lib/fog/ecloud/compute.rb
+++ b/lib/fog/ecloud/compute.rb
@@ -1184,7 +1184,7 @@ module Fog
         end
 
         def supporting_versions
-          ["v0.8b-ext2.6", "0.8b-ext2.6"]
+          ["v0.8b-ext2.6", "0.8b-ext2.6", "v0.8b-ext2.8" , "0.8b-ext2.8"]
         end
 
         private


### PR DESCRIPTION
The difference between 2.6 and 2.8 are a few additional api calls but the
existing calls are still backwards compatible, and we need the version bump
to be able to continue to use.
