### PR TITLE
[aws|storage|test] Make sure tests pass with both mocking enabled and disabled.

### DIFF
--- a/lib/fog/aws/requests/storage/copy_object.rb
+++ b/lib/fog/aws/requests/storage/copy_object.rb
@@ -48,7 +48,7 @@ module Fog
         def copy_object(source_bucket_name, source_object_name, target_bucket_name, target_object_name, options = {})
           response = Excon::Response.new
           source_bucket = self.data[:buckets][source_bucket_name]
-          source_object = source_bucket && source_bucket[:objects][source_object_name]
+          source_object = source_bucket && source_bucket[:objects][source_object_name] && source_bucket[:objects][source_object_name].first
           target_bucket = self.data[:buckets][target_bucket_name]
 
           acl = options['x-amz-acl'] || 'private'

--- a/lib/fog/aws/requests/storage/delete_object.rb
+++ b/lib/fog/aws/requests/storage/delete_object.rb
@@ -61,6 +61,7 @@ module Fog
                 else
                   response.status = 400
                   response.body = invalid_version_id_payload(version_id)
+                  raise(Excon::Errors.status_error({:expects => 200}, response))
                 end
               else
                 delete_marker = {
@@ -72,11 +73,11 @@ module Fog
 
                 # When versioning is suspended, a delete marker is placed if the last object ID is not the value 'null',
                 # otherwise the last object is replaced.
-                if bucket[:versioning] == 'Suspended' && bucket[:objects][object_name].last['VersionId'] == 'null'
-                  bucket[:objects][object_name].pop
+                if bucket[:versioning] == 'Suspended' && bucket[:objects][object_name].first['VersionId'] == 'null'
+                  bucket[:objects][object_name].shift
                 end
 
-                bucket[:objects][object_name] << delete_marker
+                bucket[:objects][object_name].unshift(delete_marker)
 
                 response.headers['x-amz-delete-marker'] = 'true'
                 response.headers['x-amz-version-id'] = delete_marker['VersionId']
@@ -85,6 +86,7 @@ module Fog
               if version_id && version_id != 'null'
                 response.status = 400
                 response.body = invalid_version_id_payload(version_id)
+                raise(Excon::Errors.status_error({:expects => 200}, response))
               else
                 bucket[:objects].delete(object_name)
 

--- a/lib/fog/aws/requests/storage/get_bucket_versioning.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_versioning.rb
@@ -60,6 +60,8 @@ module Fog
                 'HostId' => Fog::Mock.random_base64(65)
               }
             }
+
+            raise(Excon::Errors.status_error({:expects => 200}, response))
           end
 
           response

--- a/lib/fog/aws/requests/storage/get_object.rb
+++ b/lib/fog/aws/requests/storage/get_object.rb
@@ -76,7 +76,7 @@ module Fog
           if (bucket = self.data[:buckets][bucket_name])
             object = nil
             if bucket[:objects].has_key?(object_name)
-              object = version_id ? bucket[:objects][object_name].find { |object| object['VersionId'] == version_id} : bucket[:objects][object_name].last
+              object = version_id ? bucket[:objects][object_name].find { |object| object['VersionId'] == version_id} : bucket[:objects][object_name].first
             end
 
             if (object && !object[:delete_marker])
@@ -123,6 +123,8 @@ module Fog
                   'HostId' => Fog::Mock.random_base64(65)
                 }
               }
+
+              raise(Excon::Errors.status_error({:expects => 200}, response))
             else
               response.status = 404
               response.body = "...<Code>NoSuchKey<\/Code>..."

--- a/lib/fog/aws/requests/storage/put_bucket_versioning.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_versioning.rb
@@ -51,17 +51,22 @@ DATA
                   'HostId' => Fog::Mock.random_base64(65)
                 }
               }
+
+              raise(Excon::Errors.status_error({:expects => 200}, response))
             end
           else
-            response.status = 403
+            response.status = 404
             response.body = {
               'Error' => {
-                'Code' => 'AccessDenied',
-                'Message' => 'AccessDenied',
+                'Code' => 'NoSuchBucket',
+                'Message' => 'The specified bucket does not exist',
+                'BucketName' => bucket_name,
                 'RequestId' => Fog::Mock.random_hex(16),
                 'HostId' => Fog::Mock.random_base64(65)
               }
             }
+
+            raise(Excon::Errors.status_error({:expects => 200}, response))
           end
 
           response

