### PR TITLE
fix subnet tests in mocking mode

### DIFF
--- a/lib/fog/aws/requests/compute/create_subnet.rb
+++ b/lib/fog/aws/requests/compute/create_subnet.rb
@@ -54,7 +54,7 @@ module Fog
                   'state'                    => 'pending',
                   'vpcId'                    => Fog::AWS::Mock.request_id,
                   'cidrBlock'                => cidrBlock,
-                  'availableIpAddressCount'  => 16,
+                  'availableIpAddressCount'  => "255",
                   'availabilityZone'         => av_zone,
                   'tagSet'                   => {}
                 ]

--- a/lib/fog/aws/requests/compute/describe_subnets.rb
+++ b/lib/fog/aws/requests/compute/describe_subnets.rb
@@ -53,7 +53,7 @@ module Fog
                 'state'                    => 'pending',
                 'vpcId'                    => Fog::AWS::Mock.request_id,
                 'cidrBlock'                => '10.255.255.0/24',
-                'availableIpAddressCount'  => 255,
+                'availableIpAddressCount'  => "255",
                 'availabilityZone'         => 'us-east-1c',
                 'tagSet'                   => {}
               ]


### PR DESCRIPTION
quotes an integer to bring it inline with the strings returned by aws.
