### PR TITLE
[aws|dns] Support for checking record sync status.

### DIFF
--- a/lib/fog/aws/models/dns/record.rb
+++ b/lib/fog/aws/models/dns/record.rb
@@ -58,7 +58,7 @@ module Fog
 
         # Returns true if record is insync.  May only be called for newly created or modified records that
         # have a change_id and status set.
-        def insync?
+        def ready?
           requires :change_id, :status
           status == 'INSYNC'
         end

--- a/tests/aws/models/dns/record_tests.rb
+++ b/tests/aws/models/dns/record_tests.rb
@@ -15,8 +15,8 @@ Shindo.tests("Fog::Dns[:aws] | record", ['aws', 'dns']) do
     end
 
     # Waits for changes to sync to all Route 53 DNS servers.  Usually takes ~30 seconds to complete.
-    tests("#insync? - may take a minute to complete...").succeeds do
-      @instance.wait_for { insync? }
+    tests("#ready? - may take a minute to complete...").succeeds do
+      @instance.wait_for { ready? }
     end
 
     tests("#modify") do


### PR DESCRIPTION
AWS Route 53 takes some time to propagate zone record modifications to all DNS servers.  The status of the update can be determined via the get_change API call.  This commit adds support to check the sync status of a newly created or modified zone record on the record model directly.

One can now write code like:

``` ruby
record = zone.records.create({ ... })

record.wait_for { insync? }

```

Review requested as this is implemented via overriding the reload method to support fog's standard wait_for call.
