### PR TITLE
regularize examples showing use of AWS access keys

### DIFF
--- a/docs/cdn/index.markdown
+++ b/docs/cdn/index.markdown
@@ -20,8 +20,8 @@ Now you'll need to <a href="https://aws-portal.amazon.com/gp/aws/developer/subsc
     # create a connection to the service
     cdn = Fog::CDN.new({
       :provider               => 'AWS',
-      :aws_access_key_id      => AWS_ACCESS_KEY_ID,
-      :aws_secret_access_key  => AWS_SECRET_ACCESS_KEY
+      :aws_access_key_id      => YOUR_AWS_ACCESS_KEY_ID,
+      :aws_secret_access_key  => YOUR_AWS_SECRET_ACCESS_KEY
     }
 
 ## Setting Up Your CDN

--- a/docs/compute/index.markdown
+++ b/docs/compute/index.markdown
@@ -27,8 +27,8 @@ First, create a connection with your new account:
     # create a connection
     connection = Fog::Compute.new({
       :provider                 => 'AWS',
-      :aws_secret_access_key    => YOUR_SECRET_ACCESS_KEY,
-      :aws_access_key_id        => YOUR_SECRET_ACCESS_KEY_ID
+      :aws_access_key_id        => YOUR_AWS_ACCESS_KEY_ID,
+      :aws_secret_access_key    => YOUR_AWS_SECRET_ACCESS_KEY
     })
 
 With that in hand we are ready to start making EC2 calls!

--- a/docs/dns/index.markdown
+++ b/docs/dns/index.markdown
@@ -70,8 +70,8 @@ If you already have an account with another service you can just as easily use t
 
     dns = Fog::DNS.new({
       :provider               => 'AWS',
-      :aws_access_key_id      => AWS_ACCESS_KEY_ID,
-      :aws_secret_access_key  => AWS_SECRET_ACCESS_KEY
+      :aws_access_key_id      => YOUR_AWS_ACCESS_KEY_ID,
+      :aws_secret_access_key  => YOUR_AWS_SECRET_ACCESS_KEY
     })
 
 ## Go Forth and Resolve

--- a/docs/storage/index.markdown
+++ b/docs/storage/index.markdown
@@ -35,8 +35,8 @@ First, create a connection with your new account:
     # create a connection
     connection = Fog::Storage.new({
       :provider                 => 'AWS',
-      :aws_access_key_id        => YOUR_SECRET_ACCESS_KEY_ID,
-      :aws_secret_access_key    => YOUR_SECRET_ACCESS_KEY
+      :aws_access_key_id        => YOUR_AWS_ACCESS_KEY_ID,
+      :aws_secret_access_key    => YOUR_AWS_SECRET_ACCESS_KEY
     })
 
     # First, a place to contain the glorious details


### PR DESCRIPTION
Use the same order of keys and and same names of variables in the examples showing use of AWS access keys.

Minor documentation update.

It was a stupid mistake (https://github.com/fog/fog/issues/978) but I probably wouldn't have made it with these changes.
