### PR TITLE
update autoscaling scheduled actions to allow recurrence, end and start times

### DIFF
--- a/lib/fog/aws/parsers/auto_scaling/describe_scheduled_actions.rb
+++ b/lib/fog/aws/parsers/auto_scaling/describe_scheduled_actions.rb
@@ -16,16 +16,17 @@ module Fog
           end
 
           def end_element(name)
+            @activity = {}
             case name
             when 'member'
               @results['ScheduledUpdateGroupActions'] << @scheduled_update_group_action
               reset_scheduled_update_group_action
 
-            when 'AutoScalingGroupName', 'ScheduledActionARN', 'ScheduledActionName'
+            when 'AutoScalingGroupName', 'ScheduledActionARN', 'ScheduledActionName', 'Recurrence'
               @activity[name] = value
             when 'DesiredCapacity', 'MaxSize', 'MinSize'
               @scheduled_update_group_action[name] = value.to_i
-            when 'Time'
+            when 'Time', 'StartTime', 'EndTime'
               @scheduled_update_group_action[name] = Time.parse(value)
 
             when 'NextToken'

--- a/lib/fog/aws/requests/auto_scaling/describe_scheduled_actions.rb
+++ b/lib/fog/aws/requests/auto_scaling/describe_scheduled_actions.rb
@@ -42,12 +42,17 @@ module Fog
         #             Scaling group to be updated.
         #         * 'DesiredCapacity'<~Integer> -The number of instances you
         #           prefer to maintain in your Auto Scaling group.
+        #         * 'EndTime'<~Time> - The time for this action to end.
         #         * 'MaxSize'<~Integer> - The maximum size of the Auto Scaling
         #           group.
         #         * 'MinSize'<~Integer> - The minimum size of the Auto Scaling
         #           group.
+        #         * 'Recurrence'<~String> - The time when recurring future 
+        #           actions will start. Start time is specified by the user 
+        #           following the Unix cron syntax format.
         #         * 'ScheduledActionARN'<~String> - The Amazon Resource Name
         #           (ARN) of this scheduled action.
+        #         * 'StartTime'<~Time> - The time for this action to start.
         #         * 'Time'<~Time> - The time that the action is scheduled to
         #           occur. This value can be up to one month in the future.
         #       * 'NextToken'<~String> - Acts as a paging mechanism for large

--- a/lib/fog/aws/requests/auto_scaling/put_scheduled_update_group_action.rb
+++ b/lib/fog/aws/requests/auto_scaling/put_scheduled_update_group_action.rb
@@ -14,14 +14,19 @@ module Fog
         # * auto_scaling_group_name<~String> - The name or ARN of the Auto
         #   Scaling Group.
         # * scheduled_action_name<~String> - Name of this scaling action.
-        # * time<~Datetime> - The time for this action to start
+        # * time<~Datetime> - The time for this action to start (deprecated use StartTime EndTime and Recurrence)
         # * options<~Hash>:
         #   * 'DesiredCapacity'<~Integer> - The number of EC2 instances that
         #     should be running in this group.
+        #   * 'EndTime'<~DateTime> - The time for this action to end.
         #   * 'MaxSize'<~Integer> - The maximum size for the Auto Scaling
         #     group.
         #   * 'MinSize'<~Integer> - The minimum size for the Auto Scaling
         #     group.
+        #   * 'Recurrence'<~String> - The time when recurring future actions will start. Start time is specified 
+        #     by the user following the Unix cron syntax format. When StartTime and EndTime are specified with 
+        #     Recurrence, they form the boundaries of when the recurring action will start and stop.
+        #   * 'StartTime'<~DateTime> - The time for this action to start
         #
         # ==== Returns
         # * response<~Excon::Response>:
@@ -32,12 +37,17 @@ module Fog
         # ==== See Also
         # http://docs.amazonwebservices.com/AutoScaling/latest/APIReference/API_PutScheduledUpdateGroupAction.html
         #
-        def put_scheduled_update_group_action(auto_scaling_group_name, scheduled_action_name, time, options = {})
+        def put_scheduled_update_group_action(auto_scaling_group_name, scheduled_action_name, time=nil, options = {})
+          # The 'Time' paramenter is now an alias for StartTime and needs to be identical if specified.  
+          time = options['StartTime'].nil? ? time : options['StartTime']
+          if !time.nil?
+            time = time.class == Time ? time.utc.iso8601 : Time.parse(time).utc.iso8601
+          end
           request({
             'Action'               => 'PutScheduledUpdateGroupAction',
             'AutoScalingGroupName' => auto_scaling_group_name,
             'ScheduledActionName'  => scheduled_action_name,
-            'Time'                 => time.utc.strftime('%FT%T.%3NZ'),
+            'Time'                 => time,
             :parser                => Fog::Parsers::AWS::AutoScaling::Basic.new
           }.merge!(options))
         end


### PR DESCRIPTION
updates autoscaling scheduled actions to allow recurrence, end and start times also initializes @activity explicitly to fix an issue in ruby 1.8
