### PR TITLE
Allow for stringified options keys in Fog::Service#new

### DIFF
--- a/lib/fog/core/service.rb
+++ b/lib/fog/core/service.rb
@@ -48,6 +48,7 @@ module Fog
 
       def new(options={})
         # attempt to load credentials from config file
+        options = Fog.symbolize_credentials(options)
         begin
           default_credentials = Fog.credentials.reject {|key, value| !(recognized | requirements).include?(key)}
           options = default_credentials.merge(options)


### PR DESCRIPTION
Fog::Service#validate_options fails in case of using HashWithIndifferentAccess ( or Hash with stringified keys ) as options
