### PR TITLE
Add support for multiple regions in OpenStack

### DIFF
--- a/lib/fog/core/errors.rb
+++ b/lib/fog/core/errors.rb
@@ -57,6 +57,7 @@ An alternate file may be used by placing its path in the FOG_RC environment vari
   :openstack_username:
   :openstack_auth_url:
   :openstack_tenant:
+  :openstack_region:
   :ovirt_username:
   :ovirt_password:
   :ovirt_url:

--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -80,6 +80,7 @@ module Fog
       @service_name         = options[:openstack_service_name]
       @identity_service_name = options[:openstack_identity_service_name]
       @endpoint_type         = options[:openstack_endpoint_type] || 'publicURL'
+      @openstack_region      = options[:openstack_region]
 
       if @openstack_auth_token
         req_body = {
@@ -131,6 +132,12 @@ module Fog
         end
         svc = body['access']['serviceCatalog'].
           detect{|x| @service_name.include?(x['type']) }
+      end
+
+      svc['endpoints'] = svc['endpoints'].select{ |x| x['region'] == @openstack_region } if @openstack_region
+      if svc['endpoints'].count > 1
+         regions = svc["endpoints"].map { |x| x['region'] }.uniq.join(',')
+         raise Errors::NotFound.new("Multiple regions available choose one of these '#{regions}'")
       end
 
       identity_svc = body['access']['serviceCatalog'].

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -9,7 +9,7 @@ module Fog
       recognizes :openstack_auth_token, :openstack_management_url,
                  :persistent, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
-                 :current_user, :current_tenant
+                 :current_user, :current_tenant, :openstack_region
 
       ## MODELS
       #
@@ -249,6 +249,7 @@ module Fog
           @openstack_must_reauthenticate  = false
           @openstack_service_name = options[:openstack_service_name] || ['nova', 'compute']
           @openstack_identity_service_name = options[:openstack_identity_service_name] || 'identity'
+          @openstack_region      = options[:openstack_region]
 
           @connection_options = options[:connection_options] || {}
 
@@ -267,6 +268,7 @@ module Fog
             :openstack_auth_token     => @auth_token,
             :openstack_management_url => @openstack_management_url,
             :openstack_identity_endpoint => @openstack_identity_public_endpoint,
+            :openstack_region         => @openstack_region,
             :current_user             => @current_user,
             :current_tenant           => @current_tenant }
         end
@@ -319,6 +321,7 @@ module Fog
               :openstack_username => @openstack_username,
               :openstack_auth_token => @openstack_auth_token,
               :openstack_auth_uri => @openstack_auth_uri,
+              :openstack_region   => @openstack_region,
               :openstack_tenant   => @openstack_tenant,
               :openstack_service_name => @openstack_service_name,
               :openstack_identity_service_name => @openstack_identity_service_name


### PR DESCRIPTION
Multiple endpoints for the same service can be returned by identity, one for each service region.

This patch adds support for this, when multiple regions are returned an error is raised unless a region is choosed using a new opentack_region parameter.