--- a/lib/fog/aws/requests/storage/put_bucket_website.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_website.rb
@@ -52,7 +52,7 @@ DATA
           if self.data[:buckets][bucket_name]
             response.status = 200
           else
-            response.status = 403
+            response.status = 404
             raise(Excon::Errors.status_error({:expects => 200}, response))
           end
 

--- a/lib/fog/aws/requests/storage/put_object.rb
+++ b/lib/fog/aws/requests/storage/put_object.rb
@@ -86,11 +86,11 @@ module Fog
 
               # When versioning is suspended, putting an object will create a new 'null' version if the latest version
               # is a value other than 'null', otherwise it will replace the latest version.
-              if bucket[:versioning] == 'Suspended' && bucket[:objects][object_name].last['VersionId'] == 'null'
-                bucket[:objects][object_name].pop
+              if bucket[:versioning] == 'Suspended' && bucket[:objects][object_name].first['VersionId'] == 'null'
+                bucket[:objects][object_name].shift
               end
 
-              bucket[:objects][object_name] << object
+              bucket[:objects][object_name].unshift(object)
             else
               bucket[:objects][object_name] = [object]
             end

--- a/tests/aws/models/storage/version_tests.rb
+++ b/tests/aws/models/storage/version_tests.rb
@@ -31,10 +31,10 @@ Shindo.tests("Storage[:aws] | version", [:aws]) do
         @version_instance.delete_marker
       end
 
-      tests("#delete_marker should be true if the version isn't a DeleteMarker'").returns(true) do
+      tests("#delete_marker should be true if the version is a DeleteMarker'").returns(true) do
         @instance.destroy
 
-        @instance.versions.all.last.delete_marker
+        @instance.versions.all.first.delete_marker
       end
     end
 

--- a/tests/aws/models/storage/versions_tests.rb
+++ b/tests/aws/models/storage/versions_tests.rb
@@ -17,17 +17,24 @@ Shindo.tests("Storage[:aws] | versions", [:aws]) do
 
     versions = []
     versions << @instance.connection.put_object(@instance.key, 'one', 'abcde').headers['x-amz-version-id']
+
+    puts versions.first
+
     versions << @instance.connection.put_object(@instance.key, 'one', '32423').headers['x-amz-version-id']
     versions << @instance.connection.delete_object(@instance.key, 'one').headers['x-amz-version-id']
+    versions.reverse!
+
+    puts versions.first
+
     versions << @instance.connection.put_object(@instance.key, 'two', 'aoeu').headers['x-amz-version-id']
 
     tests('#versions') do
       tests('#versions.size includes versions (including DeleteMarkers) for all keys').returns(4) do
-        @instance.versions.size
+        @instance.versions.all.size
       end
 
       tests('#versions returns the correct versions').returns(versions) do
-        @instance.versions.collect(&:version)
+        @instance.versions.all.collect(&:version)
       end
     end
 
@@ -37,11 +44,11 @@ Shindo.tests("Storage[:aws] | versions", [:aws]) do
       end
 
       tests("#all for file returns only versions for that file").returns(1) do
-        @instance.files.get('two').versions.collect(&:version).size
+        @instance.files.get('two').versions.all.collect(&:version).size
       end
 
       tests("#all for file returns only versions for that file").returns(versions.last) do
-        @instance.files.get('two').versions.collect(&:version).first
+        @instance.files.get('two').versions.all.collect(&:version).first
       end
     end
 


### PR DESCRIPTION
So, I think I may have only run the request tests with mocking disabled and the model tests with mocking enabled.  I'm not 100% sure, but it seems the likely scenario.

Summary of changes:
- Fixed ordering of versions in mocks.  The S3 docs make no explicit guarantee on order, so I didn't worry about it, but the differences between mock & real were fixed by reversing the sort order.  This may break in the future if results truly are sorted in a nondeterministic order, in which case we'd have to compare Sets instead of Arrays.
- There were some issues delineating between AccessDenied & NotFound, depending on the bucket name used.  If anyone ever creates the bucket "fognonbucket" and doesn't tear it down, we're going to have a lot of failures.
- There may be sporadic failures doing the request tests un-mocked.  It seems with versioning in particular it can take S3 several seconds to update the bucket configuration.  I'm open to suggestions on how to fix this.  Sleeping for 15s seems to be the safest way, but that's quite annoying and still not even guaranteed to pass.
