### PR TITLE
fix auto-discovery for HP Cloud by fog bin [for #909]

### DIFF
--- a/lib/fog/bin/hp.rb
+++ b/lib/fog/bin/hp.rb
@@ -4,11 +4,11 @@ class HP < Fog::Bin
     def class_for(key)
       case key
       when :cdn
-        Fog::HP::CDN
+        Fog::CDN::HP
       when :compute
-        Fog::HP::Compute
+        Fog::Compute::HP
       when :storage
-        Fog::HP::Storage
+        Fog::Storage::HP
       else
         raise ArgumentError, "Unrecognized service: #{key}"
       end


### PR DESCRIPTION
Issue was:

``` ruby
>> HP.class_for(:compute)
NameError: uninitialized constant Fog::HP::Compute

>> AWS.class_for(:compute)
Fog::Compute::AWS
```

Now:

``` ruby
$ bundle exec bin/fog hp
  Welcome to fog interactive!
  :bosh-hp provides HP, VirtualBox and Vmfusion
```
