### PR TITLE
Add support for ports in AWS storage URLs

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -141,7 +141,7 @@ module Fog
 
         def url(expires, options = {})
           requires :key
-          collection.get_https_url(key, expires, options)
+          collection.get_url(key, expires, options)
         end
 
         def versions

--- a/lib/fog/aws/models/storage/files.rb
+++ b/lib/fog/aws/models/storage/files.rb
@@ -78,6 +78,11 @@ module Fog
           end
         end
 
+        def get_url(key, expires, options = {})
+          requires :directory
+          connection.get_object_url(directory.key, key, expires, options)
+        end
+
         def get_http_url(key, expires, options = {})
           requires :directory
           connection.get_object_http_url(directory.key, key, expires, options)

--- a/lib/fog/aws/requests/storage/get_object_http_url.rb
+++ b/lib/fog/aws/requests/storage/get_object_http_url.rb
@@ -19,6 +19,7 @@ module Fog
           http_url({
             :headers  => {},
             :host     => host,
+            :port     => @port,
             :method   => 'GET',
             :path     => path,
             :query    => options[:query]

--- a/lib/fog/aws/requests/storage/get_object_https_url.rb
+++ b/lib/fog/aws/requests/storage/get_object_https_url.rb
@@ -5,24 +5,7 @@ module Fog
       module GetObjectHttpsUrl
 
         def get_object_https_url(bucket_name, object_name, expires, options = {})
-          unless bucket_name
-            raise ArgumentError.new('bucket_name is required')
-          end
-          unless object_name
-            raise ArgumentError.new('object_name is required')
-          end
-          host, path = if bucket_name =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\-(?![\.])){1,61}[a-z0-9]$/
-            ["#{bucket_name}.#{@host}", object_name]
-          else
-            [@host, "#{bucket_name}/#{object_name}"]
-          end
-          https_url({
-            :headers  => {},
-            :host     => host,
-            :method   => 'GET',
-            :path     => path,
-            :query    => options[:query]
-          }, expires)
+          get_object_url(bucket_name, object_name, expires, options.merge(:scheme => 'https'))
         end
 
       end

--- a/lib/fog/aws/requests/storage/put_object_url.rb
+++ b/lib/fog/aws/requests/storage/put_object_url.rb
@@ -1,6 +1,26 @@
 module Fog
   module Storage
     class AWS
+      module PutObjectUrl
+
+        def put_object_url(bucket_name, object_name, expires, headers = {}, options = {})
+          unless bucket_name
+            raise ArgumentError.new('bucket_name is required')
+          end
+          unless object_name
+            raise ArgumentError.new('object_name is required')
+          end
+          scheme_host_path_query({
+            :scheme   => options[:scheme],
+            :headers  => headers,
+            :host     => @host,
+            :port     => @port,
+            :method   => 'PUT',
+            :path     => "#{bucket_name}/#{object_name}"
+          }, expires)
+        end
+      end
+
       class Real
 
         # Get an expiring object url from S3 for putting an object
@@ -17,39 +37,13 @@ module Fog
         # ==== See Also
         # http://docs.amazonwebservices.com/AmazonS3/latest/dev/S3_QSAuth.html
 
-        def put_object_url(bucket_name, object_name, expires, headers = {})
-          unless bucket_name
-            raise ArgumentError.new('bucket_name is required')
-          end
-          unless object_name
-            raise ArgumentError.new('object_name is required')
-          end
-          https_url({
-            :headers  => headers,
-            :host     => @host,
-            :method   => 'PUT',
-            :path     => "#{bucket_name}/#{object_name}"
-          }, expires)
-        end
+        include PutObjectUrl
 
       end
 
       class Mock # :nodoc:all
 
-        def put_object_url(bucket_name, object_name, expires, headers = {})
-          unless bucket_name
-            raise ArgumentError.new('bucket_name is required')
-          end
-          unless object_name
-            raise ArgumentError.new('object_name is required')
-          end
-          https_url({
-            :headers  => headers,
-            :host     => @host,
-            :method   => 'PUT',
-            :path     => "#{bucket_name}/#{object_name}"
-          }, expires)
-        end
+        include PutObjectUrl
 
       end
     end

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -71,11 +71,11 @@ module Fog
         end
 
         def http_url(params, expires)
-          "http://" << host_path_query(params, expires)
+          scheme_host_path_query(params.merge(:scheme => 'http', :port => 80), expires)
         end
 
         def https_url(params, expires)
-          "https://" << host_path_query(params, expires)
+          scheme_host_path_query(params.merge(:scheme => 'https', :port => 443), expires)
         end
 
         def url(params, expires)
@@ -85,7 +85,14 @@ module Fog
 
         private
 
-        def host_path_query(params, expires)
+        def scheme_host_path_query(params, expires)
+          params[:scheme] ||= @scheme
+          if params[:port] == 80 && params[:scheme] == 'http'
+            params.delete(:port)
+          end
+          if params[:port] == 443 && params[:scheme] == 'https'
+            params.delete(:port)
+          end
           params[:headers] ||= {}
           params[:headers]['Date'] = expires.to_i
           params[:path] = Fog::AWS.escape(params[:path]).gsub('%2F', '/')
@@ -98,7 +105,8 @@ module Fog
           query << "AWSAccessKeyId=#{@aws_access_key_id}"
           query << "Signature=#{Fog::AWS.escape(signature(params))}"
           query << "Expires=#{params[:headers]['Date']}"
-          "#{params[:host]}/#{params[:path]}?#{query.join('&')}"
+          port_part = params[:port] && ":#{params[:port]}"
+          "#{params[:scheme]}://#{params[:host]}#{port_part}/#{params[:path]}?#{query.join('&')}"
         end
 
       end
@@ -197,6 +205,7 @@ module Fog
           else
             "s3-#{options[:region]}.amazonaws.com"
           end
+          @scheme = options[:scheme] || 'https'
           @region = options[:region]
         end
 


### PR DESCRIPTION
- Introduce put_object_http_url request
  This is useful for when using fake S3 implementations
- Automatically detect default scheme based on the connection
