### PR TITLE
Change SQS Endpoints to sqs.<region>.amazonaws.com

### DIFF
--- a/lib/fog/aws/sqs.rb
+++ b/lib/fog/aws/sqs.rb
@@ -83,12 +83,8 @@ module Fog
           setup_credentials(options)
           @connection_options     = options[:connection_options] || {}
           options[:region] ||= 'us-east-1'
-          @host = options[:host] || case options[:region]
-          when 'us-east-1'
-            'queue.amazonaws.com'
-          else
-            "#{options[:region]}.queue.amazonaws.com"
-          end
+          @host = options[:host] || "sqs.#{options[:region]}.amazonaws.com"
+
           @path       = options[:path]        || '/'
           @persistent = options[:persistent]  || false
           @port       = options[:port]        || 443


### PR DESCRIPTION
The SQS API endpoints as defined in
http://docs.amazonwebservices.com/general/latest/gr/rande.html#sqs_region
use sqs.<region>.amazonaws.com while fog is currently using <region>.queue.amazonaws.com

We have had a few issues with the <region>.queue.amazonaws.com endpoints causing 403 errors with SignatureDoesNotMatch and SIGTERM problems. 

This commit changes to the published endpoints.

Best
Stu
