### PR TITLE
describe_instances parser always returns false

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_instances.rb
@@ -78,7 +78,7 @@ module Fog
             when 'productCode'
               @instance['productCodes'] << value
             when 'state'
-              @instance['monitoring'][name] = (value == 'true')
+              @instance['monitoring'][name] = (value == 'enabled')
             end
           end
 


### PR DESCRIPTION
Hi,

Based on AWS documentation monitoring-state is either disabled or enabled. Parser was checking if it is true or false.
              <monitoring>
                <state>enabled</state>
              </monitoring>

best wishes,
Oz 
