### PR TITLE
Fixed #875: Loosen multi_json version.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -189,11 +189,11 @@ task :changelog do
   changelog << ''
 
   require 'multi_json'
-  github_repo_data = MultiJson.load(Excon.get('http://github.com/api/v2/json/repos/show/fog/fog').body)
+  github_repo_data = Fog::JSON.decode(Excon.get('http://github.com/api/v2/json/repos/show/fog/fog').body)
   data = github_repo_data['repository'].reject {|key, value| !['forks', 'open_issues', 'watchers'].include?(key)}
-  github_collaborator_data = MultiJson.load(Excon.get('http://github.com/api/v2/json/repos/show/fog/fog/collaborators').body)
+  github_collaborator_data = Fog::JSON.decode(Excon.get('http://github.com/api/v2/json/repos/show/fog/fog/collaborators').body)
   data['collaborators'] = github_collaborator_data['collaborators'].length
-  rubygems_data = MultiJson.load(Excon.get('https://rubygems.org/api/v1/gems/fog.json').body)
+  rubygems_data = Fog::JSON.decode(Excon.get('https://rubygems.org/api/v1/gems/fog.json').body)
   data['downloads'] = rubygems_data['downloads']
   stats = []
   for key in data.keys.sort

--- a/bin/fog
+++ b/bin/fog
@@ -23,10 +23,8 @@ end
 
 if ARGV.length > 1
 
-  require 'multi_json'
-
   result = instance_eval(ARGV[1..-1].join(' '))
-  puts(MultiJson.dump(result))
+  puts(Fog::JSON.encode(result))
 
 else
 

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency('builder')
   s.add_dependency('excon', '~>0.13.0')
   s.add_dependency('formatador', '~>0.2.0')
-  s.add_dependency('multi_json', '~>1.3')
+  s.add_dependency('multi_json', '~>1.0')
   s.add_dependency('mime-types')
   s.add_dependency('net-scp', '~>1.0.4')
   s.add_dependency('net-ssh', '>=2.1.3')

--- a/lib/fog/aws/beanstalk.rb
+++ b/lib/fog/aws/beanstalk.rb
@@ -66,7 +66,6 @@ module Fog
 
         def initialize(options={})
           require 'fog/core/parser'
-          require 'multi_json'
 
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]

--- a/lib/fog/aws/cloud_formation.rb
+++ b/lib/fog/aws/cloud_formation.rb
@@ -46,7 +46,6 @@ module Fog
         # * CloudFormation object with connection to AWS.
         def initialize(options={})
           require 'fog/core/parser'
-          require 'multi_json'
 
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]

--- a/lib/fog/aws/dynamodb.rb
+++ b/lib/fog/aws/dynamodb.rb
@@ -70,8 +70,6 @@ module Fog
         # ==== Returns
         # * DynamoDB object with connection to aws
         def initialize(options={})
-          require 'multi_json'
-
           if options[:aws_session_token]
             @aws_access_key_id      = options[:aws_access_key_id]
             @aws_secret_access_key  = options[:aws_secret_access_key]
@@ -126,7 +124,7 @@ module Fog
           })
 
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
 
           response

--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -123,7 +123,6 @@ module Fog
         # * IAM object with connection to AWS.
         def initialize(options={})
           require 'fog/core/parser'
-          require 'multi_json'
 
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]

--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -192,13 +192,12 @@ module Fog
 
         def setup(credentials = {})
           requires :public_ip_address, :username
-          require 'multi_json'
           require 'net/ssh'
 
           commands = [
             %{mkdir .ssh},
             %{passwd -l #{username}},
-            %{echo "#{MultiJson.dump(Fog::JSON.sanitize(attributes))}" >> ~/attributes.json}
+            %{echo "#{Fog::JSON.encode(Fog::JSON.sanitize(attributes))}" >> ~/attributes.json}
           ]
           if public_key
             commands << %{echo "#{public_key}" >> ~/.ssh/authorized_keys}

--- a/lib/fog/aws/requests/dynamodb/batch_get_item.rb
+++ b/lib/fog/aws/requests/dynamodb/batch_get_item.rb
@@ -31,7 +31,7 @@ module Fog
           }
 
           request(
-            :body       => MultiJson.dump(body),
+            :body       => Fog::JSON.encode(body),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.BatchGetItem'},
             :idempotent => true
           )

--- a/lib/fog/aws/requests/dynamodb/batch_put_item.rb
+++ b/lib/fog/aws/requests/dynamodb/batch_put_item.rb
@@ -19,7 +19,7 @@ module Fog
           }
 
           request(
-            :body       => MultiJson.encode(body),
+            :body       => Fog::JSON.encode(body),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.BatchWriteItem'}
           )
         end

--- a/lib/fog/aws/requests/dynamodb/create_table.rb
+++ b/lib/fog/aws/requests/dynamodb/create_table.rb
@@ -43,7 +43,7 @@ module Fog
           }
 
           request(
-            :body       => MultiJson.dump(body),
+            :body       => Fog::JSON.encode(body),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.CreateTable'},
             :idempotent => true
           )

--- a/lib/fog/aws/requests/dynamodb/delete_item.rb
+++ b/lib/fog/aws/requests/dynamodb/delete_item.rb
@@ -33,7 +33,7 @@ module Fog
           }.merge(options)
 
           request(
-            :body       => MultiJson.dump(body),
+            :body       => Fog::JSON.encode(body),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.DeleteItem'},
             :idempotent => true
           )

--- a/lib/fog/aws/requests/dynamodb/delete_table.rb
+++ b/lib/fog/aws/requests/dynamodb/delete_table.rb
@@ -30,7 +30,7 @@ module Fog
           }
 
           request(
-            :body       => MultiJson.dump(body),
+            :body       => Fog::JSON.encode(body),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.DeleteTable'},
             :idempotent => true
           )

--- a/lib/fog/aws/requests/dynamodb/describe_table.rb
+++ b/lib/fog/aws/requests/dynamodb/describe_table.rb
@@ -32,7 +32,7 @@ module Fog
           }
 
           request(
-            :body       => MultiJson.dump(body),
+            :body       => Fog::JSON.encode(body),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.DescribeTable'},
             :idempotent => true
           )

--- a/lib/fog/aws/requests/dynamodb/get_item.rb
+++ b/lib/fog/aws/requests/dynamodb/get_item.rb
@@ -31,7 +31,7 @@ module Fog
           }.merge(options)
 
           request(
-            :body       => MultiJson.dump(body),
+            :body       => Fog::JSON.encode(body),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.GetItem'},
             :idempotent => true
           )

--- a/lib/fog/aws/requests/dynamodb/list_tables.rb
+++ b/lib/fog/aws/requests/dynamodb/list_tables.rb
@@ -17,7 +17,7 @@ module Fog
         #     * 'TableNames'<~Array> - table names
         def list_tables(options = {})
           request(
-            :body       => MultiJson.dump(options),
+            :body       => Fog::JSON.encode(options),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.ListTables'},
             :idempotent => true
           )

--- a/lib/fog/aws/requests/dynamodb/put_item.rb
+++ b/lib/fog/aws/requests/dynamodb/put_item.rb
@@ -30,7 +30,7 @@ module Fog
           }.merge(options)
 
           request(
-            :body       => MultiJson.dump(body),
+            :body       => Fog::JSON.encode(body),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.PutItem'}
           )
         end

--- a/lib/fog/aws/requests/dynamodb/query.rb
+++ b/lib/fog/aws/requests/dynamodb/query.rb
@@ -33,7 +33,7 @@ module Fog
           }.merge(options)
 
           request(
-            :body     => MultiJson.dump(body),
+            :body     => Fog::JSON.encode(body),
             :headers  => {'x-amz-target' => 'DynamoDB_20111205.Query'}
           )
         end

--- a/lib/fog/aws/requests/dynamodb/scan.rb
+++ b/lib/fog/aws/requests/dynamodb/scan.rb
@@ -33,7 +33,7 @@ module Fog
           }.merge(options)
 
           request(
-            :body     => MultiJson.dump(body),
+            :body     => Fog::JSON.encode(body),
             :headers  => {'x-amz-target' => 'DynamoDB_20111205.Scan'},
             :idempotent => true
           )

