### PR TITLE
SSL Certificates for Rackspace load balancer

### DIFF
--- a/lib/fog/rackspace/load_balancers.rb
+++ b/lib/fog/rackspace/load_balancers.rb
@@ -29,6 +29,8 @@ module Fog
       model :access_rule
 
       request_path 'fog/rackspace/requests/load_balancers'
+      request :get_ssl_termination
+      request :set_ssl_termination
       request :create_load_balancer
       request :get_load_balancer
       request :list_load_balancers

--- a/lib/fog/rackspace/models/load_balancers/load_balancer.rb
+++ b/lib/fog/rackspace/models/load_balancers/load_balancer.rb
@@ -27,6 +27,7 @@ module Fog
         attribute :name
         attribute :state,               :aliases => 'status'
         attribute :nodes
+        attribute :ssl_termination,     :aliases => 'ssltermination'
 
         def initialize(attributes)
           #HACK - Since we are hacking how sub-collections work, we have to make sure the connection is valid first.
@@ -56,6 +57,17 @@ module Fog
 
         def nodes=(new_nodes=[])
           nodes.load(new_nodes)
+        end
+
+        def ssl_termination
+          requires :identity
+          ssl_termination = connection.get_ssl_termination(identity)
+          (ssl_termination.status == 404) ? nil : ssl_termination.body["sslTermination"]
+        end
+
+        def enable_ssl_termination(securePort, privatekey, certificate, enabled=true, secureTrafficOnly=false)
+          requires :identity
+          connection.set_ssl_termination(identity, securePort, privatekey, certificate, enabled, secureTrafficOnly)
         end
 
         def virtual_ips

--- a/lib/fog/rackspace/requests/load_balancers/get_ssl_termination.rb
+++ b/lib/fog/rackspace/requests/load_balancers/get_ssl_termination.rb
@@ -1,0 +1,15 @@
+module Fog
+  module Rackspace
+    class LoadBalancers
+      class Real
+        def get_ssl_termination(load_balancer_id)
+          request(
+            :expects => [200,404],
+            :path => "loadbalancers/#{load_balancer_id}/ssltermination",
+            :method => 'GET'
+          )
+         end
+      end
+    end
+  end
+end

--- a/lib/fog/rackspace/requests/load_balancers/set_ssl_termination.rb
+++ b/lib/fog/rackspace/requests/load_balancers/set_ssl_termination.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Rackspace
+    class LoadBalancers
+      class Real
+        def set_ssl_termination(load_balancer_id, securePort, privatekey, certificate, enabled, secureTrafficOnly)
+          data = {
+            securePort: securePort,
+            privatekey: privatekey,
+            certificate: certificate,
+            #intermediatecertificate: intermediatecertificate
+          }
+          request(
+            :body     => MultiJson.encode(data),
+            :expects => [202,404],
+            :path => "loadbalancers/#{load_balancer_id}/ssltermination",
+            :method => 'PUT'
+          )
+         end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added this feature several weeks ago for my own purpose and realized it could benefit the community at large. Unfortunately, I'm having a bit of trouble writing te tests. Can anyone help me with that part of it? 

The use of it should look like this:
lb = connection.create_load_balancer("new-balancer", "HTTP", 80, [{type: "PUBLIC"}],[{address:"x.x.x.x", port:80, condition: "ENABLED"}])

lb.enable_ssl_termination(443, private_key, certificate)
