### PR TITLE
include fission gem?

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency('net-ssh', '>=2.1.3')
   s.add_dependency('nokogiri', '~>1.5.0')
   s.add_dependency('ruby-hmac')
+  s.add_dependency('fission')
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development


### PR DESCRIPTION
"bundle exec rake" was crapping out for us because vmfusion/compute.rb was requiring it.  The obvious fix was adding fission to the gemspec, but the require inside a method suggests that there are more subtle forces at work.  

Is this the right way to fix the problem?