--- a/lib/fog/aws/requests/dynamodb/update_item.rb
+++ b/lib/fog/aws/requests/dynamodb/update_item.rb
@@ -38,7 +38,7 @@ module Fog
           }.merge(options)
 
           request(
-            :body     => MultiJson.dump(body),
+            :body     => Fog::JSON.encode(body),
             :headers  => {'x-amz-target' => 'DynamoDB_20111205.UpdateItem'}
           )
         end

--- a/lib/fog/aws/requests/dynamodb/update_table.rb
+++ b/lib/fog/aws/requests/dynamodb/update_table.rb
@@ -34,7 +34,7 @@ module Fog
           }
 
           request(
-            :body       => MultiJson.dump(body),
+            :body       => Fog::JSON.encode(body),
             :headers    => {'x-amz-target' => 'DynamoDB_20111205.UpdateTable'},
             :idempotent => true
           )

--- a/lib/fog/aws/requests/iam/put_group_policy.rb
+++ b/lib/fog/aws/requests/iam/put_group_policy.rb
@@ -25,7 +25,7 @@ module Fog
             'Action'          => 'PutGroupPolicy',
             'GroupName'       => group_name,
             'PolicyName'      => policy_name,
-            'PolicyDocument'  => MultiJson.dump(policy_document),
+            'PolicyDocument'  => Fog::JSON.encode(policy_document),
             :parser           => Fog::Parsers::AWS::IAM::Basic.new
           )
         end

--- a/lib/fog/aws/requests/iam/put_user_policy.rb
+++ b/lib/fog/aws/requests/iam/put_user_policy.rb
@@ -24,7 +24,7 @@ module Fog
           request(
             'Action'          => 'PutUserPolicy',
             'PolicyName'      => policy_name,
-            'PolicyDocument'  => MultiJson.dump(policy_document),
+            'PolicyDocument'  => Fog::JSON.encode(policy_document),
             'UserName'        => user_name,
             :parser           => Fog::Parsers::AWS::IAM::Basic.new
           )

--- a/lib/fog/aws/requests/storage/get_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/get_bucket_policy.rb
@@ -27,7 +27,7 @@ module Fog
             :method     => 'GET',
             :query      => {'policy' => nil}
           })
-          response.body = MultiJson.load(response.body) unless response.body.nil?
+          response.body = Fog::JSON.decode(response.body) unless response.body.nil?
         end
 
       end

--- a/lib/fog/aws/requests/storage/post_object_hidden_fields.rb
+++ b/lib/fog/aws/requests/storage/post_object_hidden_fields.rb
@@ -27,7 +27,7 @@ module Fog
 
         def post_object_hidden_fields(options = {})
           if options['policy']
-            options['policy'] = Base64.encode64(MultiJson.dump(options['policy'])).gsub("\n", "")
+            options['policy'] = Base64.encode64(Fog::JSON.encode(options['policy'])).gsub("\n", "")
             options['AWSAccessKeyId'] = @aws_access_key_id
             options['Signature'] = Base64.encode64(@hmac.sign(options['policy'])).gsub("\n", "")
           end

--- a/lib/fog/aws/requests/storage/put_bucket_policy.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_policy.rb
@@ -14,7 +14,7 @@ module Fog
 
         def put_bucket_policy(bucket_name, policy)
           request({
-            :body     => MultiJson.dump(policy),
+            :body     => Fog::JSON.encode(policy),
             :expects  => 204,
             :headers  => {},
             :host     => "#{bucket_name}.#{@host}",

--- a/lib/fog/aws/requests/sts/get_federation_token.rb
+++ b/lib/fog/aws/requests/sts/get_federation_token.rb
@@ -9,7 +9,7 @@ module Fog
           request({
             'Action'          => 'GetFederationToken',
             'Name'            => name,
-            'Policy'          => MultiJson.dump(policy),
+            'Policy'          => Fog::JSON.encode(policy),
             'DurationSeconds' => duration,
             :idempotent       => true,
             :parser           => Fog::Parsers::AWS::STS::GetSessionToken.new

--- a/lib/fog/aws/sns.rb
+++ b/lib/fog/aws/sns.rb
@@ -49,7 +49,6 @@ module Fog
         # ==== Returns
         # * SNS object with connection to AWS.
         def initialize(options={})
-          require 'multi_json'
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]
           @connection_options     = options[:connection_options] || {}

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -195,7 +195,6 @@ module Fog
 
         def initialize(options={})
           require 'mime/types'
-          require 'multi_json'
           @aws_access_key_id = options[:aws_access_key_id]
           @aws_secret_access_key = options[:aws_secret_access_key]
           options[:region] ||= 'us-east-1'

--- a/lib/fog/aws/sts.rb
+++ b/lib/fog/aws/sts.rb
@@ -66,7 +66,6 @@ module Fog
         # * STS object with connection to AWS.
         def initialize(options={})
           require 'fog/core/parser'
-          require 'multi_json'
 
           @aws_access_key_id      = options[:aws_access_key_id]
           @aws_secret_access_key  = options[:aws_secret_access_key]

--- a/lib/fog/bluebox/compute.rb
+++ b/lib/fog/bluebox/compute.rb
@@ -62,7 +62,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
           @bluebox_api_key      = options[:bluebox_api_key]
           @bluebox_customer_id  = options[:bluebox_customer_id]
           @connection_options   = options[:connection_options] || {}
@@ -94,7 +93,7 @@ module Fog
             end
           end
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/bluebox/models/compute/server.rb
+++ b/lib/fog/bluebox/models/compute/server.rb
@@ -121,7 +121,7 @@ module Fog
             %{mkdir .ssh},
             %{echo "#{public_key}" >> ~/.ssh/authorized_keys},
             %{passwd -l #{username}},
-            %{echo "#{MultiJson.dump(attributes)}" >> ~/attributes.json}
+            %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json}
           ])
         rescue Errno::ECONNREFUSED
           sleep(1)

--- a/lib/fog/brightbox/compute.rb
+++ b/lib/fog/brightbox/compute.rb
@@ -117,7 +117,6 @@ module Fog
       class Real
 
         def initialize(options)
-          require 'multi_json'
           # Currently authentication and api endpoints are the same but may change
           @auth_url             = options[:brightbox_auth_url] || Fog.credentials[:brightbox_auth_url] || API_URL
           @api_url              = options[:brightbox_api_url] || Fog.credentials[:brightbox_api_url] || API_URL
@@ -134,7 +133,7 @@ module Fog
             :path     => url,
             :expects  => expected_responses
           }
-          request_options[:body] = MultiJson.dump(options) unless options.nil?
+          request_options[:body] = Fog::JSON.encode(options) unless options.nil?
           make_request(request_options)
         end
 
@@ -147,7 +146,7 @@ module Fog
           auth_url = options[:brightbox_auth_url] || @auth_url
 
           connection = Fog::Connection.new(auth_url)
-          @authentication_body = MultiJson.dump({'client_id' => @brightbox_client_id, 'grant_type' => 'none'})
+          @authentication_body = Fog::JSON.encode({'client_id' => @brightbox_client_id, 'grant_type' => 'none'})
 
           response = connection.request({
             :path => "/token",
@@ -159,7 +158,7 @@ module Fog
             :method   => 'POST',
             :body     => @authentication_body
           })
-          @oauth_token = MultiJson.load(response.body)["access_token"]
+          @oauth_token = Fog::JSON.decode(response.body)["access_token"]
           return @oauth_token
         end
 
@@ -172,7 +171,7 @@ module Fog
             response = authenticated_request(params)
           end
           unless response.body.empty?
-            response = MultiJson.load(response.body)
+            response = Fog::JSON.decode(response.body)
           end
         end
 

--- a/lib/fog/brightbox/requests/compute/resize_server.rb
+++ b/lib/fog/brightbox/requests/compute/resize_server.rb
@@ -9,7 +9,7 @@ module Fog
             :method   => 'POST',
             :path     => "/1.0/servers/#{identifier}/resize",
             :headers  => {"Content-Type" => "application/json"},
