### PR TITLE
[rackspace|storage|files] fix iteration method

### DIFF
--- a/lib/fog/rackspace/models/storage/files.rb
+++ b/lib/fog/rackspace/models/storage/files.rb
@@ -43,7 +43,7 @@ module Fog
             subset = dup.all
 
             subset.each_file_this_page {|f| yield f}
-            until subset.empty? || subset.length == (subset.limit || 10000)
+            while subset.length == (subset.limit || 10000)
               subset = subset.all(:marker => subset.last.key)
               subset.each_file_this_page {|f| yield f}
             end


### PR DESCRIPTION
Fix bug in the each method of [rackspace|storage|files], which only allow iteration over first 10k items.

https://github.com/fog/fog/issues/917
