### PR TITLE
Make aws compute server retry SSH on EHOSTUNREACH

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -210,7 +210,7 @@ module Fog
               Timeout::timeout(8) do
                 Fog::SSH.new(public_ip_address, username, credentials.merge(:timeout => 4)).run('pwd')
               end
-            rescue Errno::ECONNREFUSED
+            rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
               sleep(2)
               retry
             rescue Net::SSH::AuthenticationFailed, Timeout::Error


### PR DESCRIPTION
When bootstraping an EC2 server from a Heroku instance an EHOSTUNREACH exception is thrown. This makes bootstraping from Heroku impossible. I can't reproduce this from another EC2 instance or any other machine; only directly from Heroku.

Here are the steps I used to reproduce this problem on Heroku:

First setup the app (replace the AWS ENVs with your own):

```
mkdir -p fog-test && cd fog-test && git init .
heroku apps:create fog-test-$RANDOM -s cedar
bundle init && echo "gem 'fog'" >> Gemfile && bundle install
heroku config:add AWS_KEY=abc123 AWS_SECRET=def456
ssh-keygen -f id_rsa -P ''
git add . && git commit -m 'Initial commit with fog' && git push heroku
```

Then in a `heroku run irb` session I ran the following commands

```
require 'bundler/setup' # Needed for testing my patch
require 'fog'
key_name = 'fog-test'

connection = Fog::Compute.new(
               provider:              'AWS',
               aws_access_key_id:     ENV['AWS_KEY'],
               aws_secret_access_key: ENV['AWS_SECRET']
             )

connection.key_pairs.get(key_name).destroy if connection.key_pairs.get(key_name)
connection.import_key_pair(key_name, IO.read('id_rsa.pub')) if connection.key_pairs.get(key_name).nil?
server = connection.servers.bootstrap(
  username:          'ubuntu',
  key_name:          key_name,
  private_key_path:  'id_rsa',
  public_key_path:   'id_rsa.pub'
)

### FAILS HERE ###

# And don't forgot to cleanup the server and key:
server.destroy # Might not work if it failed to connect -- cleanup manually
connection.key_pairs.get(key_name).destroy if connection.key_pairs.get(key_name)
```

With my patched version this runs with no problem. Without it I get a `Errno::EHOSTUNREACH: No route to host - connect(2)`

Btw, I opened heroku ticket #53434 for this.
