### PR TITLE
Remove require rubygems line from core.rb

### DIFF
--- a/lib/fog/core.rb
+++ b/lib/fog/core.rb
@@ -5,7 +5,6 @@ $LOAD_PATH.unshift __LIB_DIR__ unless
   $LOAD_PATH.include?(File.expand_path(__LIB_DIR__))
 
 # external core dependencies
-require 'rubygems'
 require 'base64'
 require 'cgi'
 require 'uri'


### PR DESCRIPTION
I think this can be safely removed, when used via gem - rubygems is already available and it creates problem in non gem environments. 
