### PR TITLE
Remove coverage Rake task.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -121,14 +121,6 @@ task :nuke do
   end
 end
 
-desc "Generate RCov test coverage and open in your browser"
-task :coverage do
-  require 'rcov'
-  sh "rm -fr coverage"
-  sh "rcov test/test_*.rb"
-  sh "open coverage/index.html"
-end
-
 require 'rdoc/task'
 RDoc::Task.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'


### PR DESCRIPTION
RCov isn't in the gemspec anymore, and doesn't work when added.

We could add support for RCov/SimpleCov, but it looks like this hasn't been used in awhile.
