### PR TITLE
Fix cloudstack warning

### DIFF
--- a/lib/fog/cloudstack.rb
+++ b/lib/fog/cloudstack.rb
@@ -8,7 +8,7 @@ module Fog
 
     service(:compute, 'cloudstack/compute','Compute')
 
-    DIGEST  = OpenSSL::Digest::Digest.new('sha1')
+    @@digest  = OpenSSL::Digest::Digest.new('sha1')
 
     def self.escape(string)
       string = CGI::escape(string)
@@ -19,7 +19,7 @@ module Fog
     def self.signed_params(key,params)
       query = params.to_a.sort.collect{|c| "#{c[0]}=#{escape(c[1].to_s)}"}.join('&').downcase
 
-      signed_string = Base64.encode64(OpenSSL::HMAC.digest(DIGEST,key,query)).strip
+      signed_string = Base64.encode64(OpenSSL::HMAC.digest(@@digest,key,query)).strip
 
       signed_string
     end


### PR DESCRIPTION
On ruby 1.8.7 or REE, I get warnings like this whenever I require fog:

```
lib/fog/cloudstack.rb:11: warning: already initialized constant DIGEST
```

This patch fixes the warning by using a module variable instead of a constant. The mocked cloudstack tests pass.
