### PR TITLE
Prevents yard from trying to interpret the README.rdoc as a ruby source file

### DIFF
--- a/.document
+++ b/.document
@@ -1,3 +1,4 @@
-README.rdoc
 lib/**/*.rb
 bin/*
+-
+README.rdoc


### PR DESCRIPTION
When installing, YARD produces a non-threatening error:

```
Building YARD (yri) index for fog-1.3.1...
[error]: ParserSyntaxError: syntax error in `README.rdoc`:(3,47): syntax error, unexpected tIDENTIFIER, expecting keyword_do or '{' or '('
[error]: Stack trace:
    /Users/michael/.rvm/gems/ruby-1.9.3-p194@10genchef/gems/yard-0.7.5/lib/yard/parser/ruby/ruby_parser.rb:517:in `on_parse_error'
    /Users/michael/.rvm/gems/ruby-1.9.3-p194@10genchef/gems/yard-0.7.5/lib/yard/parser/ruby/ruby_parser.rb:49:in `parse'
    /Users/michael/.rvm/gems/ruby-1.9.3-p194@10genchef/gems/yard-0.7.5/lib/yard/parser/ruby/ruby_parser.rb:49:in `parse'
    /Users/michael/.rvm/gems/ruby-1.9.3-p194@10genchef/gems/yard-0.7.5/lib/yard/parser/ruby/ruby_parser.rb:15:in `parse'
    /Users/michael/.rvm/gems/ruby-1.9.3-p194@10genchef/gems/yard-0.7.5/lib/yard/parser/source_parser.rb:438:in `parse'
    /Users/michael/.rvm/gems/ruby-1.9.3-p194@10genchef/gems/yard-0.7.5/lib/yard/parser/source_parser.rb:361:in `parse_in_order'
```

According to [Yard setup](https://rubydoc.tenderapp.com/kb/getting-started-with-rubydocinfo/setting-up-a-yardopts-file), moving the file behind a "-" will prevent it from being compiled as ruby source code.

So it's either move this there, or edit the README to not terminate lines with colons. This seems easier.