-            :body     => MultiJson.dump(options)
+            :body     => Fog::JSON.encode(options)
           )
         end
 

--- a/lib/fog/clodo/compute.rb
+++ b/lib/fog/clodo/compute.rb
@@ -57,7 +57,6 @@ module Fog
         end
 
         def initialize(options={})
-          require 'multi_json'
           @clodo_username = options[:clodo_username]
         end
 
@@ -74,7 +73,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
           @clodo_api_key = options[:clodo_api_key]
           @clodo_username = options[:clodo_username]
           @clodo_auth_url = options[:clodo_auth_url]
@@ -119,7 +117,7 @@ module Fog
             end
           end
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/clodo/models/compute/server.rb
+++ b/lib/fog/clodo/models/compute/server.rb
@@ -121,7 +121,7 @@ module Fog
             %{mkdir .ssh},
             %{echo "#{public_key}" >> ~/.ssh/authorized_keys},
             %{passwd -l #{username}},
-            %{echo "#{MultiJson.dump(attributes)}" >> ~/attributes.json},
+            %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json},
           ])
         rescue Errno::ECONNREFUSED
           sleep(1)

--- a/lib/fog/clodo/requests/compute/create_server.rb
+++ b/lib/fog/clodo/requests/compute/create_server.rb
@@ -30,7 +30,7 @@ module Fog
           data['server'].merge! options if options
 
           request(
-                  :body     => MultiJson.dump(data),
+                  :body     => Fog::JSON.encode(data),
                   :expects  => [200, 202],
                   :method   => 'POST',
                   :path     => 'servers'

--- a/lib/fog/clodo/requests/compute/delete_ip_address.rb
+++ b/lib/fog/clodo/requests/compute/delete_ip_address.rb
@@ -19,7 +19,7 @@ module Fog
                   :expects  => [204],
                   :method   => 'DELETE',
                   :path     => "servers/#{server_id}/ips",
-                  :body     => MultiJson.dump(data)
+                  :body     => Fog::JSON.encode(data)
                   )
         end
       end

--- a/lib/fog/clodo/requests/compute/move_ip_address.rb
+++ b/lib/fog/clodo/requests/compute/move_ip_address.rb
@@ -17,7 +17,7 @@ module Fog
                   :expects  => [204],
                   :method   => 'GET',
                   :path     => "servers/#{server_id}/ips/moveip",
-                  :body     => MultiJson.dump({'ip'=>"#{ip}"})
+                  :body     => Fog::JSON.encode({'ip'=>"#{ip}"})
                   )
         end
       end

--- a/lib/fog/clodo/requests/compute/server_action.rb
+++ b/lib/fog/clodo/requests/compute/server_action.rb
@@ -4,7 +4,7 @@ module Fog
       class Real
         def server_action(id, action)
           request(
-                  :body    => MultiJson.dump(action),
+                  :body    => Fog::JSON.encode(action),
                   :expects => [204],
                   :method  => 'POST',
                   :path    => "servers/#{id}/action")

--- a/lib/fog/cloudstack/compute.rb
+++ b/lib/fog/cloudstack/compute.rb
@@ -135,7 +135,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'          
           @cloudstack_api_key         = options[:cloudstack_api_key]
           @cloudstack_secret_access_key = options[:cloudstack_secret_access_key]
           @cloudstack_session_id      = options[:cloudstack_session_id]
@@ -165,7 +164,7 @@ module Fog
           sessionid = cookies['JSESSIONID'].first
 
           # Decode the login response
-          response   = MultiJson.load(response.body)
+          response   = Fog::JSON.decode(response.body)
           
           user = response['loginresponse']
           user.merge!('sessionid' => sessionid)
@@ -188,7 +187,7 @@ module Fog
           end
 
           response = issue_request(params,headers)
-          response = MultiJson.load(response.body) unless response.body.empty?
+          response = Fog::JSON.decode(response.body) unless response.body.empty?
           response
         end
 
@@ -232,7 +231,7 @@ module Fog
             })
             
           rescue Excon::Errors::HTTPStatusError => error
-            error_response = MultiJson.load(error.response.body)
+            error_response = Fog::JSON.decode(error.response.body)
             
             error_code = error_response.values.first['errorcode']
             error_text = error_response.values.first['errortext']

--- a/lib/fog/core/collection.rb
+++ b/lib/fog/core/collection.rb
@@ -121,8 +121,7 @@ module Fog
     end
 
     def to_json(options = {})
-      require 'multi_json'
-      MultiJson.dump(self.map {|member| member.attributes})
+      Fog::JSON.encode(self.map {|member| member.attributes})
     end
 
     private

--- a/lib/fog/core/json.rb
+++ b/lib/fog/core/json.rb
@@ -1,3 +1,5 @@
+require 'multi_json'
+
 module Fog
   module JSON
 
@@ -15,6 +17,30 @@ module Fog
         data
       end
     end
+
+    # Do the MultiJson introspection at this level so we can define our encode/decode methods and perform
+    # the introspection only once rather than once per call.
+
+    if MultiJson.respond_to?(:dump)
+      def self.encode(obj)
+        MultiJson.encode(obj)
+      end
+    else
+      def self.encode(obj)
+        MultiJson.encode(obj)
+      end
+    end
+
+    if MultiJson.respond_to?(:load)
+      def self.decode(obj)
+        Fog::JSON.decode(obj)
+      end
+    else
+      def self.decode(obj)
+        MultiJson.decode(obj)
+      end
+    end
+
 
   end
 end

--- a/lib/fog/core/model.rb
+++ b/lib/fog/core/model.rb
@@ -38,8 +38,7 @@ module Fog
     end
 
     def to_json(options = {})
-      require 'multi_json'
-      MultiJson.dump(attributes)
+      Fog::JSON.encode(attributes)
     end
 
     def symbolize_keys(hash)

--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -55,8 +55,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
-
           @dnsimple_email = options[:dnsimple_email]
           @dnsimple_password  = options[:dnsimple_password]
           @connection_options = options[:connection_options] || {}
@@ -87,7 +85,7 @@ module Fog
           response = @connection.request(params.merge!({:host => @host}))
 
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/dnsimple/requests/dns/create_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/create_domain.rb
@@ -14,7 +14,7 @@ module Fog
         def create_domain(name)
           body = { "domain" => { "name" => name } }
           request(
-                  :body     => MultiJson.dump(body),
+                  :body     => Fog::JSON.encode(body),
                   :expects  => 201,
                   :method   => 'POST',
                   :path     => '/domains'

--- a/lib/fog/dnsimple/requests/dns/create_record.rb
+++ b/lib/fog/dnsimple/requests/dns/create_record.rb
@@ -36,7 +36,7 @@ module Fog
 
           body["record"].merge!(options)
 
-          request( :body     => MultiJson.dump(body),
+          request( :body     => Fog::JSON.encode(body),
                    :expects  => 201,
                    :method   => 'POST',
                    :path     => "/domains/#{domain}/records" )

--- a/lib/fog/dnsimple/requests/dns/update_record.rb
+++ b/lib/fog/dnsimple/requests/dns/update_record.rb
@@ -30,7 +30,7 @@ module Fog
 
           body = { "record" => options }
 
-          request( :body     => MultiJson.dump(body),
+          request( :body     => Fog::JSON.encode(body),
                    :expects  => 200,
                    :method   => "PUT",
                    :path     => "/domains/#{domain}/records/#{record_id}" )

--- a/lib/fog/dnsmadeeasy/dns.rb
+++ b/lib/fog/dnsmadeeasy/dns.rb
@@ -80,7 +80,6 @@ module Fog
         # * dns object with connection to aws.
         def initialize(options={})
           require 'fog/core/parser'
-          require 'multi_json'
 
           @dnsmadeeasy_api_key = options[:dnsmadeeasy_api_key]
           @dnsmadeeasy_secret_key = options[:dnsmadeeasy_secret_key]
@@ -119,7 +118,7 @@ module Fog
           end
 
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
 
           response

--- a/lib/fog/dnsmadeeasy/requests/dns/create_record.rb
+++ b/lib/fog/dnsmadeeasy/requests/dns/create_record.rb
@@ -52,7 +52,7 @@ module Fog
             :expects  => 201,
             :method   => "POST",
             :path     => "/V1.2/domains/#{domain}/records",
-            :body     => MultiJson.dump(body)
+            :body     => Fog::JSON.encode(body)
           )
         end
 

--- a/lib/fog/dnsmadeeasy/requests/dns/create_secondary.rb
+++ b/lib/fog/dnsmadeeasy/requests/dns/create_secondary.rb
@@ -26,7 +26,7 @@ module Fog
             :expects  => 201,
             :method   => 'PUT',
             :path     => "/V1.2/secondary/#{secondary_name}",
-            :body     => MultiJson.dump(body)
+            :body     => Fog::JSON.encode(body)
           )
         end
 

--- a/lib/fog/dnsmadeeasy/requests/dns/update_record.rb
+++ b/lib/fog/dnsmadeeasy/requests/dns/update_record.rb
@@ -46,7 +46,7 @@ module Fog
             :expects  => 200,
             :method   => "PUT",
             :path     => "/V1.2/domains/#{domain}/records/#{record_id}",
-            :body     => MultiJson.dump(options)
+            :body     => Fog::JSON.encode(options)
           )
         end
 

