### PR TITLE
catch passing an invalid openstack_tenant

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -124,6 +124,9 @@ module Fog
         end
 
         body = retrieve_tokens_v2(connection, req_body, uri)
+        if body['access']['token']['tenant'].nil?
+          raise Errors::NotFound.new("Invalid Tenant '#{@openstack_tenant}'")
+        end
         svc = body['access']['serviceCatalog'].
           detect{|x| @service_name.include?(x['type']) }
       end


### PR DESCRIPTION
Passing an invalid openstack_tenant throws a 
Exception: NoMethodError: undefined method `[]' for nil:NilClass 
from 
mgmt_url = svc['endpoints'].detect{|x| x[@endpoint_type]}[@endpoint_type]
because you get an empty serviceCatalog.
