### PR TITLE
Made it possible to specify security group via ID as well as name

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -221,6 +221,10 @@ module Fog
         "vol-#{Fog::Mock.random_hex(8)}"
       end
 
+      def self.security_group_id
+        "sg-#{Fog::Mock.random_hex(8)}"
+      end
+
       def self.key_id(length=21)
         #Probably close enough
         Fog::Mock.random_selection('ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789',length)
@@ -229,6 +233,25 @@ module Fog
       def self.rds_address(db_name,region)
         "#{db_name}.#{Fog::Mock.random_letters(rand(12) + 4)}.#{region}.rds.amazonaws.com"
       end
+    end
+
+    def self.parse_security_group_options(group_name, options)
+      if group_name.is_a?(Hash)
+        options = group_name
+      elsif group_name
+        if options.key?('GroupName')
+          raise Fog::Compute::AWS::Error, 'Arguments specified both group_name and GroupName in options'
+        end
+        options = options.clone
+        options['GroupName'] = group_name
+      end
+      if !options.key?('GroupName') && !options.key?('GroupId')
+        raise Fog::Compute::AWS::Error, 'Neither GroupName nor GroupId specified'
+      end
+      if options.key?('GroupName') && options.key?('GroupId')
+        raise Fog::Compute::AWS::Error, 'Both GroupName and GroupId specified'
+      end
+      options
     end
   end
 end

