### PR TITLE
[aws|dns] fix get, all, and all!

### DIFF
--- a/lib/fog/aws/models/dns/records.rb
+++ b/lib/fog/aws/models/dns/records.rb
@@ -23,9 +23,10 @@ module Fog
         def all(options = {})
           requires :zone
           options[:max_items]  ||= max_items
-          options[:name]       ||= name
+          options[:name]       ||= zone.domain
           options[:type]       ||= type
           options[:identifier] ||= identifier
+          options.delete_if {|key, value| value.nil?}
 
           data = connection.list_resource_record_sets(zone.id, options).body
           # NextRecordIdentifier is completely absent instead of nil, so set to nil, or iteration breaks.
@@ -49,6 +50,8 @@ module Fog
                 :type => next_record_type,
                 :identifier => next_record_identifier
             }
+            options.delete_if {|key, value| value.nil?}
+
             batch = connection.list_resource_record_sets(zone.id, options).body
             # NextRecordIdentifier is completely absent instead of nil, so set to nil, or iteration breaks.
             batch['NextRecordIdentifier'] = nil unless batch.has_key?('NextRecordIdentifier')
@@ -82,6 +85,7 @@ module Fog
               :type => record_type,
               :identifier => record_identifier
           }
+          options.delete_if {|key, value| value.nil?}
 
           data = connection.list_resource_record_sets(zone.id, options).body
           # Get first record


### PR DESCRIPTION
get and all returned AWS error responses about empty values being specified.  Existing shindo
tests already covered these cases as this:

FOG_MOCK=false bundle exec shindont tests/aws/models/dns/records_tests.rb

was reporting 6 failures before this fix.

Tests (and apps) pass after fix.
