### PR TITLE
wrangled security tests into working

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -117,6 +117,7 @@ module Fog
           @data ||= Hash.new do |hash, region|
             hash[region] = Hash.new do |region_hash, key|
               owner_id = Fog::AWS::Mock.owner_id
+              security_group_id = Fog::AWS::Mock.security_group_id
               region_hash[key] = {
                 :deleted_at => {},
                 :addresses  => {},
@@ -135,25 +136,25 @@ module Fog
                   'default' => {
                     'groupDescription'    => 'default group',
                     'groupName'           => 'default',
-                    'groupId'             => 'sg-11223344',
+                    'groupId'             => security_group_id,
                     'ipPermissionsEgress' => [],
                     'ipPermissions'       => [
                       {
-                        'groups'      => [{'groupName' => 'default', 'userId' => owner_id}],
+                        'groups'      => [{'groupName' => 'default', 'userId' => owner_id, 'groupId' => security_group_id }],
                         'fromPort'    => -1,
                         'toPort'      => -1,
                         'ipProtocol'  => 'icmp',
                         'ipRanges'    => []
                       },
                       {
-                        'groups'      => [{'groupName' => 'default', 'userId' => owner_id}],
+                        'groups'      => [{'groupName' => 'default', 'userId' => owner_id, 'groupId' => security_group_id}],
                         'fromPort'    => 0,
                         'toPort'      => 65535,
                         'ipProtocol'  => 'tcp',
                         'ipRanges'    => []
                       },
                       {
-                        'groups'      => [{'groupName' => 'default', 'userId' => owner_id}],
+                        'groups'      => [{'groupName' => 'default', 'userId' => owner_id, 'groupId' => security_group_id}],
                         'fromPort'    => 0,
                         'toPort'      => 65535,
                         'ipProtocol'  => 'udp',

--- a/lib/fog/aws/models/compute/subnet.rb
+++ b/lib/fog/aws/models/compute/subnet.rb
@@ -44,7 +44,6 @@ module Fog
         def save
           requires :vpc_id, :cidr_block
           data = connection.create_subnet(vpc_id, cidr_block).body['subnetSet'].first
-		puts data
           new_attributes = data.reject {|key,value| key == 'requestId'}
           merge_attributes(new_attributes)
           true

--- a/lib/fog/aws/requests/compute/describe_security_groups.rb
+++ b/lib/fog/aws/requests/compute/describe_security_groups.rb
@@ -71,7 +71,7 @@ module Fog
           }
           for filter_key, filter_value in filters
             if permission_key = filter_key.split('ip-permission.')[1]
-              if permission_key == 'group-name'
+              if permission_key == 'group-name'	
                 security_group_info = security_group_info.reject{|security_group| !security_group['ipPermissions']['groups'].detect {|group| [*filter_value].include?(group['groupName'])}}
               elsif permission_key == 'group-id'
                 security_group_info = security_group_info.reject{|security_group| !security_group['ipPermissions']['groups'].detect {|group| [*filter_value].include?(group['groupId'])}}

--- a/tests/aws/requests/compute/security_group_tests.rb
+++ b/tests/aws/requests/compute/security_group_tests.rb
@@ -13,7 +13,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
       'groupName'         => String,
       'ipPermissions'     => [{
         'fromPort'    => Fog::Nullable::Integer,
-        'groups'      => [{ 'groupName' => Fog::Nullable::String, 'userId' => String }],
+        'groups'      => [{ 'groupName' => Fog::Nullable::String, 'userId' => String, 'groupId' => String }],
         'ipProtocol'  => String,
         'ipRanges'    => [],
         'toPort'      => Fog::Nullable::Integer,
@@ -25,17 +25,17 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
   }
 
   @owner_id = Fog::Compute[:aws].describe_security_groups('group-name' => 'default').body['securityGroupInfo'].first['ownerId']
+  @group_id_default = Fog::Compute[:aws].describe_security_groups('group-name' => 'default').body['securityGroupInfo'].first['groupId']
 
   tests('success') do
 
     tests("#create_security_group('fog_security_group', 'tests group')").formats(@create_security_group_format) do
       Fog::Compute[:aws].create_security_group('fog_security_group', 'tests group').body
     end
-
     tests("#create_security_group('fog_security_group_two', 'tests group')").formats(@create_security_group_format) do
       Fog::Compute[:aws].create_security_group('fog_security_group_two', 'tests group').body
     end
-
+    @group_id_two = Fog::Compute[:aws].describe_security_groups('group-name' => 'fog_security_group_two').body['securityGroupInfo'].first['groupId']
     group_id = Fog::Compute[:aws].describe_security_groups('group-name' => 'fog_security_group').body['securityGroupInfo'].first['groupId']
     to_be_revoked = []
     expected_permissions = []
@@ -48,17 +48,17 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
     to_be_revoked.push([permission, expected_permissions.dup])
 
     expected_permissions = [
-      {"groups"=>[{"groupName"=>"default", "userId"=>@owner_id}],
+      {"groups"=>[{"groupName"=>"default", "userId"=>@owner_id, "groupId"=>@group_id_default}],
         "fromPort"=>1,
         "ipRanges"=>[],
         "ipProtocol"=>"tcp",
         "toPort"=>65535},
-      {"groups"=>[{"groupName"=>"default", "userId"=>@owner_id}],
+      {"groups"=>[{"groupName"=>"default", "userId"=>@owner_id, "groupId"=>@group_id_default}],
         "fromPort"=>1,
         "ipRanges"=>[],
         "ipProtocol"=>"udp",
         "toPort"=>65535},
-      {"groups"=>[{"groupName"=>"default", "userId"=>@owner_id}],
+      {"groups"=>[{"groupName"=>"default", "userId"=>@owner_id, "groupId"=>@group_id_default}],
         "fromPort"=>-1,
         "ipRanges"=>[],
         "ipProtocol"=>"icmp",
@@ -82,22 +82,22 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
 
     expected_permissions = [
       {"groups"=>
-        [{"userId"=>@owner_id, "groupName"=>"default"},
-          {"userId"=>@owner_id, "groupName"=>"fog_security_group_two"}],
+        [{"userId"=>@owner_id, "groupName"=>"default", "groupId"=>@group_id_default},
+          {"userId"=>@owner_id, "groupName"=>"fog_security_group_two", "groupId"=>@group_id_two}],
         "ipRanges"=>[],
         "ipProtocol"=>"tcp",
         "fromPort"=>1,
         "toPort"=>65535},
       {"groups"=>
-        [{"userId"=>@owner_id, "groupName"=>"default"},
-          {"userId"=>@owner_id, "groupName"=>"fog_security_group_two"}],
+        [{"userId"=>@owner_id, "groupName"=>"default", "groupId"=>@group_id_default},
+          {"userId"=>@owner_id, "groupName"=>"fog_security_group_two", "groupId"=>@group_id_two}],
         "ipRanges"=>[],
         "ipProtocol"=>"udp",
         "fromPort"=>1,
         "toPort"=>65535},
       {"groups"=>
-        [{"userId"=>@owner_id, "groupName"=>"default"},
-          {"userId"=>@owner_id, "groupName"=>"fog_security_group_two"}],
+        [{"userId"=>@owner_id, "groupName"=>"default", "groupId"=>@group_id_default},
+          {"userId"=>@owner_id, "groupName"=>"fog_security_group_two", "groupId"=>@group_id_two}],
         "ipRanges"=>[],
         "ipProtocol"=>"icmp",
         "fromPort"=>-1,
@@ -199,13 +199,12 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
     to_be_revoked.push([permissions, expected_permissions.dup])
 
     expected_permissions += [
-      {"groups"=>[{"userId"=>@owner_id, "groupName"=>"fog_security_group_two"}],
+      {"groups"=>[{"userId"=>@owner_id, "groupName"=>"fog_security_group_two", "groupId"=>@group_id_two}],
         "ipRanges"=>[],
         "ipProtocol"=>"tcp",
         "fromPort"=>8000,
         "toPort"=>8000}
     ]
-
     tests("#describe_security_groups('group-name' => 'fog_security_group')").returns([]) do
       array_differences(expected_permissions, Fog::Compute[:aws].describe_security_groups('group-name' => 'fog_security_group').body['securityGroupInfo'].first['ipPermissions'])
     end
@@ -229,7 +228,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
 
     expected_permissions += [
       {"groups"=>
-        [{"userId"=>@owner_id, "groupName"=>"fog_security_group_two"}],
+        [{"userId"=>@owner_id, "groupName"=>"fog_security_group_two", "groupId"=>@group_id_two}],
         "ipRanges"=>[{"cidrIp"=>"172.16.0.0/24"}],
         "ipProtocol"=>"tcp",
         "fromPort"=>9000,
@@ -275,32 +274,22 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
 
     group_id = Fog::Compute[:aws].describe_security_groups('group-name' => 'vpc_security_group').body['securityGroupInfo'].first['groupId']
     
-    # Access group with name in options array
-    permission = { 'IpProtocol' => '42', 'FromPort' => '22', 'ToPort' => '22', 'CidrIp' => '10.0.0.0/8' }
+    permissions = {
+      'IpPermissions' => [
+        {
+          'IpProtocol' => '42',
+          'IpRanges' => [{ 'CidrIp' => '10.0.0.0/8' }],
+        }
+      ]
+    }
+
     expected_permissions = [
       {"groups"=>[],
         "ipRanges"=>[{"cidrIp"=>"10.0.0.0/8"}],
-        "ipProtocol"=>"42",
-        "fromPort"=>22,
-        "toPort"=>22}
+        "ipProtocol"=>"42"}
     ]
 
-    options = permission.clone
-    options['GroupName'] = 'vpc_security_group'
-    tests("#authorize_security_group_ingress(#{options.inspect})").formats(AWS::Compute::Formats::BASIC) do
-      Fog::Compute[:aws].authorize_security_group_ingress(options).body
-    end
-
-    tests("#describe_security_groups('group-name' => 'vpc_security_group')").returns([]) do
-      array_differences(expected_permissions, Fog::Compute[:aws].describe_security_groups('group-name' => 'vpc_security_group').body['securityGroupInfo'].first['ipPermissions'])
-    end
-
-    tests("#revoke_security_group_ingress(#{options.inspect})").formats(AWS::Compute::Formats::BASIC) do
-      Fog::Compute[:aws].revoke_security_group_ingress(options).body
-    end
-
-    # Access group with id in options array
-    options = permission.clone
+    options = permissions.clone
     options['GroupId'] = group_id
     tests("#authorize_security_group_ingress(#{options.inspect})").formats(AWS::Compute::Formats::BASIC) do
       Fog::Compute[:aws].authorize_security_group_ingress(options).body
@@ -314,9 +303,13 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
       Fog::Compute[:aws].revoke_security_group_ingress(options).body
     end
 
+    vpc_group=Fog::Compute[:aws].security_groups.get_by_id(group_id)
+    vpc_group.destroy
+
     Fog::Compute[:aws].delete_vpc(vpc_id)
 
   end
+  ## Rate limiting seems to want us to take a break otherwise it will throw errors
   tests('failure') do
 
     @security_group = Fog::Compute[:aws].security_groups.create(:description => 'tests group', :name => 'fog_security_group')


### PR DESCRIPTION
This fixes the security group tests which were not working in non-mocking mode, and brings the mock returns inline with the non-mocking returns.  Also removed a line of debugging from the subnet functionality.
