### PR TITLE
OpenStack Compute addresses['internet'] and public and private_ip_address fixed

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -79,7 +79,7 @@ module Fog
           if addresses['private']
             #assume only a single private
             return addresses['private'].first
-          else
+          elsif addresses['internet']
             #assume no private IP means private cloud
             return addresses['internet'].first
           end
@@ -98,7 +98,7 @@ module Fog
           if addresses['public']
             #assume last is either original or assigned from floating IPs
             return addresses['public'].last
-          else
+          elsif addresses['internet']
             #assume no public IP means private cloud
             return addresses['internet'].first
           end


### PR DESCRIPTION
The private_ip_address only returned nil. Some OpenStack providers do not have 'public' and 'private', they have 'internet' for their addresses. The assumption is to use that for both public and private then. Also only returns the first entry until I see an OpenStack deployment with more than 1 private and public network.