--- a/lib/fog/dnsmadeeasy/requests/dns/update_secondary.rb
+++ b/lib/fog/dnsmadeeasy/requests/dns/update_secondary.rb
@@ -26,7 +26,7 @@ module Fog
             :expects  => 201,
             :method   => 'PUT',
             :path     => "/V1.2/secondary/#{secondary_name}",
-            :body     => MultiJson.dump(body)
+            :body     => Fog::JSON.encode(body)
           )
         end
 

--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -60,8 +60,6 @@ module Fog
 
       class Real
         def initialize(options={})
-          require 'multi_json'
-
           @dynect_customer = options[:dynect_customer]
           @dynect_username = options[:dynect_username]
           @dynect_password = options[:dynect_password]
@@ -95,7 +93,7 @@ module Fog
             if response.status == 307
               response = poll_job(response)
             elsif !response.body.empty?
-              response.body = MultiJson.load(response.body)
+              response.body = Fog::JSON.decode(response.body)
             end
 
             response

--- a/lib/fog/dynect/requests/dns/post_record.rb
+++ b/lib/fog/dynect/requests/dns/post_record.rb
@@ -15,7 +15,7 @@ module Fog
         def post_record(type, zone, fqdn, rdata, options = {})
           options.merge!('rdata' => rdata)
           request(
-            :body     => MultiJson.dump(options),
+            :body     => Fog::JSON.encode(options),
             :expects  => 200,
             :method   => :post,
             :path     => ["#{type.to_s.upcase}Record", zone, fqdn].join('/')

--- a/lib/fog/dynect/requests/dns/post_session.rb
+++ b/lib/fog/dynect/requests/dns/post_session.rb
@@ -8,7 +8,7 @@ module Fog
             :expects  => 200,
             :method   => :post,
             :path     => "Session",
-            :body     => MultiJson.dump({
+            :body     => Fog::JSON.encode({
               :customer_name  => @dynect_customer,
               :user_name      => @dynect_username,
               :password       => @dynect_password

--- a/lib/fog/dynect/requests/dns/post_zone.rb
+++ b/lib/fog/dynect/requests/dns/post_zone.rb
@@ -13,7 +13,7 @@ module Fog
         #   * serial_style<~String> - style of serial number, in ['day', 'epoch', 'increment', 'minute']. Defaults to increment
 
         def post_zone(rname, ttl, zone, options = {})
-          body = MultiJson.dump({
+          body = Fog::JSON.encode({
             :rname  => rname,
             :token  => auth_token,
             :ttl    => ttl

--- a/lib/fog/dynect/requests/dns/put_zone.rb
+++ b/lib/fog/dynect/requests/dns/put_zone.rb
@@ -14,7 +14,7 @@ module Fog
 
         def put_zone(zone, options = {})
           request(
-            :body     => MultiJson.dump(options),
+            :body     => Fog::JSON.encode(options),
             :expects  => 200,
             :method   => :put,
             :path     => 'Zone/' << zone

--- a/lib/fog/glesys/compute.rb
+++ b/lib/fog/glesys/compute.rb
@@ -65,7 +65,6 @@ module Fog
       class Real
 
         def initialize(options)
-          require 'multi_json'
           require 'base64'
 
           @api_url            = options[:glesys_api_url] || Fog.credentials[:glesys_api_url] || API_URL
@@ -94,7 +93,7 @@ module Fog
               }
             )
 
-            data.body = MultiJson.load(data.body)
+            data.body = Fog::JSON.decode(data.body)
 
             response_code =  data.body['response']['status']['code']
 

--- a/lib/fog/go_grid/compute.rb
+++ b/lib/fog/go_grid/compute.rb
@@ -61,7 +61,6 @@ module Fog
 
         def initialize(options={})
           require 'digest/md5'
-          require 'multi_json'
           @go_grid_api_key = options[:go_grid_api_key]
           @go_grid_shared_secret = options[:go_grid_shared_secret]
           @connection_options = options[:connection_options] || {}
@@ -105,7 +104,7 @@ module Fog
           end
 
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
 
           response

--- a/lib/fog/go_grid/models/compute/server.rb
+++ b/lib/fog/go_grid/models/compute/server.rb
@@ -76,8 +76,8 @@ module Fog
             %{mkdir .ssh},
             %{echo "#{public_key}" >> ~/.ssh/authorized_keys},
             %{passwd -l root},
-            %{echo "#{MultiJson.dump(attributes)}" >> ~/attributes.json},
-            %{echo "#{MultiJson.dump(metadata)}" >> ~/metadata.json}
+            %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json},
+            %{echo "#{Fog::JSON.encode(metadata)}" >> ~/metadata.json}
           ])
         rescue Errno::ECONNREFUSED
           sleep(1)

--- a/lib/fog/hp.rb
+++ b/lib/fog/hp.rb
@@ -13,7 +13,7 @@ module Fog
             data = nil
             message = nil
           else
-            data = MultiJson.load(error.response.body)
+            data = Fog::JSON.decode(error.response.body)
             message = data['message']
           end
 
@@ -144,12 +144,12 @@ module Fog
           :host => @host,
           :port => @port,
           :method => 'POST',
-          :body => MultiJson.dump(request_body),
+          :body => Fog::JSON.encode(request_body),
           :path => @auth_path
         }
       )
 
-      body = MultiJson.load(response.body)
+      body = Fog::JSON.decode(response.body)
 
       ### fish out auth_token and endpoint for the service
       auth_token = body['access']['token']['id']

--- a/lib/fog/hp/cdn.rb
+++ b/lib/fog/hp/cdn.rb
@@ -54,7 +54,6 @@ module Fog
         include Utils
 
         def initialize(options={})
-          require 'multi_json'
           @connection_options = options[:connection_options] || {}
           ### Set an option to use the style of authentication desired; :v1 or :v2 (default)
           auth_version = options[:hp_auth_version] || :v2
@@ -119,7 +118,7 @@ module Fog
             end
           end
           if !response.body.empty? && parse_json && response.headers['Content-Type'] =~ %r{application/json}
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/hp/compute.rb
+++ b/lib/fog/hp/compute.rb
@@ -105,7 +105,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
           @hp_secret_key = options[:hp_secret_key]
           @hp_account_id = options[:hp_account_id]
           @hp_servicenet = options[:hp_servicenet]
@@ -167,7 +166,7 @@ module Fog
           end
           unless response.body.empty?
             begin
-              response.body = MultiJson.load(response.body)
+              response.body = Fog::JSON.decode(response.body)
             rescue MultiJson::DecodeError => error
               response.body    #### the body is not in JSON format so just return it as it is
             end

--- a/lib/fog/hp/models/compute/server.rb
+++ b/lib/fog/hp/models/compute/server.rb
@@ -199,8 +199,8 @@ module Fog
             %{mkdir .ssh},
             %{echo "#{public_key}" >> ~/.ssh/authorized_keys},
             %{passwd -l #{username}},
-            %{echo "#{MultiJson.dump(attributes)}" >> ~/attributes.json},
-            %{echo "#{MultiJson.dump(metadata)}" >> ~/metadata.json}
+            %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json},
+            %{echo "#{Fog::JSON.encode(metadata)}" >> ~/metadata.json}
           ])
         rescue Errno::ECONNREFUSED
           sleep(1)

--- a/lib/fog/hp/requests/compute/create_key_pair.rb
+++ b/lib/fog/hp/requests/compute/create_key_pair.rb
@@ -37,7 +37,7 @@ module Fog
           end
 
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => 200,
             :method   => 'POST',
             :path     => 'os-keypairs.json'

--- a/lib/fog/hp/requests/compute/create_security_group.rb
+++ b/lib/fog/hp/requests/compute/create_security_group.rb
@@ -38,7 +38,7 @@ module Fog
           }
 
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => 200,
             :method   => 'POST',
             :path     => 'os-security-groups.json'

