### PR TITLE
[aws|compute] Update API version and support new DescribeInstanceStatus format.

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -299,7 +299,7 @@ module Fog
               :host               => @host,
               :path               => @path,
               :port               => @port,
-              :version            => '2011-11-01'
+              :version            => '2011-12-15'
             }
           )
 

--- a/lib/fog/aws/parsers/compute/describe_instance_status.rb
+++ b/lib/fog/aws/parsers/compute/describe_instance_status.rb
@@ -5,56 +5,89 @@ module Fog
         class DescribeInstanceStatus < Fog::Parsers::Base
 
           def new_instance
-            @instance = { 'eventsSet' => [], 'instanceState' => {} }
+            @instance = { 'instanceState' => {}, 'systemStatus' => { 'details' => [] }, 'instanceStatus' => { 'details' => [] }, 'event' => {} }
           end
 
-          def new_event
-            @event = {}
+          def new_item
+            @item = {}
           end
 
           def reset
             @instance_status = {}
             @response = { 'instanceStatusSet' => [] }
-            @in_events_set = false
-            new_event
+            @in_system_status = false
+            @in_details = false
+            @in_event = false
             new_instance
+            new_item
           end
 
           def start_element(name, attrs=[])
             super
             case name
-            when 'eventsSet'
-              @in_events_set = true
+            when 'systemStatus'
+              @in_system_status = true
+            when 'instanceStatus'
+              @in_instance_status = true
+            when 'details'
+              @in_details = true
+            when 'event'
+              @in_event = true
             end
           end
 
-
           def end_element(name)
-            if @in_events_set
-              case name
-              when 'code', 'description'
-                @event[name] = value
-              when 'notAfter', 'notBefore'
-                @event[name] = Time.parse(value)
-              when 'item'
-                @instance['eventsSet'] << @event
-                new_event
-              when 'eventsSet'
-                @in_events_set = false
-              end
-            else
-              case name
-              when 'instanceId', 'availabilityZone'
-                @instance[name] = value
-              when 'name', 'code'
+            case name
+            when 'name'
+              if @in_details
+                @item[name] = value
+              else
                 @instance['instanceState'][name] = value
-              when 'item'
+              end
+            when 'status'
+              if @in_details
+                @item[name] = value
+              elsif @in_system_status
+                @instance['systemStatus'][name] = value
+              elsif @in_instance_status
+                @instance['instanceStatus'][name] = value
+              end
+            when 'details'
+              @in_details = false
+            when 'item'
+              if @in_system_status
+                @instance['systemStatus']['details'] << @item
+              elsif @in_instance_status
+                @instance['instanceStatus']['details'] << @item
+              else
                 @response['instanceStatusSet'] << @instance
                 new_instance
-              when 'requestId'
-                @response[name] = value
-
               end
+              new_item
+            when 'instanceStatus'
+              @in_instance_status = false
+            when 'systemStatus'
+              @in_system_status = false
+            when 'code'
+              if @in_event
+                @instance['event'][name] = value.strip
+              else
+                @instance['instanceState'][name] = value
+              end
+            when 'description'
+              if @in_event
+                @instance['event'][name] = value.strip
+              end
+            when 'notAfter', 'notBefore'
+              if @in_event
+                @instance['event'][name] = Time.parse(value)
+              end
+            when 'event'
+              @in_event = false
+            when 'instanceId', 'availabilityZone'
+              @instance[name] = value
+            when 'requestId'
+              @response[name] = value
             end
           end
         end

--- a/tests/aws/requests/compute/instance_tests.rb
+++ b/tests/aws/requests/compute/instance_tests.rb
@@ -131,12 +131,26 @@ Shindo.tests('Fog::Compute[:aws] | instance requests', ['aws']) do
                                 'code' => Integer,
                                 'name' => String
                               },
-                              'eventsSet' => [{
+                              'systemStatus' => {
+                                'status' => String,
+                                'details' => [{
+                                  'name' => String,
+                                  'status' => String
+                                }]
+                              },
+                              'instanceStatus' => {
+                                'status' => String,
+                                'details' => [{
+                                  'name' => String,
+                                  'status' => String
+                                }]
+                              },
+                              'event' => {
                                                 'code' => String,
                                                 'description' => String,
                                                 'notBefore' => Time,
                                                 'notAfter' => Time
-                                              }]
+                                              }
                             }]
 
   }


### PR DESCRIPTION
Opening a PR for this because I'm not sure what the protocol is for the DescribeInstanceStatus body changing. I'm probably missing something obvious from the past but I couldn't immediately find a case where an AWS parser changed due to a breaking change in response.

In this case, `systemStatus` and `instanceStatus` items were added and `eventsSet` changed to just a single `event`, according to the sample [here](http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstanceStatus.html). I also used the sample to verify the parser.

The current format was made public in fog 1.1.2 with the initial implementation of the DescribeInstanceStatus request and parser.

Halp?
