### PR TITLE
use kernel_id for mocked kernel, not stackscript_id

### DIFF
--- a/lib/fog/linode/requests/compute/avail_kernels.rb
+++ b/lib/fog/linode/requests/compute/avail_kernels.rb
@@ -55,7 +55,7 @@ module Fog
           {
             "ISPVOPS"  => 1,
             "ISXEN"    => 1,
-            "KERNELID" => stackscript_id,
+            "KERNELID" => kernel_id,
             "LABEL"    => "Latest 3.0 (3.0.18-linode43)"
           }
         end


### PR DESCRIPTION
This commit fixes a bug I found in the Linode mocks.