--- a/lib/fog/hp/requests/compute/create_security_group_rule.rb
+++ b/lib/fog/hp/requests/compute/create_security_group_rule.rb
@@ -31,7 +31,7 @@ module Fog
           }
 
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => 200,
             :method   => 'POST',
             :path     => 'os-security-group-rules.json'

--- a/lib/fog/hp/requests/compute/create_server.rb
+++ b/lib/fog/hp/requests/compute/create_server.rb
@@ -86,7 +86,7 @@ module Fog
           end
 
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => 202,
             :method   => 'POST',
             :path     => 'servers.json'

--- a/lib/fog/hp/requests/compute/server_action.rb
+++ b/lib/fog/hp/requests/compute/server_action.rb
@@ -12,7 +12,7 @@ module Fog
         #
         def server_action(server_id, body, expects=202)
           request(
-            :body     => MultiJson.dump(body),
+            :body     => Fog::JSON.encode(body),
             :expects  => expects,
             :method   => 'POST',
             :path     => "servers/#{server_id}/action.json"

--- a/lib/fog/hp/requests/compute/update_server.rb
+++ b/lib/fog/hp/requests/compute/update_server.rb
@@ -12,7 +12,7 @@ module Fog
         #   * name<~String> - New name for server
         def update_server(server_id, options = {})
           request(
-            :body     => MultiJson.dump({ 'server' => options }),
+            :body     => Fog::JSON.encode({ 'server' => options }),
             :expects  => 200,
             :method   => 'PUT',
             :path     => "servers/#{server_id}.json"

--- a/lib/fog/hp/storage.rb
+++ b/lib/fog/hp/storage.rb
@@ -126,7 +126,6 @@ module Fog
 
         def initialize(options={})
           require 'mime/types'
-          require 'multi_json'
           @hp_secret_key = options[:hp_secret_key]
           @hp_account_id = options[:hp_account_id]
           @hp_auth_uri   = options[:hp_auth_uri]
@@ -189,7 +188,7 @@ module Fog
             end
           end
           if !response.body.empty? && parse_json && response.headers['Content-Type'] =~ %r{application/json}
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/ibm.rb
+++ b/lib/fog/ibm.rb
@@ -18,7 +18,6 @@ module Fog
     class Connection < Fog::Connection
 
       def initialize(user, password)
-        require 'multi_json'
         @user = user
         @password = password
         @endpoint = URI.parse('https://www-147.ibm.com/computecloud/enterprise/api/rest/20100331')
@@ -38,7 +37,7 @@ module Fog
         end
         response = super(options)
         unless response.body.empty?
-          response.body = MultiJson.load(response.body)
+          response.body = Fog::JSON.decode(response.body)
         end
         response
       end

--- a/lib/fog/joyent/compute.rb
+++ b/lib/fog/joyent/compute.rb
@@ -1,7 +1,6 @@
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'joyent'))
 require File.expand_path(File.join(File.dirname(__FILE__), 'errors'))
 require 'fog/compute'
-require 'multi_json'
 
 module Fog
   module Compute
@@ -144,7 +143,7 @@ module Fog
           }.merge(request[:headers] || {}).merge(@header_method.call) 
 
           if request[:body]
-            request[:body] = MultiJson.dump(request[:body])
+            request[:body] = Fog::JSON.encode(request[:body])
           end
 
           response = @connection.request(request)
@@ -161,7 +160,7 @@ module Fog
         private
 
         def json_decode(body)
-          parsed = MultiJson.load(body)
+          parsed = Fog::JSON.decode(body)
           decode_time_attrs(parsed)
         end
 

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -192,7 +192,6 @@ module Fog
         # Sets up a new key
         def setup(credentials = {})
           requires :public_key, :public_ip_address, :username
-          require 'multi_json'
 
           credentials[:proxy]= ssh_proxy unless ssh_proxy.nil?
           credentials[:password] = password unless self.password.nil?
@@ -201,7 +200,7 @@ module Fog
           commands = [
             %{mkdir .ssh},
             #              %{passwd -l #{username}}, #Not sure if we need this here
-            #              %{echo "#{MultiJson.dump(attributes)}" >> ~/attributes.json}
+            #              %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json}
           ]
           if public_key
             commands << %{echo "#{public_key}" >> ~/.ssh/authorized_keys}

--- a/lib/fog/linode/compute.rb
+++ b/lib/fog/linode/compute.rb
@@ -80,7 +80,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
           @linode_api_key = options[:linode_api_key]
           @host   = options[:host]    || "api.linode.com"
           @port   = options[:port]    || 443
@@ -99,7 +98,7 @@ module Fog
           response = @connection.request(params.merge!({:host => @host}))
 
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
             if data = response.body['ERRORARRAY'].first
               error = case data['ERRORCODE']
               when 5

--- a/lib/fog/linode/dns.rb
+++ b/lib/fog/linode/dns.rb
@@ -53,7 +53,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
           @connection_options = options[:connection_options] || {}
           @host           = options[:host]        || "api.linode.com"
           @linode_api_key = options[:linode_api_key]
@@ -74,7 +73,7 @@ module Fog
           response = @connection.request(params.merge!({:host => @host}))
 
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
             if data = response.body['ERRORARRAY'].first
               error = case data['ERRORCODE']
               when 5

--- a/lib/fog/linode/requests/compute/linode_disk_createfromstackscript.rb
+++ b/lib/fog/linode/requests/compute/linode_disk_createfromstackscript.rb
@@ -15,7 +15,7 @@ module Fog
               :label => name,
               :size => size,
               :rootPass => password,
-              :stackScriptUDFResponses => MultiJson.dump(options)
+              :stackScriptUDFResponses => Fog::JSON.encode(options)
             }
           )
         end

--- a/lib/fog/ninefold/compute.rb
+++ b/lib/fog/ninefold/compute.rb
@@ -63,8 +63,6 @@ module Fog
       class Mock
 
         def initialize(options)
-          require 'multi_json'
-
           @api_url = options[:ninefold_api_url] || Fog.credentials[:ninefold_api_url] || API_URL
           @ninefold_compute_key = options[:ninefold_compute_key] || Fog.credentials[:ninefold_compute_key]
           @ninefold_compute_secret = options[:ninefold_compute_secret] || Fog.credentials[:ninefold_compute_secret]
@@ -78,8 +76,6 @@ module Fog
       class Real
 
         def initialize(options)
-          require 'multi_json'
-
           @api_url                  = options[:ninefold_api_url] || Fog.credentials[:ninefold_api_url] || API_URL
           @ninefold_compute_key     = options[:ninefold_compute_key] || Fog.credentials[:ninefold_compute_key]
           @ninefold_compute_secret  = options[:ninefold_compute_secret] || Fog.credentials[:ninefold_compute_secret]
@@ -108,7 +104,7 @@ module Fog
             # Because the response is some weird xml-json thing, we need to try and mung
             # the values out with a prefix, and if there is an empty data entry return an
             # empty version of the expected type (if provided)
-            response = MultiJson.load(response.body)
+            response = Fog::JSON.decode(response.body)
             if options.has_key? :response_prefix
               keys = options[:response_prefix].split('/')
               keys.each do |k|

--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -13,7 +13,7 @@ module Fog
             data = nil
             message = nil
           else
