### PR TITLE
Store the region for S3.

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -255,6 +255,7 @@ module Fog
             @scheme = endpoint.scheme
           else
             options[:region] ||= 'us-east-1'
+            @region = options[:region]
             @host = options[:host] || case options[:region]
             when 'us-east-1'
               's3.amazonaws.com'


### PR DESCRIPTION
This is a fix for #654: can't create S3 buckets in regions other than the default. S3 complains that the location constraint doesn't match the specified region.

I couldn't see any obvious way to test this (other than manually), so there is no test included.

I don't think this fix will work in the case where the `:endpoint` option is provided. I suspect that you would need to parse the region out of the URL in that case. But this is progress, anyway.
