### PR TITLE
Adds Support for AWS DynamoDB batch_put_item

### DIFF
--- a/lib/fog/aws/dynamodb.rb
+++ b/lib/fog/aws/dynamodb.rb
@@ -9,6 +9,7 @@ module Fog
 
       request_path 'fog/aws/requests/dynamodb'
       request :batch_get_item
+      request :batch_put_item
       request :create_table
       request :delete_item
       request :delete_table

--- a/lib/fog/aws/requests/dynamodb/batch_put_item.rb
+++ b/lib/fog/aws/requests/dynamodb/batch_put_item.rb
@@ -1,0 +1,30 @@
+module Fog
+  module AWS
+    class DynamoDB
+      class Real
+
+        #request_items has form:
+        #{"table_name"=>
+        #  [{"PutRequest"=>
+        #    {"Item"=>
+        #      {"hash_key"=>{"N"=>"99"},
+        #       "range_key"=>{"N"=>"99"},
+        #       "attribute"=>{"S"=>"hi"}
+        #       }}}, ... ]}
+        # For more information:
+        # http://docs.amazonwebservices.com/amazondynamodb/latest/developerguide/API_BatchWriteItems.html
+        def batch_put_item(request_items)
+          body = {
+            'RequestItems' => request_items
+          }
+
+          request(
+            :body       => MultiJson.encode(body),
+            :headers    => {'x-amz-target' => 'DynamoDB_20111205.BatchWriteItem'}
+          )
+        end
+
+      end
+    end
+  end
+end

--- a/tests/aws/requests/dynamodb/item_tests.rb
+++ b/tests/aws/requests/dynamodb/item_tests.rb
@@ -43,6 +43,26 @@ Shindo.tests('Fog::AWS[:dynamodb] | item requests', ['aws']) do
       ).body
     end
 
+    @batch_put_item_format = {
+      'Responses'=> {
+        @table_name => {
+          'ConsumedCapacityUnits' => Float}
+      },
+      'UnprocessedItems'=> {}
+    }
+
+    tests("#batch_put_item({ '#{@table_name}' => [{ 'PutRequest' => { 'Item' =>
+            { 'HashKeyElement' => { 'S' => 'key' }, 'RangeKeyElement' => { 'S' => 'key' }}}}]})"
+         ).formats(@batch_put_item_format) do
+            pending if Fog.mocking?
+            Fog::AWS[:dynamodb].batch_put_item(
+              {@table_name => [{'PutRequest'=> {'Item'=>
+                {'HashKeyElement' => { 'S' => 'key' },
+                 'RangeKeyElement' => { 'S' => 'key' }
+                }}}]}
+            ).body
+         end
+
     @get_item_format = {
       'ConsumedCapacityUnits' => Float,
       'Item' => {


### PR DESCRIPTION
Currently, the ruby aws sdk has a "batch_put_item" method, but fog doesn't have this functionality yet.

I forked fog, implemented batch_put_item, wrote a test, and would like someone to review / merge this pull request

Code available here : git@github.com:adgaudio/fog.git

Please review my tests, as I copied the format for batch_get_item.

Thanks!

Alex
