### PR TITLE
Default to being less pessimistic about excon

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
   s.add_dependency('builder')
-  s.add_dependency('excon', '~>0.14.0')
+  s.add_dependency('excon', '~>0.14')
   s.add_dependency('formatador', '~>0.2.0')
   s.add_dependency('multi_json', '~>1.0')
   s.add_dependency('mime-types')


### PR DESCRIPTION
Require anything greater than 0.14
- It limits using more recent gems through a project
- If there are explicit breaking changes in future versions, then add an additional <=
