### PR TITLE
Added PrivateIpAddress to the list of valid parameters for instance creation

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -152,6 +152,7 @@ module Fog
             'Placement.AvailabilityZone'  => availability_zone,
             'Placement.GroupName'         => placement_group,
             'Placement.Tenancy'           => tenancy,
+            'PrivateIpAddress'            => private_ip_address,
             'RamdiskId'                   => ramdisk_id,
             'SecurityGroup'               => groups,
             'SecurityGroupId'             => security_group_ids,


### PR DESCRIPTION
Simple one-line addition, allows specifying the IP when creating an instance within a VPC.

Please let me know if there's additional work that needs to be done to get this accepted -- not exactly sure how/were to test this one, but it works when creating actual instances at least :)
