### PR TITLE
Added idempotent => true to create_tags

### DIFF
--- a/lib/fog/aws/requests/compute/create_tags.rb
+++ b/lib/fog/aws/requests/compute/create_tags.rb
@@ -30,9 +30,9 @@ module Fog
           params.merge!(Fog::AWS.indexed_param('Tag.%d.Key', tags.keys))
           params.merge!(Fog::AWS.indexed_param('Tag.%d.Value', tags.values))
           request({
-            'Action'            => 'CreateTags',
-            :idempotent   => true,
-            :parser             => Fog::Parsers::Compute::AWS::Basic.new
+            'Action'    => 'CreateTags',
+            :idempotent => true,
+            :parser     => Fog::Parsers::Compute::AWS::Basic.new
           }.merge!(params))
         end
 


### PR DESCRIPTION
This appears to fix an issue when launching many instance from cluster_chef, which tags servers on the way up.
