### PR TITLE
Fix :path pollution after re-authentication 

### DIFF
--- a/lib/fog/rackspace/storage.rb
+++ b/lib/fog/rackspace/storage.rb
@@ -100,7 +100,7 @@ module Fog
 
         def request(params, parse_json = true, &block)
           begin
-            response = @connection.request(params.merge!({
+            response = @connection.request(params.merge({
               :headers  => {
                 'Content-Type' => 'application/json',
                 'X-Auth-Token' => @auth_token


### PR DESCRIPTION
correct in compute.rb
https://github.com/fog/fog/commit/5c6ca0ee22ece7e86f798e2fa862258c99ad64ef
but not in storage.rb
