### PR TITLE
Add ssh_port to Fog::Compute::Server

### DIFF
--- a/lib/fog/compute/models/server.rb
+++ b/lib/fog/compute/models/server.rb
@@ -12,7 +12,7 @@ module Fog
         require 'net/scp'
         requires :public_ip_address, :username
 
-        scp_options = {}
+        scp_options = {:port => ssh_port}
         scp_options[:key_data] = [private_key] if private_key
         Fog::SCP.new(public_ip_address, username, scp_options).upload(local_path, remote_path, upload_options)
       end
@@ -23,7 +23,7 @@ module Fog
         require 'net/scp'
         requires :public_ip_address, :username
 
-        scp_options = {}
+        scp_options = {:port => ssh_port}
         scp_options[:key_data] = [private_key] if private_key
         Fog::SCP.new(public_ip_address, username, scp_options).download(remote_path, local_path, download_options)
       end
@@ -33,7 +33,12 @@ module Fog
         requires :public_ip_address, :username
 
         options[:key_data] = [private_key] if private_key
+        options[:port] ||= ssh_port
         Fog::SSH.new(public_ip_address, username, options).run(commands, &blk)
+      end
+
+      def ssh_port
+        22
       end
 
       def sshable?


### PR DESCRIPTION
This is for when a server may not be listening for ssh on port 22
