### PR TITLE
Fix typo.

### DIFF
--- a/lib/fog/aws/requests/auto_scaling/create_launch_configuration.rb
+++ b/lib/fog/aws/requests/auto_scaling/create_launch_configuration.rb
@@ -78,7 +78,7 @@ module Fog
             'BlockDeviceMappings'     => [],
             'CreatedTime'             => Time.now.utc,
             'ImageId'                 => image_id,
-            'InstanceMonitoring.Enabled'      => true
+            'InstanceMonitoring.Enabled'      => true,
             'InstanceType'            => instance_type,
             'KernelId'                => nil,
             'KeyName'                 => nil,


### PR DESCRIPTION
This typo is causing a syntax error and the entire test suite to fail when running mocked.
