### PR TITLE
[ecloud|compute] Adding multiple disks at once was not working properly

### DIFF
--- a/lib/fog/ecloud/models/compute/server.rb
+++ b/lib/fog/ecloud/models/compute/server.rb
@@ -165,7 +165,7 @@ module Fog
         end
         
         def disks
-          c = hardware_configuration.storage[:Disk]
+          c = hardware_configuration.reload.storage[:Disk]
           c = c.is_a?(Hash) ? [c] : c
           @disks = c
         end


### PR DESCRIPTION
Fixed adding more than 1 disk at a time
