### PR TITLE
[libvirt] Fix SSH keyfile being pulled from wrong param

### DIFF
--- a/lib/fog/libvirt/models/compute/util/uri.rb
+++ b/lib/fog/libvirt/models/compute/util/uri.rb
@@ -77,7 +77,7 @@ module Fog
         end
 
         def keyfile
-          value("command")
+          value("keyfile")
         end
 
         def netcat


### PR DESCRIPTION
According to the libvirt docs ( http://libvirt.org/remote.html#Remote_URI_parameters ) the ssh keyfile should be pulled from the keyfile param not the command param. Without this Fog was unable to SSH into the newly provisioned VM to get the IP. 
