### PR TITLE
[local|storage] Fix Local::File deletion for Ruby 1.8.

### DIFF
--- a/lib/fog/local/models/storage/file.rb
+++ b/lib/fog/local/models/storage/file.rb
@@ -50,7 +50,7 @@ module Fog
               break
             end
             pwd = Dir.pwd
-            if ::Dir.exists?(dir_path)
+            if ::File.exists?(dir_path) && ::File.directory?(dir_path)
               Dir.chdir(dir_path)
               if Dir.glob('*').empty?
                 Dir.rmdir(dir_path)


### PR DESCRIPTION
Ruby 1.8 doesn't have a Dir.exists? method, which causes an exception and
prevents empty parent directories from being deleted. These changes use
File.exists? and File.directory? in place of Dir.exists?. Fixes
fog/fog#707.

I'm not sure how to test for this. I tested locally by running the following in IRB.

``` ruby
`mkdir test1`
`mkdir test1/test2`
`mkdir test1/test2/test3`
`mkdir test1/test2/test3/test4`
`touch test1/test2/test3/test4/file1`
`touch test1/test2/file2`

File.exists?('test1/test2/test3/test4/file1') # => true

directory = Fog::Storage.new(:provider => 'Local', :local_root => '.').directories.get('.')
file = directory.files.get('test1/test2/test3/test4/file1')
file.destroy

File.exists?('test1/test2/test3/test4/file1') # => false
File.exists?('test1/test2/test3/test4') # => false
File.exists?('test1/test2/test3') # => false
File.exists?('test1/test2/file2') # => true
File.exists?('test1/test2') # => true
```

I'll see if I create some shindo test for Local::File to make sure that this doesn't break anything - but that still doesn't test for 1.8/1.9 compatibility.
