### PR TITLE
fix response-cache-control typo for AWS signed urls

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -331,7 +331,7 @@ DATA
               partNumber
               policy
               requestPayment
-              reponse-cache-control
+              response-cache-control
               response-content-disposition
               response-content-encoding
               response-content-language

--- a/tests/aws/models/storage/url_tests.rb
+++ b/tests/aws/models/storage/url_tests.rb
@@ -1,0 +1,22 @@
+# encoding: utf-8
+
+Shindo.tests('AWS | url') do
+
+  @expires = DateTime.parse('2013-01-01T00:00:00Z').to_time.utc.to_i
+
+  @storage = Fog::Storage.new(
+    provider: 'AWS',
+    aws_access_key_id: '123',
+    aws_secret_access_key: 'abc',
+    region: 'us-east-1'
+  )
+  
+  @file = @storage.directories.new(key: 'fognonbucket').files.new(key: 'test.txt')
+
+  tests('#url w/ response-cache-control').returns(
+    'https://fognonbucket.s3.amazonaws.com/test.txt?response-cache-control=No-cache&AWSAccessKeyId=123&Signature=tajHIhKHAdFYsigmzybCpaq8N0Q%3D&Expires=1356998400'
+  ) do
+    @file.url(@expires, query: { 'response-cache-control' => 'No-cache' })
+  end
+
+end


### PR DESCRIPTION
I fixed a typo that I found while creating a AWS signed URLs using the `response-cache-control` query parameter.
