### PR TITLE
Allow custom headers in Storage#put_object_url

### DIFF
--- a/lib/fog/aws/requests/storage/put_object_url.rb
+++ b/lib/fog/aws/requests/storage/put_object_url.rb
@@ -24,7 +24,7 @@ module Fog
           unless object_name
             raise ArgumentError.new('object_name is required')
           end
-          url({
+          https_url({
             :headers  => headers,
             :host     => @host,
             :method   => 'PUT',
@@ -43,7 +43,7 @@ module Fog
           unless object_name
             raise ArgumentError.new('object_name is required')
           end
-          url({
+          https_url({
             :headers  => headers,
             :host     => @host,
             :method   => 'PUT',

--- a/lib/fog/google/requests/storage/put_object_url.rb
+++ b/lib/fog/google/requests/storage/put_object_url.rb
@@ -21,7 +21,7 @@ module Fog
           unless object_name
             raise ArgumentError.new('object_name is required')
           end
-          url({
+          https_url({
             :headers  => headers,
             :host     => @host,
             :method   => 'PUT',
@@ -40,7 +40,7 @@ module Fog
           unless object_name
             raise ArgumentError.new('object_name is required')
           end
-          url({
+          https_url({
             :headers  => headers,
             :host     => @host,
             :method   => 'PUT',


### PR DESCRIPTION
It would be very nice to allow custom headers when generating put URLs. In particular, this would allow supplying a `Content-Type` which is part of the signature for AWS S3.
