### PR TITLE
[openstack|compute] authenticate_v2 fixes

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -107,7 +107,7 @@ module Fog
       unless svc
         unless @openstack_tenant
           response = Fog::Connection.new(
-            "#{uri.scheme}://#{uri.host}:5000/v2.0/tenants", false).request({
+            "#{uri.scheme}://#{uri.host}:#{uri.port}/v2.0/tenants", false, connection_options).request({
             :expects => [200, 204],
             :headers => {'Content-Type' => 'application/json',
                          'X-Auth-Token' => body['access']['token']['id']},


### PR DESCRIPTION
- Add connection_options to Fog::Connection when
  authenticating so we can disable SSL cert verification for example.
- Do not use hardcoded keystone 5000 port

Sample code:

```
conn = Fog::Compute.new({
  :provider => 'OpenStack',
  :openstack_api_key => "changeme",
  :openstack_username => "user@bvox.net",
  :openstack_auth_url => "https://auth-server/v2.0/tokens",
  :connection_options => { :ssl_verify_peer => false }
})
```
