### PR TITLE
[storage|test] Run storage tests on a file in a subdirectory.

### DIFF
--- a/examples/storage_tests.rb
+++ b/examples/storage_tests.rb
@@ -98,6 +98,71 @@ Shindo.tests('storage examples', 'storage') do
 
       end
 
+      tests(':key => \"fog/storageobject\"') do
+
+        # create a directory
+        #   key should be a unique string
+        #   public should be a boolean
+        tests('@directory = @storage.directories.create').succeeds do
+          @directory = @storage.directories.create(
+            :key    => "fogstoragedirectory#{Time.now.to_i}",
+            :public => true
+          )
+        end
+
+        # list directories
+        tests('@directories = @storage.directories').succeeds do
+          @directories = @storage.directories
+        end
+
+        # get a directory
+        tests('@storage.directories.get(@directory.identity)').succeeds do
+          @storage.directories.get(@directory.identity)
+        end
+
+        # create a file in the directory
+        #   key can be any string
+        #   body can be a string or a file as File.open(path)
+        #   public should be a boolean and match the directory
+        tests('@file = @directory.files.create').succeeds do
+          @file = @directory.files.create(
+            :body   => 'fog_storage_object_body',
+            :key    => 'fog/storageobject',
+            :public => true
+          )
+        end
+
+        # list files
+        tests('@files = @directory.files').succeeds do
+          @files = @directory.files
+        end
+
+        # get a file
+        tests('@directory.files.get(@file.identity)').succeeds do
+          @directory.files.get(@file.identity)
+        end
+
+        # test the publicity of files
+        # Local is unable to inherently serve files, so we can skip it
+        unless provider == Local
+          tests('Excon.get(@file.public_url).body').returns('fog_storage_object_body') do
+            pending if Fog.mocking?
+            Excon.get(@file.public_url).body
+          end
+        end
+
+        # destroy the file
+        tests('@file.destroy').succeeds do
+          @file.destroy
+        end
+
+        # destroy the directory
+        tests('@directory.destroy').succeeds do
+          @directory.destroy
+        end
+
+      end
+
     end
 
   end


### PR DESCRIPTION
Running the storage tests prior to fog/fog#746 in Ruby 1.8 succeeded
because the current tests do not run empty parent tree deletion. After
the addition of this test, running the storage tests will fail if an
exception occurs while deleting the parent directories.

This essentially runs the same tests as above, but with `:public => true` as a constant and the file key set to `:key => "fog/storageobject"` instead of `:key => "fogstorageobject"`.

I have tested this against `Local`, `AWS`, and `Google`: all three succeeded. I don't have accounts with the other storage providers Fog supports (`Rackspace` and `Ninefold`).
