### PR TITLE
Modify url regexp to handle periods in bucket names

### DIFF
--- a/lib/fog/aws/requests/storage/get_object_url.rb
+++ b/lib/fog/aws/requests/storage/get_object_url.rb
@@ -11,7 +11,7 @@ module Fog
           unless object_name
             raise ArgumentError.new('object_name is required')
           end
-          host, path = if bucket_name =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
+          host, path = if bucket_name =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\-(?![\.])){1,61}[a-z0-9]$/
             ["#{bucket_name}.#{@host}", object_name]
           else
             [@host, "#{bucket_name}/#{object_name}"]


### PR DESCRIPTION
It looks like this was fixed by #835, but was ditched when the get object handling was centralized.
