### PR TITLE
Revert "Add debug option to Fog::Compute::Server#ssh"

### DIFF
--- a/lib/fog/core/ssh.rb
+++ b/lib/fog/core/ssh.rb
@@ -48,7 +48,6 @@ module Fog
 
         @address  = address
         @username = username
-        @debug    = options.delete :debug
         @options  = { :paranoid => false }.merge(options)
       end
 
@@ -58,7 +57,7 @@ module Fog
         begin
           Net::SSH.start(@address, @username, @options) do |ssh|
             commands.each do |command|
-              result = Result.new(command, @debug)
+              result = Result.new(command)
               ssh.open_channel do |ssh_channel|
                 ssh_channel.request_pty
                 ssh_channel.exec(command) do |channel, success|
@@ -100,19 +99,6 @@ module Fog
 
     end
 
-    class DebugString < SimpleDelegator
-
-      def initialize(string='')
-        super
-      end
-
-      def <<(add_me)
-        puts add_me
-        super
-      end
-
-    end
-
     class Result
 
       attr_accessor :command, :stderr, :stdout, :status
@@ -130,10 +116,10 @@ module Fog
         Formatador.display_line(stderr.split("\r\n"))
       end
 
-      def initialize(command, debug=false)
+      def initialize(command)
         @command = command
-        @stderr = debug ? DebugString.new : ''
-        @stdout = debug ? DebugString.new : ''
+        @stderr = ''
+        @stdout = ''
       end
 
     end


### PR DESCRIPTION
This reverts commit 1cf33ccc7acc1c68eba23c9fa4556571f67c175f.

Conflicts:
lib/fog/core/ssh.rb

Use a block when you care about getting streaming output, this way you
can decide to puts it, store it somewhere, etc, etc, etc.
