### PR TITLE
[aws|storage|test] Use the MD5 of the file as the ETag for put_object to match S3's behavior.

### DIFF
--- a/lib/fog/aws/requests/storage/put_object.rb
+++ b/lib/fog/aws/requests/storage/put_object.rb
@@ -66,7 +66,7 @@ module Fog
             object = {
               :body             => data[:body],
               'Content-Type'    => options['Content-Type'] || data[:headers]['Content-Type'],
-              'ETag'            => Fog::AWS::Mock.etag,
+              'ETag'            => Digest::MD5.hexdigest(data[:body]),
               'Key'             => object_name,
               'Last-Modified'   => Fog::Time.now.to_date_header,
               'Content-Length'  => options['Content-Length'] || data[:headers]['Content-Length'],


### PR DESCRIPTION
I'm not sure why the ETag was mocked originally, but it seems to make sense to continue mocking for multi-part stores.  For simple put_object, the docs specify what the format of the ETag should be.

The value is a bit more important now that objects can have multiple versions.  E.g., I'm trying to write a job to clean up duplicate versioned data in S3 and need the mock framework to better match S3.
