### PR TITLE
[vpc-fixes] AWS security group model + VPC

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -237,6 +237,7 @@ module Fog
     end
 
     def self.parse_security_group_options(group_name, options)
+      options ||= Hash.new
       if group_name.is_a?(Hash)
         options = group_name
       elsif group_name
@@ -246,11 +247,13 @@ module Fog
         options = options.clone
         options['GroupName'] = group_name
       end
-      if !options.key?('GroupName') && !options.key?('GroupId')
+      name_specified = options.key?('GroupName') && !options['GroupName'].nil?
+      group_id_specified = options.key?('GroupId') && !options['GroupId'].nil?
+      unless name_specified || group_id_specified
         raise Fog::Compute::AWS::Error, 'Neither GroupName nor GroupId specified'
       end
-      if options.key?('GroupName') && options.key?('GroupId')
-        raise Fog::Compute::AWS::Error, 'Both GroupName and GroupId specified'
+      if name_specified && group_id_specified
+        options.delete('GroupName')
       end
       options
     end

--- a/lib/fog/aws/models/compute/security_group.rb
+++ b/lib/fog/aws/models/compute/security_group.rb
@@ -40,12 +40,13 @@ module Fog
         #
 
         def authorize_group_and_owner(group, owner = nil)
-          requires :name
+          requires_one :name, :group_id
 
           connection.authorize_security_group_ingress(
             name,
-            'SourceSecurityGroupName'     => group,
-            'SourceSecurityGroupOwnerId'  => owner
+            'GroupId'                    => group_id,
+            'SourceSecurityGroupName'    => group,
+            'SourceSecurityGroupOwnerId' => owner
           )
         end
 
@@ -78,14 +79,23 @@ module Fog
         #
 
         def authorize_port_range(range, options = {})
-          requires :name
+          requires_one :name, :group_id
 
           connection.authorize_security_group_ingress(
             name,
-            'CidrIp'      => options[:cidr_ip] || '0.0.0.0/0',
-            'FromPort'    => range.min,
-            'ToPort'      => range.max,
-            'IpProtocol'  => options[:ip_protocol] || 'tcp'
+            'GroupId'       => group_id,
+            'IpPermissions' => [
+              {
+                'FromPort'   => range.min,
+                'ToPort'     => range.max,
+                'IpProtocol' => options[:ip_protocol] || 'tcp',
+                'IpRanges'   => [
+                  {
+                    'CidrIp' => options[:cidr_ip] || '0.0.0.0/0'
+                  }
+                ]
+              }
+            ]
           )
         end
 
@@ -99,7 +109,7 @@ module Fog
         #
 
         def destroy
-          requires :name
+          requires_one :name, :group_id
 
           if group_id.nil?
             connection.delete_security_group(name)
@@ -136,12 +146,13 @@ module Fog
         #
 
         def revoke_group_and_owner(group, owner = nil)
-          requires :name
+          requires_one :name, :group_id
 
           connection.revoke_security_group_ingress(
             name,
-            'SourceSecurityGroupName'     => group,
-            'SourceSecurityGroupOwnerId'  => owner
+            'GroupId'                    => group_id,
+            'SourceSecurityGroupName'    => group,
+            'SourceSecurityGroupOwnerId' => owner
           )
         end
 
@@ -174,14 +185,23 @@ module Fog
         #
 
         def revoke_port_range(range, options = {})
-          requires :name
+          requires_one :name, :group_id
 
           connection.revoke_security_group_ingress(
             name,
-            'CidrIp'      => options[:cidr_ip] || '0.0.0.0/0',
-            'FromPort'    => range.min,
-            'ToPort'      => range.max,
-            'IpProtocol'  => options[:ip_protocol] || 'tcp'
+            'GroupId'       => group_id,
+            'IpPermissions' => [
+              {
+                'FromPort'   => range.min,
+                'ToPort'     => range.max,
+                'IpProtocol' => options[:ip_protocol] || 'tcp',
+                'IpRanges'   => [
+                  {
+                    'CidrIp' => options[:cidr_ip] || '0.0.0.0/0'
+                  }
+                ]
+              }
+            ]
           )
         end
 

--- a/lib/fog/aws/parsers/compute/describe_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_instances.rb
@@ -31,7 +31,7 @@ module Fog
             when 'architecture', 'clientToken', 'dnsName', 'imageId',
                   'instanceId', 'instanceType', 'ipAddress', 'kernelId',
                   'keyName', 'platform', 'privateDnsName', 'privateIpAddress', 'ramdiskId',
-                  'reason', 'rootDeviceType',  'subnetId', 'vpcId'
+                  'reason', 'rootDeviceType', 'subnetId', 'vpcId'
               @instance[name] = value
             when 'attachTime'
               @block_device_mapping[name] = Time.parse(value)

--- a/tests/aws/requests/compute/security_group_tests.rb
+++ b/tests/aws/requests/compute/security_group_tests.rb
@@ -273,7 +273,7 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
     end
 
     group_id = Fog::Compute[:aws].describe_security_groups('group-name' => 'vpc_security_group').body['securityGroupInfo'].first['groupId']
-    
+
     permissions = {
       'IpPermissions' => [
         {
@@ -413,9 +413,10 @@ Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
     end
 
     broken_params = [
-                     [ 'fog_security_group', { 'GroupName' => 'fog_security_group'}],
-                     [ 'fog_security_group', { 'GroupId' => 'sg-11223344'}],
-                     [ { 'GroupName' => 'fog_security_group', 'GroupId' => 'sg-11223344'}, nil]
+                     ['fog_security_group', { 'GroupName' => 'fog_security_group' }],
+                     [nil, nil],
+                     [nil, { 'GroupId' => nil }],
+                     [nil, { 'GroupName' => nil, 'GroupId' => nil }]
                     ]
 
     broken_params.each do |list_elem|


### PR DESCRIPTION
- Drop AWS security group name when id is provided
- Security group id must be used when dealing w/ VPC
- "authorize_port_range" (AuthorizeSecurityGroupIngress) must use IpPermissions in order to work w/ VPC
- Adjusted security group tests, as group id can be used instead of group name
- Added a few tests for nil group name and nil group id

Looking for feedback, as deleting a key in a method intend for parsing is a bit odd.

http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-AuthorizeSecurityGroupIngress.html

http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-RevokeSecurityGroupIngress.html