-            data = MultiJson.load(error.response.body)
+            data = Fog::JSON.decode(error.response.body)
             message = data['message']
           end
 
@@ -91,12 +91,12 @@ module Fog
       response = connection.request({
         :expects  => [200, 204],
         :headers => {'Content-Type' => 'application/json'},
-        :body  => MultiJson.dump(req_body),
+        :body  => Fog::JSON.encode(req_body),
         :host     => uri.host,
         :method   => 'POST',
         :path     =>  (uri.path and not uri.path.empty?) ? uri.path : 'v2.0'
       })
-      body=MultiJson.load(response.body)
+      body=Fog::JSON.decode(response.body)
      
       if svc = body['access']['serviceCatalog'].detect{|x| x['name'] == @compute_service_name}
         mgmt_url = svc['endpoints'].detect{|x| x['publicURL']}['publicURL']

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -87,7 +87,6 @@ module Fog
         end
 
         def initialize(options={})
-          require 'multi_json'
           @openstack_username = options[:openstack_username]
         end
 
@@ -104,7 +103,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
           @openstack_api_key = options[:openstack_api_key]
           @openstack_username = options[:openstack_username]
           @openstack_tenant = options[:openstack_tenant]
@@ -151,7 +149,7 @@ module Fog
             end
           end
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -175,8 +175,8 @@ module Fog
             %{mkdir .ssh},
             %{echo "#{public_key}" >> ~/.ssh/authorized_keys},
             %{passwd -l #{username}},
-            %{echo "#{MultiJson.dump(attributes)}" >> ~/attributes.json},
-            %{echo "#{MultiJson.dump(metadata)}" >> ~/metadata.json}
+            %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json},
+            %{echo "#{Fog::JSON.encode(metadata)}" >> ~/metadata.json}
           ])
         rescue Errno::ECONNREFUSED
           sleep(1)

--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -29,7 +29,7 @@ module Fog
           end
 
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :method   => 'POST',
             :path     => 'servers.json'

--- a/lib/fog/openstack/requests/compute/server_action.rb
+++ b/lib/fog/openstack/requests/compute/server_action.rb
@@ -5,7 +5,7 @@ module Fog
 
         def server_action(server_id, body, expects=202)
           request(
-            :body     => MultiJson.dump(body),
+            :body     => Fog::JSON.encode(body),
             :expects  => expects,
             :method   => 'POST',
             :path     => "servers/#{server_id}/action.json"

--- a/lib/fog/openstack/requests/compute/set_metadata.rb
+++ b/lib/fog/openstack/requests/compute/set_metadata.rb
@@ -6,7 +6,7 @@ module Fog
 
         def set_metadata(collection_name, parent_id, metadata = {})
           request(
-            :body     => MultiJson.dump({ 'metadata' => metadata }),
+            :body     => Fog::JSON.encode({ 'metadata' => metadata }),
             :expects  => 200,
             :method   => 'PUT',
             :path     => "#{collection_name}/#{parent_id}/metadata"

--- a/lib/fog/openstack/requests/compute/update_meta.rb
+++ b/lib/fog/openstack/requests/compute/update_meta.rb
@@ -6,7 +6,7 @@ module Fog
 
         def update_meta(collection_name, parent_id, key, value)
           request(
-            :body     => MultiJson.dump({ 'meta' => { key => value }}),
+            :body     => Fog::JSON.encode({ 'meta' => { key => value }}),
             :expects  => 200,
             :method   => 'PUT',
             :path     => "#{collection_name}/#{parent_id}/metadata/#{key}"

--- a/lib/fog/openstack/requests/compute/update_metadata.rb
+++ b/lib/fog/openstack/requests/compute/update_metadata.rb
@@ -6,7 +6,7 @@ module Fog
 
         def update_metadata(collection_name, parent_id, metadata = {})
           request(
-            :body     => MultiJson.dump({ 'metadata' => metadata }),
+            :body     => Fog::JSON.encode({ 'metadata' => metadata }),
             :expects  => 200,
             :method   => 'POST',
             :path     => "#{collection_name}/#{parent_id}/metadata.json"

--- a/lib/fog/openstack/requests/compute/update_server.rb
+++ b/lib/fog/openstack/requests/compute/update_server.rb
@@ -5,7 +5,7 @@ module Fog
 
         def update_server(server_id, options = {})
           request(
-            :body     => MultiJson.dump({ 'server' => options }),
+            :body     => Fog::JSON.encode({ 'server' => options }),
             :expects  => 200,
             :method   => 'PUT',
             :path     => "servers/#{server_id}.json"

--- a/lib/fog/rackspace.rb
+++ b/lib/fog/rackspace.rb
@@ -13,7 +13,7 @@ module Fog
             data = nil
             message = nil
           else
-            data = MultiJson.load(error.response.body)
+            data = Fog::JSON.decode(error.response.body)
             message = data['message']
           end
 

--- a/lib/fog/rackspace/cdn.rb
+++ b/lib/fog/rackspace/cdn.rb
@@ -45,7 +45,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
           @connection_options = options[:connection_options] || {}
           credentials = Fog::Rackspace.authenticate(options, @connection_options)
           @auth_token = credentials['X-Auth-Token']
@@ -90,7 +89,7 @@ module Fog
             end
           end
           if !response.body.empty? && parse_json && response.headers['Content-Type'] =~ %r{application/json}
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/rackspace/compute.rb
+++ b/lib/fog/rackspace/compute.rb
@@ -61,7 +61,6 @@ module Fog
         end
 
         def initialize(options={})
-          require 'multi_json'
           @rackspace_username = options[:rackspace_username]
         end
 
@@ -78,7 +77,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
           @rackspace_api_key = options[:rackspace_api_key]
           @rackspace_username = options[:rackspace_username]
           @rackspace_auth_url = options[:rackspace_auth_url]
@@ -125,7 +123,7 @@ module Fog
             end
           end
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/rackspace/dns.rb
+++ b/lib/fog/rackspace/dns.rb
@@ -73,7 +73,6 @@ module Fog
 
       class Real
         def initialize(options={})
-          require 'multi_json'
           @rackspace_api_key = options[:rackspace_api_key]
           @rackspace_username = options[:rackspace_username]
           @rackspace_auth_url = options[:rackspace_auth_url]
@@ -108,7 +107,7 @@ module Fog
             raise Fog::Rackspace::Errors::ServiceUnavailable.slurp error
           end
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/rackspace/load_balancers.rb
+++ b/lib/fog/rackspace/load_balancers.rb
@@ -97,7 +97,6 @@ module Fog
         include Shared
 
         def initialize(options={})
-          require 'multi_json'
           @rackspace_api_key = options[:rackspace_api_key]
           @rackspace_username = options[:rackspace_username]
           @rackspace_auth_url = options[:rackspace_auth_url]
@@ -136,7 +135,7 @@ module Fog
             raise ServiceError.slurp error
           end
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/rackspace/models/compute/server.rb
+++ b/lib/fog/rackspace/models/compute/server.rb
@@ -104,8 +104,8 @@ module Fog
             %{mkdir .ssh},
             %{echo "#{public_key}" >> ~/.ssh/authorized_keys},
             %{passwd -l #{username}},
-            %{echo "#{MultiJson.dump(attributes)}" >> ~/attributes.json},
-            %{echo "#{MultiJson.dump(metadata)}" >> ~/metadata.json}
+            %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json},
+            %{echo "#{Fog::JSON.encode(metadata)}" >> ~/metadata.json}
           ])
         rescue Errno::ECONNREFUSED
           sleep(1)

--- a/lib/fog/rackspace/requests/compute/create_image.rb
+++ b/lib/fog/rackspace/requests/compute/create_image.rb
@@ -23,7 +23,7 @@ module Fog
           }
           data['image'].merge!(options)
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => 202,
             :method   => 'POST',
             :path     => "images"

--- a/lib/fog/rackspace/requests/compute/create_server.rb
+++ b/lib/fog/rackspace/requests/compute/create_server.rb
@@ -56,7 +56,7 @@ module Fog
             end
           end
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :method   => 'POST',
             :path     => 'servers.json'

--- a/lib/fog/rackspace/requests/compute/server_action.rb
+++ b/lib/fog/rackspace/requests/compute/server_action.rb
@@ -12,7 +12,7 @@ module Fog
         #
         def server_action(server_id, body, expects=202)
           request(
-            :body     => MultiJson.dump(body),
+            :body     => Fog::JSON.encode(body),
             :expects  => expects,
             :method   => 'POST',
             :path     => "servers/#{server_id}/action.json"

--- a/lib/fog/rackspace/requests/compute/update_server.rb
+++ b/lib/fog/rackspace/requests/compute/update_server.rb
@@ -12,7 +12,7 @@ module Fog
         #   * name<~String> - New name for server
         def update_server(server_id, options = {})
           request(
-            :body     => MultiJson.dump({ 'server' => options }),
+            :body     => Fog::JSON.encode({ 'server' => options }),
             :expects  => 204,
             :method   => 'PUT',
             :path     => "servers/#{server_id}.json"

--- a/lib/fog/rackspace/requests/dns/add_records.rb
+++ b/lib/fog/rackspace/requests/dns/add_records.rb
@@ -25,7 +25,7 @@ module Fog
             :expects  => 202,
             :method   => 'POST',
             :path     => "domains/#{domain_id}/records",
-            :body     => MultiJson.dump(data)
+            :body     => Fog::JSON.encode(data)
           )
         end
       end

--- a/lib/fog/rackspace/requests/dns/create_domains.rb
+++ b/lib/fog/rackspace/requests/dns/create_domains.rb
@@ -39,7 +39,7 @@ module Fog
             :expects  => 202,
             :method   => 'POST',
             :path     => 'domains',
-            :body     => MultiJson.dump(data)
+            :body     => Fog::JSON.encode(data)
           )
         end
       end

--- a/lib/fog/rackspace/requests/dns/modify_domain.rb
+++ b/lib/fog/rackspace/requests/dns/modify_domain.rb
@@ -27,7 +27,7 @@ module Fog
             :expects  => [202, 204],
             :method   => 'PUT',
             :path     => path,
-            :body     => MultiJson.dump(data)
+            :body     => Fog::JSON.encode(data)
           )
         end
       end

--- a/lib/fog/rackspace/requests/dns/modify_record.rb
+++ b/lib/fog/rackspace/requests/dns/modify_record.rb
@@ -28,7 +28,7 @@ module Fog
             :expects  => [202, 204],
             :method   => 'PUT',
             :path     => path,
-            :body     => MultiJson.dump(data)
+            :body     => Fog::JSON.encode(data)
           )
         end
       end

