### PR TITLE
[AWS|Autoscaling] fix group#instances returning all autoscaled instances...

### DIFF
--- a/lib/fog/aws/models/auto_scaling/group.rb
+++ b/lib/fog/aws/models/auto_scaling/group.rb
@@ -73,10 +73,7 @@ module Fog
         end
 
         def instances
-          Fog::AWS::AutoScaling::Instances.new({
-            :data => attributes['Instances'],
-            :connection => connection
-          })
+          Fog::AWS::AutoScaling::Instances.new(:connection => connection).load(attributes[:instance])
         end
 
         def instances_in_service


### PR DESCRIPTION
attributes[:instances] already has all the data - we just need to load it into a collection

addresses #960
