### PR TITLE
[AWS|Autoscale] Fixing Parameters notes for autoscale create_launch_configuration for InstanceMonitoring.

### DIFF
--- a/lib/fog/aws/requests/auto_scaling/create_launch_configuration.rb
+++ b/lib/fog/aws/requests/auto_scaling/create_launch_configuration.rb
@@ -23,7 +23,7 @@ module Fog
         #     * 'Ebs.VolumeSize'<~Integer> - The volume size, in GigaBytes.
         #     * 'VirtualName'<~String> - The virtual name associated with the
         #       device.
-        #   * 'InstanceMonitoring.Enabled'<~Boolean> - Enable/Disable detailed monitoring, default is enabled:
+        #   * 'InstanceMonitoring.Enabled'<~Boolean> - Enable/Disable detailed monitoring, default is enabled
         #   * 'KernelId'<~String> - The ID of the kernel associated with the
         #     EC2 AMI.
         #   * 'KeyName'<~String> - The name of the EC2 key pair.
@@ -78,7 +78,7 @@ module Fog
             'BlockDeviceMappings'     => [],
             'CreatedTime'             => Time.now.utc,
             'ImageId'                 => image_id,
-            'InstanceMonitoring'      => { 'Enabled' => true },
+            'InstanceMonitoring.Enabled'      => true
             'InstanceType'            => instance_type,
             'KernelId'                => nil,
             'KeyName'                 => nil,


### PR DESCRIPTION
_NO REAL CODE COMMIT, ONLY MOCK AND COMMENTS_

So pretty much the notes for using create_launch_configuration are wrong for InstanceMonitoring as it seems either AWS changed or their was some plan to use the Hash in some different way but pretty much all you need to do is what I described in the notes and the mock has the example.  Credit goes to boto, https://github.com/boto/boto/blob/develop/boto/ec2/autoscale/__init__.py, for having it correct but this caused me a lot of pain as AWS API spec was not very clear.

Zuhaib
