### PR TITLE
Stop vSphere vms before destroying, or destroy will fail

### DIFF
--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -71,6 +71,7 @@ module Fog
 
         def destroy(options = {})
           requires :instance_uuid
+          stop if ready? # need to turn it off before destroying
           connection.vm_destroy('instance_uuid' => instance_uuid)
         end
 


### PR DESCRIPTION
vSphere throws an error trying to destroy a running vm
Seems that in other providers destroy will go ahead whether the vm is running or not, so vSphere should do the same
