### PR TITLE
Support for rds parameter groups mocking

### DIFF
--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -66,8 +66,17 @@ module Fog
               region_hash[key] = {
                 :servers => {},
                 :security_groups => {},
-                :snapshots => {}
-              }
+                :snapshots => {},
+                :parameter_groups => {"default.mysql5.1" => { "DBParameterGroupFamily"=>"mysql5.1",
+                                                              "Description"=>"Default parameter group for mysql5.1",
+                                                              "DBParameterGroupName"=>"default.mysql5.1"
+                                                            },
+                                      "default.mysql5.5" => {"DBParameterGroupFamily"=>"mysql5.5",
+                                                            "Description"=>"Default parameter group for mysql5.5",
+                                                            "DBParameterGroupName"=>"default.mysql5.5"
+                                                            }
+                                      }
+                                 }
             end
           end
         end

--- a/lib/fog/aws/requests/rds/create_db_parameter_group.rb
+++ b/lib/fog/aws/requests/rds/create_db_parameter_group.rb
@@ -32,7 +32,25 @@ module Fog
       class Mock
 
         def create_db_parameter_group(group_name, group_family, description)
-          Fog::Mock.not_implemented
+          response = Excon::Response.new
+          if self.data[:parameter_groups] and self.data[:parameter_groups][group_name]
+            raise Fog::AWS::RDS::IdentifierTaken.new("Parameter group #{group_name} already exists")
+          end
+          
+          data = {
+            'DBParameterGroupName' => group_name,
+            'DBParameterGroupFamily' => group_family.downcase,
+            'Description' => description
+          }
+          self.data[:parameter_groups][group_name] = data
+          
+          response.body = {
+            "ResponseMetadata"=>{ "RequestId"=> Fog::AWS::Mock.request_id },
+            "CreateDBParameterGroupResult"=> {"DBParameterGroup"=> data}
+          }
+          response.status = 200
+          response
+          
         end
 
       end

--- a/lib/fog/aws/requests/rds/delete_db_parameter_group.rb
+++ b/lib/fog/aws/requests/rds/delete_db_parameter_group.rb
@@ -27,7 +27,17 @@ module Fog
       class Mock
 
         def delete_db_parameter_group(group_name)
-          Fog::Mock.not_implemented
+          response = Excon::Response.new
+          
+          if self.data[:parameter_groups].delete(group_name)
+            response.status = 200
+            response.body = {
+              "ResponseMetadata"=>{ "RequestId"=> Fog::AWS::Mock.request_id },
+            }
+            response
+          else
+            raise Fog::AWS::RDS::NotFound.new("DBParameterGroup not found: #{group_name}")
+          end
         end
 
       end

--- a/lib/fog/aws/requests/rds/describe_db_parameter_groups.rb
+++ b/lib/fog/aws/requests/rds/describe_db_parameter_groups.rb
@@ -36,7 +36,25 @@ module Fog
       class Mock
 
         def describe_db_parameter_groups(name=nil, opts={})
-          Fog::Mock.not_implemented
+          response = Excon::Response.new
+          parameter_set = []
+          if name
+            if server = self.data[:parameter_groups][name]
+              parameter_set << server
+            else
+              raise Fog::AWS::RDS::NotFound.new("DBInstance #{name} not found")
+            end
+          else
+            parameter_set = self.data[:parameter_groups].values
+          end
+          
+
+          response.status = 200
+          response.body = {
+            "ResponseMetadata"=>{ "RequestId"=> Fog::AWS::Mock.request_id },
+            "DescribeDBParameterGroupsResult" => { "DBParameterGroups" => parameter_set }
+          }
+          response
         end
 
       end

--- a/lib/fog/aws/requests/rds/describe_db_parameters.rb
+++ b/lib/fog/aws/requests/rds/describe_db_parameters.rb
@@ -39,7 +39,6 @@ module Fog
         def describe_db_parameters(name, opts={})
           Fog::Mock.not_implemented
         end
-
       end
     end
   end

--- a/tests/aws/requests/rds/parameter_group_tests.rb
+++ b/tests/aws/requests/rds/parameter_group_tests.rb
@@ -1,9 +1,7 @@
 Shindo.tests('AWS::RDS | parameter group requests', ['aws', 'rds']) do
   tests('success') do
-    pending if Fog.mocking?
 
     tests("#create_db_parameter_groups").formats(AWS::RDS::Formats::CREATE_DB_PARAMETER_GROUP) do
-      pending if Fog.mocking?
       body = Fog::AWS[:rds].create_db_parameter_group('fog-group', 'MySQL5.1', 'Some description').body
 
       returns( 'mysql5.1') { body['CreateDBParameterGroupResult']['DBParameterGroup']['DBParameterGroupFamily']}
@@ -16,16 +14,14 @@ Shindo.tests('AWS::RDS | parameter group requests', ['aws', 'rds']) do
     Fog::AWS[:rds].create_db_parameter_group('other-fog-group', 'MySQL5.1', 'Some description')
 
     tests("#describe_db_parameter_groups").formats(AWS::RDS::Formats::DESCRIBE_DB_PARAMETER_GROUP) do
-      pending if Fog.mocking?
 
       body = Fog::AWS[:rds].describe_db_parameter_groups().body
       
-      returns(3) {body['DescribeDBParameterGroupsResult']['DBParameterGroups'].length}      
+      returns(4) {body['DescribeDBParameterGroupsResult']['DBParameterGroups'].length}      
       body
     end
 
     tests("#describe_db_parameter_groups('fog-group)").formats(AWS::RDS::Formats::DESCRIBE_DB_PARAMETER_GROUP) do
-      pending if Fog.mocking?
 
       body = Fog::AWS[:rds].describe_db_parameter_groups('fog-group').body
       
@@ -40,7 +36,6 @@ Shindo.tests('AWS::RDS | parameter group requests', ['aws', 'rds']) do
     end
     
     tests("delete_db_parameter_group").formats(AWS::RDS::Formats::BASIC) do
-      pending if Fog.mocking?
       body = Fog::AWS[:rds].delete_db_parameter_group('fog-group').body
       
       raises(Fog::AWS::RDS::NotFound) {Fog::AWS[:rds].describe_db_parameter_groups('fog-group')}
@@ -52,7 +47,6 @@ Shindo.tests('AWS::RDS | parameter group requests', ['aws', 'rds']) do
   end
 
   tests("failures") do
-    pending if Fog.mocking?
     raises(Fog::AWS::RDS::NotFound) {Fog::AWS[:rds].describe_db_parameter_groups('doesntexist')}
     raises(Fog::AWS::RDS::NotFound) {Fog::AWS[:rds].delete_db_parameter_group('doesntexist')}
 


### PR DESCRIPTION
Shindo tests now pass in mocking mode. 

[fog] export FOG_MOCK=true ;bundle exec shindo tests/aws/requests/rds/parameter_group_tests.rb

  AWS::RDS | parameter group requests (aws, rds)
    success
      #create_db_parameter_groups + returns "mysql5.1"
- returns "fog-group"
- returns "Some description"
- has proper format
    #describe_db_parameter_groups + returns 4
- has proper format
    #describe_db_parameter_groups('fog-group) + returns 1
- returns "mysql5.1"
- returns "fog-group"
- returns "Some description"
- has proper format
    delete_db_parameter_group + raises Fog::AWS::RDS::NotFound
- has proper format
  failures
  - raises Fog::AWS::RDS::NotFound
  - raises Fog::AWS::RDS::NotFound
    creating second group with same id
  
  ```
  + raises Fog::AWS::RDS::IdentifierTaken
  ```
  
  16 succeeded in 0.564274 seconds
