### PR TITLE
[openstack] Add Public Identity URL to parameters to enable tenant auto detection

### DIFF
--- a/.irbrc
+++ b/.irbrc
@@ -40,12 +40,18 @@ def connection
   connections[$connection_manager_previous_key]
 end
 
-def connect_openstack(username, password, tenant = nil, url = 'http://192.168.27.100:35357/')
+def connect_openstack(
+  username, password,
+  tenant      = nil,
+  url         = 'http://192.168.27.100:35357/',
+  public_url  = 'http://192.168.27.100:5000/'  )
+
   parameters = {
     :provider => 'openstack',
     :openstack_api_key => password,
     :openstack_username => username,
-    :openstack_auth_url => "#{url}v2.0/tokens"
+    :openstack_auth_url => "#{url}v2.0/tokens",
+    :openstack_public_identity_url => public_url
   }
 
   parameters.merge!(:openstack_tenant => tenant) if tenant

--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -71,11 +71,14 @@ module Fog
     def self.authenticate_v2(options, connection_options = {})
       uri = options[:openstack_auth_uri]
       connection = Fog::Connection.new(uri.to_s, false, connection_options)
-      @openstack_api_key  = options[:openstack_api_key]
-      @openstack_username = options[:openstack_username]
-      @openstack_tenant   = options[:openstack_tenant]
-      @openstack_auth_token = options[:openstack_auth_token]
-      @service_name         = options[:openstack_service_name]
+
+      @openstack_api_key     = options[:openstack_api_key]
+      @openstack_username    = options[:openstack_username]
+      @openstack_tenant      = options[:openstack_tenant]
+      @openstack_auth_token  = options[:openstack_auth_token]
+      @openstack_public_identity_url = options[:openstack]
+
+      @service_name          = options[:openstack_service_name]
       @identity_service_name = options[:openstack_identity_service_name]
       @endpoint_type         = options[:openstack_endpoint_type] || 'publicURL'
 
@@ -106,8 +109,14 @@ module Fog
 
       unless svc
         unless @openstack_tenant
+          tenant_detection_uri = options[:openstack_public_identity_uri] || uri
+
           response = Fog::Connection.new(
-            "#{uri.scheme}://#{uri.host}:#{uri.port}/v2.0/tenants", false, connection_options).request({
+            "#{     tenant_detection_uri.scheme
+             }://#{ tenant_detection_uri.host
+             }:#{   tenant_detection_uri.port
+             }/v2.0/tenants",
+            false, connection_options).request({
             :expects => [200, 204],
             :headers => {'Content-Type' => 'application/json',
                          'X-Auth-Token' => body['access']['token']['id']},

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -9,7 +9,7 @@ module Fog
       recognizes :openstack_auth_token, :openstack_management_url,
                  :persistent, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
-                 :current_user, :current_tenant
+                 :current_user, :current_tenant, :openstack_public_identity_url
 
       ## MODELS
       #
@@ -152,7 +152,7 @@ module Fog
       # Hosts
       request :list_hosts
       request :get_host_details
-      
+
 
       class Mock
 
@@ -234,6 +234,8 @@ module Fog
 
           @openstack_tenant     = options[:openstack_tenant]
           @openstack_auth_uri   = URI.parse(options[:openstack_auth_url])
+          @openstack_public_identity_uri  = URI.parse(options[:openstack_public_identity_url]) if options[:openstack_public_identity_url]
+
           @openstack_management_url       = options[:openstack_management_url]
           @openstack_must_reauthenticate  = false
           @openstack_service_name = options[:openstack_service_name] || ['nova', 'compute']
@@ -310,7 +312,8 @@ module Fog
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_tenant   => @openstack_tenant,
               :openstack_service_name => @openstack_service_name,
-              :openstack_identity_service_name => @openstack_identity_service_name
+              :openstack_identity_service_name => @openstack_identity_service_name,
+              :openstack_public_identity_uri   => @openstack_public_identity_uri
             }
 
             if @openstack_auth_uri.path =~ /\/v2.0\//

--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -8,7 +8,7 @@ module Fog
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_current_user_id,
-                 :current_user, :current_tenant
+                 :current_user, :current_tenant, :openstack_public_identity_url
 
       model_path 'fog/openstack/models/identity'
       model       :tenant
@@ -116,11 +116,13 @@ module Fog
             raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
           end
 
-          @openstack_tenant   = options[:openstack_tenant]
-          @openstack_auth_uri   = URI.parse(options[:openstack_auth_url])
+          @openstack_tenant               = options[:openstack_tenant]
+          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
+          @openstack_public_identity_uri  = URI.parse(options[:openstack_public_identity_url]) if options[:openstack_public_identity_url]
+
           @openstack_management_url       = options[:openstack_management_url]
           @openstack_must_reauthenticate  = false
-          @openstack_service_name = options[:openstack_service_name] || ['identity']
+          @openstack_service_name         = options[:openstack_service_name] || ['identity']
 
           @connection_options = options[:connection_options] || {}
 
@@ -194,7 +196,8 @@ module Fog
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_tenant   => @openstack_tenant,
               :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => 'adminURL'
+              :openstack_endpoint_type => 'adminURL',
+              :openstack_public_identity_uri   => @openstack_public_identity_uri
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)

--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -8,7 +8,7 @@ module Fog
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant
+                 :current_user, :current_tenant, :openstack_public_identity_url
 
       model_path 'fog/openstack/models/image'
 
@@ -99,6 +99,8 @@ module Fog
 
           @openstack_tenant               = options[:openstack_tenant]
           @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
+          @openstack_public_identity_uri  = URI.parse(options[:openstack_public_identity_url]) if options[:openstack_public_identity_url]
+
           @openstack_management_url       = options[:openstack_management_url]
           @openstack_must_reauthenticate  = false
           @openstack_service_name         = options[:openstack_service_name] || ['image']
@@ -172,7 +174,8 @@ module Fog
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_auth_token => @openstack_auth_token,
               :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => 'adminURL'
+              :openstack_endpoint_type => 'adminURL',
+              :openstack_public_identity_uri   => @openstack_public_identity_uri
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -8,7 +8,7 @@ module Fog
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant
+                 :current_user, :current_tenant, :openstack_public_identity_url
 
       model_path 'fog/openstack/models/volume'
 
@@ -99,6 +99,8 @@ module Fog
 
           @openstack_tenant               = options[:openstack_tenant]
           @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
+          @openstack_public_identity_uri  = URI.parse(options[:openstack_public_identity_url]) if options[:openstack_public_identity_url]
+
           @openstack_management_url       = options[:openstack_management_url]
           @openstack_must_reauthenticate  = false
           @openstack_service_name         = options[:openstack_service_name] || ['volume']
@@ -172,7 +174,8 @@ module Fog
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_auth_token => @openstack_auth_token,
               :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => 'adminURL'
+              :openstack_endpoint_type => 'adminURL',
+              :openstack_public_identity_uri   => @openstack_public_identity_uri
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)


### PR DESCRIPTION
This is a followup to Pull Request #890

@rubiojr @xtoddx what do you think?

Auto-detection of tenant won't work on my environment on port 35357 (Admin URL) giving me authentication errors and must be port 5000 (Public URL).
