### PR TITLE
Default to false for persistent connections. You can't pass in false.

### DIFF
--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -68,7 +68,7 @@ module Fog
           @host       = "api2.dynect.net"
           @port       = options[:port]        || 443
           @path       = options[:path]        || '/REST'
-          @persistent = options[:persistent]  || true
+          @persistent = options[:persistent]  || false
           @scheme     = options[:scheme]      || 'https'
           @version    = options[:version]     || '2.3.1'
           @connection = Fog::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)


### PR DESCRIPTION
This now behaves like other connections in fog. :v: :cloud:
