### PR TITLE
make eips useable in a VPC

### DIFF
--- a/lib/fog/aws/models/compute/address.rb
+++ b/lib/fog/aws/models/compute/address.rb
@@ -9,6 +9,7 @@ module Fog
         identity  :public_ip, :aliases => 'publicIp'
 
         attribute :server_id, :aliases => 'instanceId'
+        attribute :domain
 
         def initialize(attributes = {})
           # assign server first to prevent race condition with new_record?
@@ -33,7 +34,7 @@ module Fog
 
         def save
           raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
-          data = connection.allocate_address.body
+          data = connection.allocate_address(domain).body
           new_attributes = data.reject {|key,value| key == 'requestId'}
           merge_attributes(new_attributes)
           if @server

--- a/lib/fog/aws/parsers/compute/allocate_address.rb
+++ b/lib/fog/aws/parsers/compute/allocate_address.rb
@@ -7,7 +7,7 @@ module Fog
 
           def end_element(name)
             case name
-            when 'publicIp', 'requestId'
+            when 'publicIp', 'requestId', 'domain', 'allocationId'
               @response[name] = value
             end
           end

--- a/lib/fog/aws/parsers/compute/describe_addresses.rb
+++ b/lib/fog/aws/parsers/compute/describe_addresses.rb
@@ -12,7 +12,7 @@ module Fog
 
           def end_element(name)
             case name
-            when 'instanceId', 'publicIp'
+            when 'instanceId', 'publicIp', 'domain', 'allocationId'
               @address[name] = value
             when 'item'
               @response['addressesSet'] << @address

--- a/lib/fog/aws/requests/compute/allocate_address.rb
+++ b/lib/fog/aws/requests/compute/allocate_address.rb
@@ -7,6 +7,8 @@ module Fog
 
         # Acquire an elastic IP address.
         #
+        # ==== Parameters
+        # * domain<~String> - Type of EIP, either standard or vpc
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
@@ -14,9 +16,11 @@ module Fog
         #     * 'requestId'<~String> - Id of the request
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-AllocateAddress.html]
-        def allocate_address
+        def allocate_address(domain='standard')
+          domain = domain == 'vpc' ? 'vpc' : 'standard'
           request(
             'Action'  => 'AllocateAddress',
+            'Domain'  => domain,
             :parser   => Fog::Parsers::Compute::AWS::AllocateAddress.new
           )
         end
@@ -25,7 +29,7 @@ module Fog
 
       class Mock
 
-        def allocate_address
+        def allocate_address(domain = 'standard')
           response = Excon::Response.new
           if describe_addresses.body['addressesSet'].size < self.data[:limits][:addresses]
             response.status = 200
@@ -36,6 +40,7 @@ module Fog
             }
             self.data[:addresses][public_ip] = data
             response.body = {
+              'domain'    => standard,
               'publicIp'  => public_ip,
               'requestId' => Fog::AWS::Mock.request_id
             }

--- a/tests/aws/requests/compute/address_tests.rb
+++ b/tests/aws/requests/compute/address_tests.rb
@@ -2,8 +2,10 @@ Shindo.tests('Fog::Compute[:aws] | address requests', ['aws']) do
 
   @addresses_format = {
     'addressesSet' => [{
-      'instanceId'  => NilClass,
-      'publicIp'    => String
+      'allocationId' => Fog::Nullable::String,
+      'domain'       => String,
+      'instanceId'   => Fog::Nullable::String,
+      'publicIp'     => String
     }],
     'requestId' => String
   }
@@ -16,7 +18,7 @@ Shindo.tests('Fog::Compute[:aws] | address requests', ['aws']) do
 
     @public_ip = nil
 
-    tests('#allocate_address').formats({'publicIp' => String, 'requestId' => String}) do
+    tests('#allocate_address').formats({'domain' => String, 'publicIp' => String, 'requestId' => String}) do
       data = Fog::Compute[:aws].allocate_address.body
       @public_ip = data['publicIp']
       data


### PR DESCRIPTION
This patch allows the creation of Elastic IPs in a VPC. 
