### PR TITLE
reserved instance hourly cost was empty

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
@@ -16,7 +16,7 @@ module Fog
               @reserved_instance[name] = value
             when 'duration', 'instanceCount'
               @reserved_instance[name] = value.to_i
-            when 'fixedPrice', 'usagePrice'
+            when 'fixedPrice', 'amount'
               @reserved_instance[name] = value.to_f
             when 'item'
               @response['reservedInstancesSet'] << @reserved_instance


### PR DESCRIPTION
Hi,

AWS has changed the result set for describe reserved instances call. UsagePrice is always 0 while amount gives the correct hourly cost of a reserved instances.

best wishes,
Oz
