### PR TITLE
fog bombs out using ruby 1.8.x because it cannot find Mutex without requiring thread.

### DIFF
--- a/lib/fog/core/current_machine.rb
+++ b/lib/fog/core/current_machine.rb
@@ -1,3 +1,4 @@
+require 'thread'
 module Fog
   class CurrentMachine
     @@lock = Mutex.new


### PR DESCRIPTION
fog bombs out because it cannot find Mutex without requiring thread.
