### PR TITLE
Removed mutual exclusion between subnet and security group

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -160,15 +160,6 @@ module Fog
           }
           options.delete_if {|key, value| value.nil?}
 
-          # If subnet is defined we are working on a virtual private cloud.
-          # subnet & security group cannot co-exist. I wish VPC just ignored
-          # the security group parameter instead, it would be much easier!
-          if subnet_id
-            options.delete('SecurityGroup')
-          else
-            options.delete('SubnetId')
-          end
-
           data = connection.run_instances(image_id, 1, 1, options)
           merge_attributes(data.body['instancesSet'].first)
 


### PR DESCRIPTION
In the AWS::Server class there were a few lines that made the assumption that security groups and subnets were somehow mutually exclusive. This is in fact not true and both can be used at once, and they cooperate quite nicely.

A setup with both subnets and security groups is integral to our production configuration so I'm submitting a request to remove the restriction.

Thanks!
rusty