--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -124,6 +124,7 @@ module Fog
                   'default' => {
                     'groupDescription'    => 'default group',
                     'groupName'           => 'default',
+                    'groupId'             => 'sg-11223344',
                     'ipPermissionsEgress' => [],
                     'ipPermissions'       => [
                       {

--- a/lib/fog/aws/requests/compute/create_security_group.rb
+++ b/lib/fog/aws/requests/compute/create_security_group.rb
@@ -10,6 +10,7 @@ module Fog
         # ==== Parameters
         # * group_name<~String> - Name of the security group.
         # * group_description<~String> - Description of group.
+        # * vpc_id<~String> - ID of the VPC
         #
         # ==== Returns
         # * response<~Excon::Response>:
@@ -38,6 +39,7 @@ module Fog
             data = {
               'groupDescription'    => description,
               'groupName'           => name,
+              'groupId'             => Fog::AWS::Mock.security_group_id,
               'ipPermissionsEgress' => [],
               'ipPermissions'       => [],
               'ownerId'             => self.data[:owner_id],

--- a/lib/fog/aws/requests/compute/describe_security_groups.rb
+++ b/lib/fog/aws/requests/compute/describe_security_groups.rb
@@ -73,6 +73,8 @@ module Fog
             if permission_key = filter_key.split('ip-permission.')[1]
               if permission_key == 'group-name'
                 security_group_info = security_group_info.reject{|security_group| !security_group['ipPermissions']['groups'].detect {|group| [*filter_value].include?(group['groupName'])}}
+              elsif permission_key == 'group-id'
+                security_group_info = security_group_info.reject{|security_group| !security_group['ipPermissions']['groups'].detect {|group| [*filter_value].include?(group['groupId'])}}
               elsif permission_key == 'user-id'
                 security_group_info = security_group_info.reject{|security_group| !security_group['ipPermissions']['groups'].detect {|group| [*filter_value].include?(group['userId'])}}
               else

--- a/lib/fog/aws/requests/compute/request_spot_instances.rb
+++ b/lib/fog/aws/requests/compute/request_spot_instances.rb
@@ -25,7 +25,8 @@ module Fog
         #   * 'LaunchSpecification.KeyName'<~String> - Name of a keypair to add to booting instances
         #   * 'LaunchSpecification.Monitoring.Enabled'<~Boolean> - Enables monitoring, defaults to disabled
         #   * 'LaunchSpecification.Placement.AvailabilityZone'<~String> - Placement constraint for instances
-        #   * 'LaunchSpecification.SecurityGroup'<~Array> or <~String> - Name of security group(s) for instances
+        #   * 'LaunchSpecification.SecurityGroup'<~Array> or <~String> - Name of security group(s) for instances, not supported in VPC
+        #   * 'LaunchSpecification.SecurityGroupId'<~Array> or <~String> - Id of security group(s) for instances, use this or LaunchSpecification.SecurityGroup
         #   * 'LaunchSpecification.UserData'<~String> -  Additional data to provide to booting instances
         #   * 'Type'<~String> - spot instance request type in ['one-time', 'persistent']
         #   * 'ValidFrom'<~Time> - start date for request
@@ -63,6 +64,9 @@ module Fog
           end
           if security_groups = options.delete('LaunchSpecification.SecurityGroup')
             options.merge!(Fog::AWS.indexed_param('LaunchSpecification.SecurityGroup', [*security_groups]))
+          end
+          if security_group_ids = options.delete('LaunchSpecification.SecurityGroupId')
+            options.merge!(Fog::AWS.indexed_param('LaunchSpecification.SecurityGroupId', [*security_group_ids]))
           end
           if options['LaunchSpecification.UserData']
             options['LaunchSpecification.UserData'] = Base64.encode64(options['LaunchSpecification.UserData'])

--- a/lib/fog/aws/requests/compute/revoke_security_group_ingress.rb
+++ b/lib/fog/aws/requests/compute/revoke_security_group_ingress.rb
@@ -8,8 +8,10 @@ module Fog
         # Remove permissions from a security group
         #
         # ==== Parameters
-        # * group_name<~String> - Name of group
+        # * group_name<~String> - Name of group, optional (can also be specifed as GroupName in options)
         # * options<~Hash>:
+        #   * 'GroupName'<~String> - Name of security group to modify
+        #   * 'GroupId'<~String> - Id of security group to modify
         #   * 'SourceSecurityGroupName'<~String> - Name of security group to authorize
         #   * 'SourceSecurityGroupOwnerId'<~String> - Name of owner to authorize
         #   or
@@ -39,11 +41,7 @@ module Fog
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-RevokeSecurityGroupIngress.html]
         def revoke_security_group_ingress(group_name, options = {})
-          if group_name.is_a?(Hash)
-            Fog::Logger.deprecation("Fog::AWS::Compute#revoke_security_group_ingress now requires the 'group_name' parameter. Only specifying an options hash is now deprecated [light_black](#{caller.first})[/]")
-            options = group_name
-            group_name = options.delete('GroupName')
-          end
+          options = Fog::AWS.parse_security_group_options(group_name, options)
 
           if ip_permissions = options.delete('IpPermissions')
             options.merge!(indexed_ip_permissions_params(ip_permissions))
@@ -51,7 +49,6 @@ module Fog
 
           request({
             'Action'    => 'RevokeSecurityGroupIngress',
-            'GroupName' => group_name,
             :idempotent => true,
             :parser     => Fog::Parsers::Compute::AWS::Basic.new
           }.merge!(options))
@@ -62,10 +59,11 @@ module Fog
       class Mock
 
         def revoke_security_group_ingress(group_name, options = {})
-          if group_name.is_a?(Hash)
-            Fog::Logger.deprecation("Fog::AWS::Compute#revoke_security_group_ingress now requires the 'group_name' parameter. Only specifying an options hash is now deprecated [light_black](#{caller.first})[/]")
-            options = group_name
-            group_name = options.delete('GroupName')
+          options = Fog::AWS.parse_security_group_options(group_name, options)
+          if options.key?('GroupName')
+            group_name = options['GroupName']
+          else
+            group_name = self.data[:security_groups].reject { |k,v| v['groupId'] != options['GroupId'] } .keys.first
           end
 
           verify_permission_options(options)

--- a/lib/fog/aws/requests/compute/run_instances.rb
+++ b/lib/fog/aws/requests/compute/run_instances.rb
@@ -30,7 +30,8 @@ module Fog
         #     * 'Ebs.DeleteOnTermination'<~String> - specifies whether or not to delete the volume on instance termination
         #   * 'ClientToken'<~String> - unique case-sensitive token for ensuring idempotency
         #   * 'DisableApiTermination'<~Boolean> - specifies whether or not to allow termination of the instance from the api
-        #   * 'SecurityGroup'<~Array> or <~String> - Name of security group(s) for instances (you must omit this parameter if using Virtual Private Clouds)
+        #   * 'SecurityGroup'<~Array> or <~String> - Name of security group(s) for instances (not supported for VPC)
+        #   * 'SecurityGroupId'<~Array> or <~String> - id's of security group(s) for instances, use this or SecurityGroup
         #   * 'InstanceInitiatedShutdownBehaviour'<~String> - specifies whether volumes are stopped or terminated when instance is shutdown, in [stop, terminate]
         #   * 'InstanceType'<~String> - Type of instance to boot. Valid options
         #     in ['t1.micro', 'm1.small', 'm1.large', 'm1.xlarge', 'c1.medium', 'c1.xlarge', 'm2.xlarge', m2.2xlarge', 'm2.4xlarge', 'cc1.4xlarge', 'cg1.4xlarge']
@@ -96,6 +97,9 @@ module Fog
           end
           if security_groups = options.delete('SecurityGroup')
             options.merge!(Fog::AWS.indexed_param('SecurityGroup', [*security_groups]))
+          end
+          if security_group_ids = options.delete('SecurityGroupId')
+            options.merge!(Fog::AWS.indexed_param('SecurityGroupId', [*security_group_ids]))
           end
           if options['UserData']
             options['UserData'] = Base64.encode64(options['UserData'])

--- a/tests/aws/requests/compute/security_group_tests.rb
+++ b/tests/aws/requests/compute/security_group_tests.rb
@@ -31,6 +31,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
       Fog::Compute[:aws].create_security_group('fog_security_group_two', 'tests group').body
     end
 
+    group_id = Fog::Compute[:aws].describe_security_groups('group-name' => 'fog_security_group').body['securityGroupInfo'].first['groupId']
     to_be_revoked = []
     expected_permissions = []
 
@@ -61,6 +62,10 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
 
     tests("#describe_security_groups('group-name' => 'fog_security_group')").returns([]) do
       array_differences(expected_permissions, Fog::Compute[:aws].describe_security_groups('group-name' => 'fog_security_group').body['securityGroupInfo'].first['ipPermissions'])
+    end
+
+    tests("#describe_security_groups('group-id' => '#{group_id}')").returns([]) do
+      array_differences(expected_permissions, Fog::Compute[:aws].describe_security_groups('group-id' => group_id).body['securityGroupInfo'].first['ipPermissions'])
     end
 
     permission = { 'SourceSecurityGroupName' => 'fog_security_group_two', 'SourceSecurityGroupOwnerId' => @owner_id }
@@ -256,6 +261,52 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
       Fog::Compute[:aws].delete_security_group('fog_security_group_two').body
     end
 
+    # Create security group in VPC
+    tests("#create_security_group('vpc_security_group', 'tests group')").formats(AWS::Compute::Formats::BASIC) do
+      Fog::Compute[:aws].create_security_group('vpc_security_group', 'tests group', 'vpc-11223344').body
+    end
+
+    group_id = Fog::Compute[:aws].describe_security_groups('group-name' => 'vpc_security_group').body['securityGroupInfo'].first['groupId']
+    
+    # Access group with name in options array
+    permission = { 'IpProtocol' => 'tcp', 'FromPort' => '22', 'ToPort' => '22', 'CidrIp' => '10.0.0.0/8' }
+    expected_permissions = [
+      {"groups"=>[],
+        "ipRanges"=>[{"cidrIp"=>"10.0.0.0/8"}],
+        "ipProtocol"=>"tcp",
+        "fromPort"=>22,
+        "toPort"=>22}
+    ]
+
+    options = permission.clone
+    options['GroupName'] = 'vpc_security_group'
+    tests("#authorize_security_group_ingress(#{options.inspect})").formats(AWS::Compute::Formats::BASIC) do
+      Fog::Compute[:aws].authorize_security_group_ingress(options).body
+    end
+
+    tests("#describe_security_groups('group-name' => 'vpc_security_group')").returns([]) do
+      array_differences(expected_permissions, Fog::Compute[:aws].describe_security_groups('group-name' => 'vpc_security_group').body['securityGroupInfo'].first['ipPermissions'])
+    end
+
+    tests("#revoke_security_group_ingress(#{options.inspect})").formats(AWS::Compute::Formats::BASIC) do
+      Fog::Compute[:aws].revoke_security_group_ingress(options).body
+    end
+
+    # Access group with id in options array
+    options = permission.clone
+    options['GroupId'] = group_id
+    tests("#authorize_security_group_ingress(#{options.inspect})").formats(AWS::Compute::Formats::BASIC) do
+      Fog::Compute[:aws].authorize_security_group_ingress(options).body
+    end
+
+    tests("#describe_security_groups('group-name' => 'vpc_security_group')").returns([]) do
+      array_differences(expected_permissions, Fog::Compute[:aws].describe_security_groups('group-name' => 'vpc_security_group').body['securityGroupInfo'].first['ipPermissions'])
+    end
+
+    tests("#revoke_security_group_ingress(#{options.inspect})").formats(AWS::Compute::Formats::BASIC) do
+      Fog::Compute[:aws].revoke_security_group_ingress(options).body
+    end
+
   end
   tests('failure') do
 
@@ -358,6 +409,23 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
     tests("#delete_security_group('default')").raises(Fog::Compute::AWS::Error) do
       Fog::Compute[:aws].delete_security_group('default')
     end
+
+    broken_params = [
+                     [ 'fog_security_group', { 'GroupName' => 'fog_security_group'}],
+                     [ 'fog_security_group', { 'GroupId' => 'sg-11223344'}],
+                     [ { 'GroupName' => 'fog_security_group', 'GroupId' => 'sg-11223344'}, nil]
+                    ]
+
+    broken_params.each do |list_elem|
+      tests("#authorize_security_group_ingress(#{list_elem[0].inspect}, #{list_elem[1].inspect})").raises(Fog::Compute::AWS::Error) do
+        Fog::Compute[:aws].authorize_security_group_ingress(list_elem[0], list_elem[1])
+      end
+
+      tests("#revoke_security_group_ingress(#{list_elem[0].inspect}, #{list_elem[1].inspect})").raises(Fog::Compute::AWS::Error) do
+        Fog::Compute[:aws].revoke_security_group_ingress(list_elem[0], list_elem[1])
+      end
+    end
+
   end
 
 end


### PR DESCRIPTION
This patch makes it possible to specify GroupID in the options hash to the
aws computre requests operating on security groups. This is needed since
when working with VPC you must use GroupID instead of name.
