### PR TITLE
add a method to IPAddr instead of breaking a useful one

### DIFF
--- a/lib/fog/ecloud/compute.rb
+++ b/lib/fog/ecloud/compute.rb
@@ -2,7 +2,7 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'ecloud'))
 require 'ipaddr'
 
 class IPAddr
-  def mask
+  def mask_string
     _to_string(@mask_addr)
   end
 end
@@ -367,7 +367,7 @@ module Fog
         end
 
         def netmask
-          self[:netmask] || subnet_ipaddr.mask
+          self[:netmask] || subnet_ipaddr.mask_string
         end
 
         def dns


### PR DESCRIPTION
The monkey patch to `IPAddr#mask` in the [ecloud compute provider](https://github.com/fog/fog/blob/master/lib/fog/ecloud/compute.rb#L4-8) unnecessarily removes functionality from IPAddr in both [1.8.7](http://ruby-doc.org/stdlib-1.8.7/libdoc/ipaddr/rdoc/IPAddr.html#method-i-mask) and [1.9](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/ipaddr/rdoc/IPAddr.html#method-i-mask). This pull request adds a method to IPAddr instead of breaking a useful one.
