### PR TITLE
[AWS|Auto Scale] Add support for PutNotificationConfiguration

### DIFF
--- a/lib/fog/aws/auto_scaling.rb
+++ b/lib/fog/aws/auto_scaling.rb
@@ -32,6 +32,7 @@ module Fog
       request :execute_policy
       request :put_scaling_policy
       request :put_scheduled_update_group_action
+      request :put_notification_configuration
       request :resume_processes
       request :set_desired_capacity
       request :set_instance_health
@@ -103,7 +104,7 @@ module Fog
               :host               => @host,
               :path               => @path,
               :port               => @port,
-              :version            => '2010-08-01'
+              :version            => '2011-01-01'
             }
           )
 

--- a/lib/fog/aws/parsers/auto_scaling/put_notification_configuration.rb
+++ b/lib/fog/aws/parsers/auto_scaling/put_notification_configuration.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Parsers
+    module AWS
+      module AutoScaling
+
+        class PutNotificationConfiguration < Fog::Parsers::Base
+
+          def reset
+            @response = { 'ResponseMetadata' => {} }
+          end
+
+          def start_element(name, attrs = [])
+            super
+          end
+          
+          def end_element(name)
+            case name
+            when 'RequestId'
+              @response['ResponseMetadata'][name] = value
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/auto_scaling/put_notification_configuration.rb
+++ b/lib/fog/aws/requests/auto_scaling/put_notification_configuration.rb
@@ -1,0 +1,51 @@
+module Fog
+  module AWS
+    class AutoScaling
+
+      class Real
+
+        require 'fog/aws/parsers/auto_scaling/put_notification_configuration'
+
+        # Creates a notification configuration for an Auto Scaling group. To update an
+        # existing policy, overwrite the existing notification configuration name 
+        # and set the parameter(s) you want to change. 
+        #
+        # ==== Parameters
+        # * auto_scaling_group_name<~String> - The name of the Auto Scaling group.
+        # * notification_types<~Array> - The type of events that will trigger the 
+        #   notification.
+        # * topic_arn<~String> - The Amazon Resource Name (ARN) of the Amazon 
+        #   Simple Notification Service (SNS) topic.
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'ResponseMetadata'<~Hash>:
+        #       * 'RequestId'<~String> - Id of request
+        #
+        # ==== See Also
+        # http://docs.amazonwebservices.com/AutoScaling/latest/APIReference/API_PutNotificationConfiguration.html
+        #
+        def put_notification_configuration(auto_scaling_group_name, notification_types, topic_arn)
+          options = {}
+          options.merge!(AWS.indexed_param('NotificationTypes.member.%d', [*notification_types]))
+          request({
+            'Action'               => 'PutNotificationConfiguration',
+            'AutoScalingGroupName' => auto_scaling_group_name,
+            'TopicARN'             => topic_arn,
+            :parser                => Fog::Parsers::AWS::AutoScaling::PutNotificationConfiguration.new
+          }.merge!(options))
+        end
+
+      end
+
+      class Mock
+
+        def put_notification_configuration(auto_scaling_group_name, notification_types, topic_arn)
+          Fog::Mock.not_implemented
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
[AWS|Auto Scale] Add support for put_notification_configuration and change AWS API for Autoscale to use 01-01-2011 version which support PutNotificationConfiguration, http://docs.amazonwebservices.com/AutoScaling/latest/APIReference/API_PutNotificationConfiguration.html
Likely more things to add for 01-01-2011 version but will add as we hit them.
