### PR TITLE
ensure apiKey and command are included in parameter sorting for Ninefold

### DIFF
--- a/lib/fog/ninefold/compute.rb
+++ b/lib/fog/ninefold/compute.rb
@@ -86,9 +86,9 @@ module Fog
 
         def request(command, params, options)
           params['response'] = "json"
-          req = "apiKey=#{@ninefold_compute_key}&command=#{command}&"
           # convert params to strings for sort
-          req += URI.escape(params.sort_by{|k,v| k.to_s }.collect{|e| "#{e[0].to_s}=#{e[1].to_s}"}.join('&'))
+          req_params = params.merge('apiKey' => @ninefold_compute_key, 'command' => command)
+          req = URI.escape(req_params.sort_by{|k,v| k.to_s }.collect{|e| "#{e[0].to_s}=#{e[1].to_s}"}.join('&'))
           encoded_signature = url_escape(encode_signature(req))
 
           options = {


### PR DESCRIPTION
When creating a new VM on Ninefold and an account is required, the secret generation was incorrect because apiKey was always at the beginning of the request string. In this case, the account parameter should be sorted to the start.
