### PR TITLE
Added check if Fog.mock! should be used in AWS tests

### DIFF
--- a/tests/aws/models/storage/directory_tests.rb
+++ b/tests/aws/models/storage/directory_tests.rb
@@ -1,4 +1,4 @@
-Fog.mock!
+Fog.mock! if ENV['FOG_MOCK']
 
 Shindo.tests("Storage[:aws] | directory", [:aws]) do
 

--- a/tests/aws/models/storage/file_tests.rb
+++ b/tests/aws/models/storage/file_tests.rb
@@ -1,4 +1,4 @@
-Fog.mock!
+Fog.mock! if ENV['FOG_MOCK']
 
 Shindo.tests("Storage[:aws] | file", [:aws]) do
 

--- a/tests/aws/models/storage/files_tests.rb
+++ b/tests/aws/models/storage/files_tests.rb
@@ -1,4 +1,4 @@
-Fog.mock!
+Fog.mock! if ENV['FOG_MOCK']
 
 Shindo.tests("Storage[:aws] | files", [:aws]) do
 

--- a/tests/aws/models/storage/version_tests.rb
+++ b/tests/aws/models/storage/version_tests.rb
@@ -1,4 +1,4 @@
-Fog.mock!
+Fog.mock! if ENV['FOG_MOCK']
 
 Shindo.tests("Storage[:aws] | version", [:aws]) do
 

--- a/tests/aws/models/storage/versions_tests.rb
+++ b/tests/aws/models/storage/versions_tests.rb
@@ -1,4 +1,4 @@
-Fog.mock!
+Fog.mock! if ENV['FOG_MOCK']
 
 Shindo.tests("Storage[:aws] | versions", [:aws]) do
 


### PR DESCRIPTION
Without the check all tests were assumed mocked regardless of the user's environment setting.

I don't have the accounts to confirm the specs are now running with mocking disabled so would appreciate a second opinion.
