### PR TITLE
SSH connections don't seem to use passed SSH keys first

### DIFF
--- a/lib/fog/core/scp.rb
+++ b/lib/fog/core/scp.rb
@@ -52,6 +52,14 @@ module Fog
           raise ArgumentError.new(':key_data, :keys, :password or a loaded ssh-agent is required to initialize SSH')
         end
 
+        if options[:key_data] || options[:keys]
+          options[:keys_only] = true
+          #Explicitly set these so net-ssh doesn't add the default keys
+          #as seen at https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/authentication/session.rb#L131-146
+          options[:keys] = [] unless options[:keys]
+          options[:key_data] = [] unless options[:key_data]
+        end
+
         @address  = address
         @username = username
         @options  = { :paranoid => false }.merge(options)

--- a/lib/fog/core/ssh.rb
+++ b/lib/fog/core/ssh.rb
@@ -46,6 +46,14 @@ module Fog
           raise ArgumentError.new(':key_data, :keys, :password or a loaded ssh-agent is required to initialize SSH')
         end
 
+        if options[:key_data] || options[:keys]
+          options[:keys_only] = true
+          #Explicitly set these so net-ssh doesn't add the default keys
+          #as seen at https://github.com/net-ssh/net-ssh/blob/master/lib/net/ssh/authentication/session.rb#L131-146
+          options[:keys] = [] unless options[:keys]
+          options[:key_data] = [] unless options[:key_data]
+        end
+
         @address  = address
         @username = username
         @options  = { :paranoid => false }.merge(options)


### PR DESCRIPTION
I have a Jenkins server which runs on an .ssh/config file, looking like this:

```
Host *
    PreferredAuthentications publickey,keyboard-interactive,password
    StrictHostKeyChecking no
    UserKnownHostsFile /dev/null
    CheckHostIP no
IdentityFile /var/lib/jenkins/.ssh/id_rsa
IdentityFile /var/lib/jenkins/keys/something/ssh/default
IdentityFile /var/lib/jenkins/keys/something2/ssh/default
IdentityFile /var/lib/jenkins/keys/something3/ssh/default
IdentityFile /var/lib/jenkins/keys/something4/ssh/default
IdentityFile /var/lib/jenkins/keys/something5/ssh/default
```

Bunch of identity files, but it really shouldn't matter because I explicitly pass the SSH key to fog:

```
Fog.credential = 'project_qa_key'
<stuff>
Fog.credentials = Fog.credentials.merge(
{
    :private_key_path => "./keys/project_qa_id_rsa", 
    :public_key_path => "./keys/project_qa_id_rsa.pub"
})
<stuff>
connection.import_key_pair('project_qa_key', IO.read('./keys/project_qa_id_rsa.pub')) if connection.key_pairs.get('project_qa_key').nil?
<stuff>
 server_attributes = {
  :flavor_id => instance_size,
  :tags => tags_for_the_server,
  :image_id => chosen_image_id,
  :key_name => 'project_qa_key',
  :groups => ['bla_dev']
}
server = connection.servers.bootstrap(server_attributes)
```

The strange part, if I have too many "IdentityFile" entries, I will end up with this error:

```
disconnected: Too many authentication failures for ubuntu (2)
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/transport/session.rb:176:in `poll_message'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/transport/session.rb:166:in `loop'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/transport/session.rb:166:in `poll_message'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/transport/session.rb:151:in `next_message'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/session.rb:94:in `next_message'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/session.rb:93:in `loop'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/session.rb:93:in `next_message'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/methods/publickey.rb:53:in `authenticate_with'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/methods/publickey.rb:20:in `authenticate'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/key_manager.rb:121:in `each_identity'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/key_manager.rb:118:in `each'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/key_manager.rb:118:in `each_identity'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/methods/publickey.rb:19:in `authenticate'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/session.rb:78:in `authenticate'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/session.rb:65:in `each'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh/authentication/session.rb:65:in `authenticate'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/net-ssh-2.5.2/lib/net/ssh.rb:190:in `start'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/core/ssh.rb:58:in `run'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/compute/models/server.rb:37:in `ssh'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/compute/models/server.rb:45:in `sshable?'
/usr/local/lib/ruby/1.8/timeout.rb:67:in `timeout'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/compute/models/server.rb:45:in `sshable?'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/aws/models/compute/server.rb:214:in `setup'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/core/model.rb:64:in `instance_eval'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/core/model.rb:64:in `wait_for'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/core/wait_for.rb:6:in `wait_for'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/core/model.rb:55:in `wait_for'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/aws/models/compute/server.rb:214:in `setup'
/vol/ebs1/jenkins/jobs/project-stage-setup/workspace/instance_setup/vendor/bundle/ruby/1.8/gems/fog-1.4.0/lib/fog/aws/models/compute/servers.rb:102:in `bootstrap'
```

If I comment out 3-4 of them, the bootstrap will be successful.
In http://net-ssh.rubyforge.org/ssh/v2/api/classes/Net/SSH.html#M000002 , there is a parameter to the start() method called:

> :keys_only => set to true to use only private keys from keys and key_data parameters, even if ssh-agent offers more identities. This option is intended for situations where ssh-agent offers many different identites.    

I think adding this to https://github.com/fog/fog/blob/master/lib/fog/core/ssh.rb#L51 might solve the problem, but I'm still thinking through this, so feel free to add comments :)    
