### PR TITLE
Fix sync_clock method, only rescue Excon::Errors::HTTPStatusError that a...

### DIFF
--- a/lib/fog/aws/requests/storage/sync_clock.rb
+++ b/lib/fog/aws/requests/storage/sync_clock.rb
@@ -8,8 +8,8 @@ module Fog
         def sync_clock
           response = begin
             get_service
-          rescue => error
-            error.respond_to(:response) ? error.response : error.message
+          rescue Excon::Errors::HTTPStatusError => error
+            error.response
           end
           Fog::Time.now = Time.parse(response.headers['Date'])
         end


### PR DESCRIPTION
...re known to have a #response method, let all other exceptions bubble up

Discussion in #789
