### PR TITLE
[aws|address] fixes release_address for VPC EIPs

### DIFF
--- a/lib/fog/aws/requests/compute/release_address.rb
+++ b/lib/fog/aws/requests/compute/release_address.rb
@@ -14,10 +14,18 @@ module Fog
         #     * 'return'<~Boolean> - success?
         #
         # {Amazon API Reference}[http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-ReleaseAddress.html]
-        def release_address(public_ip)
+        # 
+        # non-VPC: requires public_ip only
+        #     VPC: requires allocation_id only
+        def release_address(ip_or_allocation)
+          field = if ip_or_allocation.to_s =~ /^(\d|\.)+$/
+                    "PublicIp"
+                  else
+                    "AllocationId"
+                  end
           request(
             'Action'    => 'ReleaseAddress',
-            'PublicIp'  => public_ip,
+            field       => ip_or_allocation,
             :idempotent => true,
             :parser     => Fog::Parsers::Compute::AWS::Basic.new
           )


### PR DESCRIPTION
there doesn't seem to be any documentation on ReleaseAddress for this requirement, but attempts to release an EIP allocated within VPC bomb without providing the AllocationId. further, the API will error if PublicIp is passed in addition to AllocationId, lord only knows why.

wasn't sure where to slot in tests for VPC EIPs. here's a before and after anyway. 

```
>> compute.release_address "107.21.53.97"
Fog::Compute::AWS::Error: InvalidParameterValue => You must specify an allocation id when releasing a VPC elastic IP address
    from gems/excon-0.13.4/lib/excon/connection.rb:266:in `request_kernel'
    from gems/excon-0.13.4/lib/excon/connection.rb:97:in `request'
    from bundler/gems/fog-a816990270e1/lib/fog/core/connection.rb:20:in `request'
    from bundler/gems/fog-a816990270e1/lib/fog/aws/compute.rb:331:in `request'
    from bundler/gems/fog-a816990270e1/lib/fog/aws/requests/compute/release_address.rb:22:in `release_address'
>> compute.release_address "107.21.53.97", "eipalloc-946c29fc"
Fog::Compute::AWS::Error: InvalidParameterCombination => You may specify public IP or allocation id, but not both in the same call
    from gems/excon-0.13.4/lib/excon/connection.rb:266:in `request_kernel'
    from gems/excon-0.13.4/lib/excon/connection.rb:97:in `request'
    from bundler/gems/fog-a816990270e1/lib/fog/core/connection.rb:20:in `request'
    from bundler/gems/fog-a816990270e1/lib/fog/aws/compute.rb:331:in `request'
        from bundler/gems/fog-a816990270e1/lib/fog/aws/requests/compute/release_address.rb:22:in `release_address'
```

```
>> compute.release_address "107.21.53.97", "eipalloc-946c29fc"
=> #<Excon::Response:0x007fed16f1fc60 @body={"requestId"=>"a4e3d6a0-0629-4ca5-a6e6-98cbbdad81c1", "return"=>true}, @headers={"Content-Type"=>"text/xml;charset=UTF-8", "Transfer-Encoding"=>"chunked", "Date"=>"Thu, 26 Apr 2012 01:50:11 GMT", "Server"=>"AmazonEC2"}, @status=200>
```
