### PR TITLE
[aws|storage] Default to false for persistent connections.

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -284,7 +284,7 @@ module Fog
               "s3-#{options[:region]}.amazonaws.com"
             end
             @path       = options[:path]        || '/'
-            @persistent = options.fetch(:persistent, true)
+            @persistent = options.fetch(:persistent, false)
             @port       = options[:port]        || 443
             @scheme     = options[:scheme]      || 'https'
           end


### PR DESCRIPTION
Using false provides for a more stable solution by default.

@geemus, this is the pull request discussed in #1021.  Thank you for your help with this issue.
