### PR TITLE
Catch Errno::ETIMEDOUT timeout for new EC2 machines

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -210,7 +210,7 @@ module Fog
               Timeout::timeout(8) do
                 Fog::SSH.new(public_ip_address, username, credentials.merge(:timeout => 4)).run('pwd')
               end
-            rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+            rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ETIMEDOUT
               sleep(2)
               retry
             rescue Net::SSH::AuthenticationFailed, Timeout::Error


### PR DESCRIPTION
Is it possible that we should also catch Errno::ETIMEDOUT somewhere in here:
https://github.com/fog/fog/blob/master/lib/fog/aws/models/compute/server.rb#L213

Because I've been running into this little bugger:

``` ruby
Connection timed out - connect(2)
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/net-ssh-2.3.0/lib/net/ssh/transport/session.rb:66:in `initialize'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/net-ssh-2.3.0/lib/net/ssh/transport/session.rb:66:in `open'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/net-ssh-2.3.0/lib/net/ssh/transport/session.rb:66:in `initialize'
/usr/local/lib/ruby/1.8/timeout.rb:67:in `timeout'
/usr/local/lib/ruby/1.8/timeout.rb:101:in `timeout'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/net-ssh-2.3.0/lib/net/ssh/transport/session.rb:66:in `initialize'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/net-ssh-2.3.0/lib/net/ssh.rb:186:in `new'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/net-ssh-2.3.0/lib/net/ssh.rb:186:in `start'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/fog-1.3.1/lib/fog/core/ssh.rb:52:in `run'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/fog-1.3.1/lib/fog/aws/models/compute/server.rb:209:in `setup'
/usr/local/lib/ruby/1.8/timeout.rb:67:in `timeout'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/fog-1.3.1/lib/fog/aws/models/compute/server.rb:208:in `setup'
/usr/local/lib/ruby/1.8/timeout.rb:67:in `timeout'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/fog-1.3.1/lib/fog/aws/models/compute/server.rb:206:in `setup'
/something/instance-setup-fog/vendor/bundle/ruby/1.8/gems/fog-1.3.1/lib/fog/aws/models/compute/servers.rb:102:in `bootstrap'
```
