### PR TITLE
[xenserver] Added missing Server.tags attribute, minor fixes

### DIFF
--- a/lib/fog/xenserver.rb
+++ b/lib/fog/xenserver.rb
@@ -33,6 +33,8 @@ module Fog
           else
             if params.length.eql?(1) and params.first.is_a?(Hash)
               response = @factory.call(method, @credentials, params.first)
+            elsif params.length.eql?(2) and params.last.is_a?(Array)
+              response = @factory.call(method, @credentials, params.first, params.last)
             else
               response = eval("@factory.call('#{method}', '#{@credentials}', #{params.map {|p|  p.is_a?(String) ? "'#{p}'" : p}.join(',')})")
             end

--- a/lib/fog/xenserver/models/compute/server.rb
+++ b/lib/fog/xenserver/models/compute/server.rb
@@ -17,6 +17,7 @@ module Fog
         attribute :consoles
         attribute :domarch
         attribute :domid
+        attribute :tags
         attribute :__guest_metrics,      :aliases => :guest_metrics
         attribute :is_a_snapshot
         attribute :is_a_template

--- a/tests/xenserver/helper.rb
+++ b/tests/xenserver/helper.rb
@@ -1,5 +1,5 @@
 def test_template_name
-  'squeeze-test'
+  ENV['FOG_XENSERVER_TEMPLATE'] || 'squeeze-test'
 end
 
 def test_ephemeral_vm_name

--- a/tests/xenserver/models/compute/storage_repository_tests.rb
+++ b/tests/xenserver/models/compute/storage_repository_tests.rb
@@ -46,8 +46,8 @@ Shindo.tests('Fog::Compute[:xenserver] | StorageRepository model', ['xenserver']
   tests("A real StorageRepository should") do
     tests("return a valid list of VDIs") do
       storage_repository.vdis.each do |vdi| 
-        test("where #{vid.uuid} is a Fog::Compute::XenServer::VDI") {
-          p.is_a? Fog::Compute::XenServer::VDI
+        test("where #{vdi.uuid} is a Fog::Compute::XenServer::VDI") {
+          vdi.is_a? Fog::Compute::XenServer::VDI
         }
       end
     end

--- a/tests/xenserver/requests/compute/set_attribute_tests.rb
+++ b/tests/xenserver/requests/compute/set_attribute_tests.rb
@@ -44,8 +44,18 @@ Shindo.tests('Fog::Compute[:xenserver] | set_attribute request', ['xenserver']) 
 
       server.start
     end
+    test('set an array valued attribute') do
+      server = create_ephemeral_server
+      response = connection.set_attribute('VM',
+                                          server.reference,
+                                          'tags',
+                                          ['foo','bar']
+                                         )
+      server.reload
+      server.tags.include?('foo') and server.tags.include?('bar')
+    end
   end
-  
+
   tests('The expected options') do
     raises(ArgumentError, 'raises ArgumentError when ref,attr,value missing') { connection.get_record }
   end


### PR DESCRIPTION
Added support for Array parameters to Connection.request:

```
server = connection.server.create :name => 'fooserver',
                                  :template_name => 'debian-squeeze'
server.wait_for { ready? }
server.set_attribute 'tags', ['tagfoo', 'tagbar']
```

Added required shindo test for set_attribute request.
