### PR TITLE
[rackspace|identity] Better checking around hash/array responses.

### DIFF
--- a/lib/fog/rackspace/requests/identity/list_credentials.rb
+++ b/lib/fog/rackspace/requests/identity/list_credentials.rb
@@ -9,7 +9,7 @@ module Fog
             :path => "users/#{user_id}/OS-KSADM/credentials"
           )
 
-          if response.body.include? 'credential'
+          unless response.body['credentials'].is_a?(Array)
             response.body['credentials'] = [response.body['credential']]
             response.body.delete('credential')
           end

--- a/lib/fog/rackspace/requests/identity/list_tenants.rb
+++ b/lib/fog/rackspace/requests/identity/list_tenants.rb
@@ -9,7 +9,7 @@ module Fog
             :path => 'tenants'
           )
 
-          if response.body.include? 'tenant'
+          unless response.body['tenants'].is_a?(Array)
             response.body['tenants'] = [response.body['tenant']]
             response.body.delete('tenant')
           end

--- a/lib/fog/rackspace/requests/identity/list_user_roles.rb
+++ b/lib/fog/rackspace/requests/identity/list_user_roles.rb
@@ -9,7 +9,7 @@ module Fog
             :path => "users/#{user_id}/roles"
           )
 
-          if response.body.include? 'role'
+          unless response.body['roles'].is_a?(Array)
             response.body['roles'] = [response.body['role']]
             response.body.delete('role')
           end

--- a/lib/fog/rackspace/requests/identity/list_users.rb
+++ b/lib/fog/rackspace/requests/identity/list_users.rb
@@ -9,7 +9,7 @@ module Fog
             :path => 'users'
           )
 
-          if response.body.include? 'user'
+          unless response.body['users'].is_a?(Array)
             response.body['users'] = [response.body['user']]
             response.body.delete('user')
           end


### PR DESCRIPTION
Previously, the Identity API request methods simply checked for the existence of a key in the response to determine whether a single object or an array was returned. Using type checking should be a less fragile approach. Tests still pass.

/cc @brianhartsock 