--- a/lib/fog/rackspace/requests/load_balancers/create_access_rule.rb
+++ b/lib/fog/rackspace/requests/load_balancers/create_access_rule.rb
@@ -12,7 +12,7 @@ module Fog
               }
           ]}
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :method   => 'POST',
             :path     => "loadbalancers/#{load_balancer_id}/accesslist"

--- a/lib/fog/rackspace/requests/load_balancers/create_load_balancer.rb
+++ b/lib/fog/rackspace/requests/load_balancers/create_load_balancer.rb
@@ -17,7 +17,7 @@ module Fog
           data['loadBalancer']['algorithm'] = options[:algorithm] if options.has_key? :algorithm
 
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => 202,
             :method   => 'POST',
             :path     => 'loadbalancers.json'

--- a/lib/fog/rackspace/requests/load_balancers/create_node.rb
+++ b/lib/fog/rackspace/requests/load_balancers/create_node.rb
@@ -15,7 +15,7 @@ module Fog
             data['nodes'][0]['weight'] = options[:weight]
           end
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :method   => 'POST',
             :path     => "loadbalancers/#{load_balancer_id}/nodes.json"

--- a/lib/fog/rackspace/requests/load_balancers/create_virtual_ip.rb
+++ b/lib/fog/rackspace/requests/load_balancers/create_virtual_ip.rb
@@ -8,7 +8,7 @@ module Fog
             'ipVersion' => 'IPV6'
           }
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :method   => 'POST',
             :path     => "loadbalancers/#{load_balancer_id}/virtualips.json"

--- a/lib/fog/rackspace/requests/load_balancers/set_connection_logging.rb
+++ b/lib/fog/rackspace/requests/load_balancers/set_connection_logging.rb
@@ -9,7 +9,7 @@ module Fog
             }
           }
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :path     => "loadbalancers/#{load_balancer_id}/connectionlogging",
             :method   => 'PUT'

--- a/lib/fog/rackspace/requests/load_balancers/set_connection_throttling.rb
+++ b/lib/fog/rackspace/requests/load_balancers/set_connection_throttling.rb
@@ -10,7 +10,7 @@ module Fog
             'rateInterval' => rate_interval
           }
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :path     => "loadbalancers/#{load_balancer_id}/connectionthrottle",
             :method   => 'PUT'

--- a/lib/fog/rackspace/requests/load_balancers/set_error_page.rb
+++ b/lib/fog/rackspace/requests/load_balancers/set_error_page.rb
@@ -9,7 +9,7 @@ module Fog
             }
           }
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :path     => "loadbalancers/#{load_balancer_id}/errorpage",
             :method   => 'PUT'

--- a/lib/fog/rackspace/requests/load_balancers/set_monitor.rb
+++ b/lib/fog/rackspace/requests/load_balancers/set_monitor.rb
@@ -19,7 +19,7 @@ module Fog
             data['statusRegex'] = options[:status_regex]
           end
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :path     => "loadbalancers/#{load_balancer_id}/healthmonitor",
             :method   => 'PUT'

--- a/lib/fog/rackspace/requests/load_balancers/set_session_persistence.rb
+++ b/lib/fog/rackspace/requests/load_balancers/set_session_persistence.rb
@@ -9,7 +9,7 @@ module Fog
             }
           }
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :path     => "loadbalancers/#{load_balancer_id}/sessionpersistence",
             :method   => 'PUT'

--- a/lib/fog/rackspace/requests/load_balancers/update_load_balancer.rb
+++ b/lib/fog/rackspace/requests/load_balancers/update_load_balancer.rb
@@ -12,7 +12,7 @@ module Fog
             }
           }
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => 202,
             :method   => 'PUT',
             :path     => "loadbalancers/#{load_balancer_id}.json"

--- a/lib/fog/rackspace/requests/load_balancers/update_node.rb
+++ b/lib/fog/rackspace/requests/load_balancers/update_node.rb
@@ -14,7 +14,7 @@ module Fog
           end
           #TODO - Do anything if no valid options are passed in?
           request(
-            :body     => MultiJson.dump(data),
+            :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],
             :method   => 'PUT',
             :path     => "loadbalancers/#{load_balancer_id}/nodes/#{node_id}.json"

--- a/lib/fog/rackspace/storage.rb
+++ b/lib/fog/rackspace/storage.rb
@@ -79,7 +79,6 @@ module Fog
 
         def initialize(options={})
           require 'mime/types'
-          require 'multi_json'
           @rackspace_api_key = options[:rackspace_api_key]
           @rackspace_username = options[:rackspace_username]
           @rackspace_cdn_ssl = options[:rackspace_cdn_ssl]
@@ -121,7 +120,7 @@ module Fog
             end
           end
           if !response.body.empty? && parse_json && response.headers['Content-Type'] =~ %r{application/json}
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           response
         end

--- a/lib/fog/slicehost/models/compute/server.rb
+++ b/lib/fog/slicehost/models/compute/server.rb
@@ -95,7 +95,7 @@ module Fog
             %{mkdir .ssh},
             %{echo "#{public_key}" >> ~/.ssh/authorized_keys},
             %{passwd -l #{username}},
-            %{echo "#{MultiJson.dump(attributes)}" >> ~/attributes.json}
+            %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json}
           ])
         rescue Errno::ECONNREFUSED
           sleep(1)

--- a/lib/fog/storm_on_demand/compute.rb
+++ b/lib/fog/storm_on_demand/compute.rb
@@ -85,7 +85,6 @@ module Fog
       class Real
 
         def initialize(options={})
