### PR TITLE
All directories.create on us-east-1

### DIFF
--- a/lib/fog/aws/models/storage/directory.rb
+++ b/lib/fog/aws/models/storage/directory.rb
@@ -107,7 +107,10 @@ module Fog
           if @acl
             options['x-amz-acl'] = @acl
           end
-          options['LocationConstraint'] = @location || self.connection.region
+          lc = @location || self.connection.region
+          if lc != 'us-east-1'     # us-east-1 is not valid: See http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTBucketPUT.html
+            options['LocationConstraint'] = lc
+          end
           connection.put_bucket(key, options)
           true
         end


### PR DESCRIPTION
Pull request for comment...

w/o this you can't do directories.create(key: <name>) in us-east-1.
