### PR TITLE
Idempotent Dynect calls. :v:

### DIFF
--- a/lib/fog/dynect/requests/dns/delete_record.rb
+++ b/lib/fog/dynect/requests/dns/delete_record.rb
@@ -14,6 +14,7 @@ module Fog
         def delete_record(type, zone, fqdn, record_id)
           request(
             :expects  => 200,
+            :idempotent => true,
             :method   => :delete,
             :path     => ["#{type.to_s.upcase}Record", zone, fqdn, record_id].join('/')
           )

--- a/lib/fog/dynect/requests/dns/get_node_list.rb
+++ b/lib/fog/dynect/requests/dns/get_node_list.rb
@@ -14,6 +14,7 @@ module Fog
           requested_fqdn = options['fqdn'] || options[:fqdn]
           request(
             :expects  => 200,
+            :idempotent => true,
             :method   => :get,
             :path     => ['NodeList', zone, requested_fqdn].compact.join('/')
           )

--- a/lib/fog/dynect/requests/dns/get_record.rb
+++ b/lib/fog/dynect/requests/dns/get_record.rb
@@ -15,6 +15,7 @@ module Fog
         def get_record(type, zone, fqdn, options = {})
           request(
             :expects  => 200,
+            :idempotent => true,
             :method   => :get,
             :path     => ["#{type.to_s.upcase}Record", zone, fqdn, options['record_id']].compact.join('/')
           )

--- a/lib/fog/dynect/requests/dns/get_zone.rb
+++ b/lib/fog/dynect/requests/dns/get_zone.rb
@@ -12,6 +12,7 @@ module Fog
         def get_zone(options = {})
           request(
             :expects  => 200,
+            :idempotent => true,
             :method   => :get,
             :path     => ['Zone', options['zone']].compact.join('/')
           )

--- a/lib/fog/dynect/requests/dns/post_session.rb
+++ b/lib/fog/dynect/requests/dns/post_session.rb
@@ -6,6 +6,7 @@ module Fog
         def post_session
           request(
             :expects  => 200,
+            :idempotent => true,
             :method   => :post,
             :path     => "Session",
             :body     => Fog::JSON.encode({


### PR DESCRIPTION
The only call I am unsure of currently is put_zone.

```
=> #<Excon::Response:0x00000004709cd0 @body={"status"=>"success", "data"=>{"zone_type"=>"Primary", "serial_style"=>"increment", "serial"=>1234, "zone"=>"..."}, "job_id"=>1234, "msgs"=>[{"INFO"=>"changeset: No changes to apply.", "SOURCE"=>"BLL", "ERR_CD"=>nil, "LVL"=>"INFO"}, {"INFO"=>"publish: Could not publish .... No changes to apply.", "SOURCE"=>"BLL", "ERR_CD"=>nil, "LVL"=>"INFO"}]}, @headers={"Server"=>"nginx/0.7.67", "Date"=>"Mon, 28 May 2012 14:22:39 GMT", "Content-Type"=>"application/json", "Transfer-Encoding"=>"chunked", "Connection"=>"keep-alive"}, @status=200>
```

The delete_record call should also work fine for `Fog.mock!` too.
