### PR TITLE
Nested Credentials with Array gets flattened; restrict flatten to 1L

### DIFF
--- a/lib/fog/core/credentials.rb
+++ b/lib/fog/core/credentials.rb
@@ -52,9 +52,11 @@ module Fog
 
   def self.symbolize_credentials(args)
     if args.is_a? Hash
-      Hash[ *args.collect do |key, value|
-        [key.to_sym, self.symbolize_credentials(value)]
-      end.flatten ]
+      copy = Array.new
+      args.each do |key, value|
+        copy.push(key.to_sym, self.symbolize_credentials(value))
+      end
+      Hash[*copy]
     else
       args
     end


### PR DESCRIPTION
This is mainly to take into account credentials which has a structure wherein when flattened would result into an odd number of elements. For example:

```
{ :token => 'abcdefg',
  :roles => [{:id => 1, :name => 'admin'}, {:id => 2, :name => 'netadmin'}]
}
```

@redzebra The other thing I'm concerned about is that if this works with ruby 1.8.5. I wanted to try it myself but currently rvm is giving me compilation errors whenever I try to install 1.8.5... I think I'm missing something.
