### PR TITLE
Fix for Issue #845 - Parsing error for EC instances with networkInterfaceSet tag

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_instances.rb
@@ -8,7 +8,7 @@ module Fog
           def reset
             @block_device_mapping = {}
             @context = []
-            @contexts = ['blockDeviceMapping', 'groupSet', 'instancesSet', 'instanceState', 'placement', 'productCodes', 'stateReason', 'tagSet']
+            @contexts = ['blockDeviceMapping', 'groupSet', 'instancesSet', 'instanceState', 'networkInterfaceSet', 'placement', 'productCodes', 'stateReason', 'tagSet']
             @instance = { 'blockDeviceMapping' => [], 'instanceState' => {}, 'monitoring' => {}, 'placement' => {}, 'productCodes' => [], 'stateReason' => {}, 'tagSet' => {} }
             @reservation = { 'groupSet' => [], 'instancesSet' => [] }
             @response = { 'reservationSet' => [] }


### PR DESCRIPTION
Fixes a problem parsing the AWS describe_instances request when the response includes content within a networkInterfaceSet element.
