### PR TITLE
add support for HP availability zone az-3.region-a.geo-1

### DIFF
--- a/lib/fog/hp.rb
+++ b/lib/fog/hp.rb
@@ -184,6 +184,8 @@ module Fog
             endpoint_url = service_item['endpoints'][0]['publicURL'] if service_item['endpoints'][0]
           elsif avl_zone == :az2
             endpoint_url = service_item['endpoints'][1]['publicURL'] if service_item['endpoints'][1]
+          elsif avl_zone == :az3
+            endpoint_url = service_item['endpoints'][2]['publicURL'] if service_item['endpoints'][2]
           end
           raise "Unable to retrieve endpoint service url from service catalog." if endpoint_url.nil?
           return endpoint_url


### PR DESCRIPTION
missing from the 'HP' provider in Fog.