-          require 'multi_json'
           uri = URI.parse(options[:storm_on_demand_auth_url] ||= API_URL)
           @connection_options = options[:connection_options] || {}
           @host       = uri.host
@@ -123,7 +122,7 @@ module Fog
             end
           end
           unless response.body.empty?
-            response.body = MultiJson.load(response.body)
+            response.body = Fog::JSON.decode(response.body)
           end
           if response.body.has_key?('full_error')
             raise(Fog::Compute::StormOnDemand::Error, response.body.inspect)

--- a/lib/fog/storm_on_demand/requests/compute/add_balancer_node.rb
+++ b/lib/fog/storm_on_demand/requests/compute/add_balancer_node.rb
@@ -6,7 +6,7 @@ module Fog
         def add_balancer_node(options = {})
           request(
             :path     => "/network/loadbalancer/addnode",
-            :body     => MultiJson.dump({:params => options})
+            :body     => Fog::JSON.encode({:params => options})
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/clone_server.rb
+++ b/lib/fog/storm_on_demand/requests/compute/clone_server.rb
@@ -6,7 +6,7 @@ module Fog
         def clone_server(options = {})
           request(
             :path     => "/storm/server/clone",
-            :body     => MultiJson.dump({:params => options})
+            :body     => Fog::JSON.encode({:params => options})
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/create_server.rb
+++ b/lib/fog/storm_on_demand/requests/compute/create_server.rb
@@ -6,7 +6,7 @@ module Fog
         def create_server(options = {})
           request(
             :path     => "/storm/server/create",
-            :body     => MultiJson.dump({:params => options})
+            :body     => Fog::JSON.encode({:params => options})
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/delete_server.rb
+++ b/lib/fog/storm_on_demand/requests/compute/delete_server.rb
@@ -6,7 +6,7 @@ module Fog
         def delete_server(options = {})
           request(
             :path     => "/storm/server/destroy",
-            :body     => MultiJson.dump({:params => options})
+            :body     => Fog::JSON.encode({:params => options})
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/get_server.rb
+++ b/lib/fog/storm_on_demand/requests/compute/get_server.rb
@@ -6,7 +6,7 @@ module Fog
         def get_server(options = {})
           request(
             :path     => "/storm/server/details",
-            :body     => MultiJson.dump({:params => options})
+            :body     => Fog::JSON.encode({:params => options})
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/get_stats.rb
+++ b/lib/fog/storm_on_demand/requests/compute/get_stats.rb
@@ -6,7 +6,7 @@ module Fog
         def get_stats(options = {})
           request(
             :path     => "/monitoring/load/stats",
-            :body     => MultiJson.dump({:params => options})
+            :body     => Fog::JSON.encode({:params => options})
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/list_balancers.rb
+++ b/lib/fog/storm_on_demand/requests/compute/list_balancers.rb
@@ -6,7 +6,7 @@ module Fog
         def list_balancers(options = {})
           request(
             :path     => "/network/loadbalancer/list",
-            :body     => MultiJson.dump(options)
+            :body     => Fog::JSON.encode(options)
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/list_configs.rb
+++ b/lib/fog/storm_on_demand/requests/compute/list_configs.rb
@@ -6,7 +6,7 @@ module Fog
         def list_configs(options = {})
           request(
             :path     => "/storm/config/list",
-            :body     => MultiJson.dump(options)
+            :body     => Fog::JSON.encode(options)
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/list_images.rb
+++ b/lib/fog/storm_on_demand/requests/compute/list_images.rb
@@ -6,7 +6,7 @@ module Fog
         def list_images(options = {})
           request(
             :path     => "/server/image/list",
-            :body     => MultiJson.dump(options)
+            :body     => Fog::JSON.encode(options)
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/list_private_ips.rb
+++ b/lib/fog/storm_on_demand/requests/compute/list_private_ips.rb
@@ -6,7 +6,7 @@ module Fog
         def list_private_ips(options = {})
           request(
             :path     => "/network/private/get",
-            :body     => MultiJson.dump(options)
+            :body     => Fog::JSON.encode(options)
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/list_servers.rb
+++ b/lib/fog/storm_on_demand/requests/compute/list_servers.rb
@@ -6,7 +6,7 @@ module Fog
         def list_servers(options = {})
           request(
             :path     => "/storm/server/list",
-            :body     => MultiJson.dump(options)
+            :body     => Fog::JSON.encode(options)
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/list_templates.rb
+++ b/lib/fog/storm_on_demand/requests/compute/list_templates.rb
@@ -6,7 +6,7 @@ module Fog
         def list_templates(options = {})
           request(
             :path     => "/server/template/list",
-            :body     => MultiJson.dump(options)
+            :body     => Fog::JSON.encode(options)
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/reboot_server.rb
+++ b/lib/fog/storm_on_demand/requests/compute/reboot_server.rb
@@ -6,7 +6,7 @@ module Fog
         def reboot_server(options = {})
           request(
             :path     => "/storm/server/reboot",
-            :body     => MultiJson.dump({:params => options})
+            :body     => Fog::JSON.encode({:params => options})
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/remove_balancer_node.rb
+++ b/lib/fog/storm_on_demand/requests/compute/remove_balancer_node.rb
@@ -6,7 +6,7 @@ module Fog
         def remove_balancer_node(options = {})
           request(
             :path     => "/network/loadbalancer/removenode",
-            :body     => MultiJson.dump({:params => options})
+            :body     => Fog::JSON.encode({:params => options})
           )
         end
 

--- a/lib/fog/storm_on_demand/requests/compute/resize_server.rb
+++ b/lib/fog/storm_on_demand/requests/compute/resize_server.rb
@@ -6,7 +6,7 @@ module Fog
         def resize_server(options = {})
           request(
             :path     => "/storm/server/resize",
-            :body     => MultiJson.dump({:params => options})
+            :body     => Fog::JSON.encode({:params => options})
           )
         end
 

--- a/lib/fog/virtual_box/models/compute/server.rb
+++ b/lib/fog/virtual_box/models/compute/server.rb
@@ -167,8 +167,8 @@ module Fog
         #     %{mkdir .ssh},
         #     %{echo "#{public_key}" >> ~/.ssh/authorized_keys},
         #     %{passwd -l #{username}},
-        #     %{echo "#{MultiJson.dump(attributes)}" >> ~/attributes.json},
-        #     %{echo "#{MultiJson.dump(metadata)}" >> ~/metadata.json}
+        #     %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json},
+        #     %{echo "#{Fog::JSON.encode(metadata)}" >> ~/metadata.json}
         #   ])
         # rescue Errno::ECONNREFUSED
         #   sleep(1)

--- a/tests/aws/requests/sns/subscription_tests.rb
+++ b/tests/aws/requests/sns/subscription_tests.rb
@@ -7,7 +7,7 @@ Shindo.tests('AWS::SES | topic lifecycle tests', ['aws', 'sns']) do
     Fog::AWS[:sqs].set_queue_attributes(
       @queue_url,
       'Policy',
-      MultiJson.dump({
+      Fog::JSON.encode({
         'Id' => @topic_arn,
         'Statement' => {
           'Action'    => 'sqs:SendMessage',
@@ -64,7 +64,7 @@ Shindo.tests('AWS::SES | topic lifecycle tests', ['aws', 'sns']) do
       Fog.wait_for do
         message = Fog::AWS[:sqs].receive_message(@queue_url).body['Message'].first
       end
-      MultiJson.load(message['Body'])['Message']
+      Fog::JSON.decode(message['Body'])['Message']
     end
 
     tests("#unsubscribe('#{@subscription_arn}')").formats(AWS::SNS::Formats::BASIC) do


### PR DESCRIPTION
If I could get another set of eyes to either review the code or at least verify it works, I'd appreciate that.  I ran the tests with multi_json 1.2.0 and 1.3.2 and didn't seem to have any problems.

One change introduced that I'm not wild about is we use to lazy require 'multi_json'.  I now require it optimistically in 'fog/core/json.rb', but this file gets loaded everywhere, so we effectively always load multi_json.  We could relax that, but I liked caching the results of the `:respond_to?` call, since introspecting on every call would incur considerably more overhead than requiring once.  I'm open to suggestions if anyone has a way to blend the two approaches.
