### PR TITLE
Added offeringType value in the response for the describe_reserved_instances function.

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_reserved_instances.rb
@@ -12,7 +12,7 @@ module Fog
 
           def end_element(name)
             case name
-            when 'availabilityZone', 'instanceType', 'productDescription', 'reservedInstancesId', 'state'
+            when 'availabilityZone', 'instanceType', 'productDescription', 'reservedInstancesId', 'state', 'offeringType'
               @reserved_instance[name] = value
             when 'duration', 'instanceCount'
               @reserved_instance[name] = value.to_i


### PR DESCRIPTION
The issue was that the response for the describe_reserved_instances function didn't contain the offeringType for the reservations made. Managed to fix it by modifying line 16 in fog-1.3.1/lib/fog/aws/parsers/compute/describe_reserved_instances.rb from:
when 'availabilityZone', 'instanceType', 'productDescription', 'reservedInstancesId', 'state'
to:
when 'availabilityZone', 'instanceType', 'productDescription', 'reservedInstancesId', 'state', 'offeringType'
