### PR TITLE
[compute|aws] Apply tags to volume at creation

### DIFF
--- a/lib/fog/aws/models/compute/volume.rb
+++ b/lib/fog/aws/models/compute/volume.rb
@@ -44,6 +44,19 @@ module Fog
           data = connection.create_volume(availability_zone, size, snapshot_id).body
           new_attributes = data.reject {|key,value| key == 'requestId'}
           merge_attributes(new_attributes)
+
+          if tags = self.tags
+            # expect eventual consistency
+            Fog.wait_for { self.reload rescue nil }
+            for key, value in (self.tags = tags)
+              connection.tags.create(
+                :key          => key,
+                :resource_id  => self.identity,
+                :value        => value
+              )
+            end
+          end
+
           if @server
             self.server = @server
           end

--- a/tests/aws/models/compute/volume_tests.rb
+++ b/tests/aws/models/compute/volume_tests.rb
@@ -3,7 +3,7 @@ Shindo.tests("Fog::Compute[:aws] | volume", ['aws']) do
   @server = Fog::Compute[:aws].servers.create
   @server.wait_for { ready? }
 
-  model_tests(Fog::Compute[:aws].volumes, {:availability_zone => @server.availability_zone, :size => 1, :device => '/dev/sdz1'}, true) do
+  model_tests(Fog::Compute[:aws].volumes, {:availability_zone => @server.availability_zone, :size => 1, :device => '/dev/sdz1', :tags => {"key" => "value"}}, true) do
 
     @instance.wait_for { ready? }
 
@@ -31,6 +31,10 @@ Shindo.tests("Fog::Compute[:aws] | volume", ['aws']) do
     end
 
     @instance.wait_for { ready? }
+
+    tests('@instance.reload.tags').returns({'key' => 'value'}) do
+      @instance.reload.tags
+    end
 
   end
 


### PR DESCRIPTION
Same approach as used for server tags for issue #366

---

I need a bit of guidance to add tests for this.
