### PR TITLE
[aws|compute] Nicer interface for security group authorizations

### DIFF
--- a/lib/fog/aws/models/compute/security_group.rb
+++ b/lib/fog/aws/models/compute/security_group.rb
@@ -242,11 +242,26 @@ module Fog
 
         private
 
-        def group_info(group_str)
-          account, group = group_str.split(":")
-
-          if account.empty? || group.nil? || group.empty?
-            raise ArgumentError, "group must be specified in form of \"<account id>:<group name or id>\", #{group_str} given"
+        #
+        # +group_arg+ may be a string or a hash with one key & value.
+        #
+        # If group_arg is a string, it is assumed to be the group name,
+        # and the UserId is assumed to be self.owner_id.
+        #
+        # The "account:group" form is deprecated.
+        #
+        # If group_arg is a hash, the key is the UserId and value is the group.
+        def group_info(group_arg)
+          if Hash === group_arg
+            account = group_arg.keys.first
+            group   = group_arg.values.first
+          elsif group_arg.match(/:/)
+            account, group = group_arg.split(':')
+            Fog::Logger.deprecation("'account:group' argument is deprecated. Use {account => group} or just group instead")
+          else
+            requires :owner_id
+            account = owner_id
+            group = group_arg
           end
 
           info = { 'UserId' => account }

--- a/tests/aws/models/compute/security_group_tests.rb
+++ b/tests/aws/models/compute/security_group_tests.rb
@@ -6,6 +6,7 @@ Shindo.tests("Fog::Compute[:aws] | security_group", ['aws']) do
     @group = Fog::Compute[:aws].security_groups.create(:name => "foggroup", :description => "fog group desc")
 
     @other_group = Fog::Compute[:aws].security_groups.create(:name => 'fog other group', :description => 'another fog group')
+    @other_group.reload
 
     test("authorize access by another security group") do
       @group.authorize_group_and_owner(@other_group.name)
@@ -31,18 +32,26 @@ Shindo.tests("Fog::Compute[:aws] | security_group", ['aws']) do
       @group.ip_permissions.empty?
     end
 
-    test("authorize port range access by another security group") do
-      @other_group.reload
-      @group.authorize_port_range(5000..6000, {:group => "#{@other_group.owner_id}:#{@other_group.group_id}"})
-      @group.reload
-      @group.ip_permissions.size == 1
-    end
+    group_forms = [
+      "#{@other_group.owner_id}:#{@other_group.group_id}", # deprecated form
+      @other_group.group_id,
+      {@other_group.owner_id => @other_group.group_id}
+    ]
 
-    test("revoke port range access by another security group") do
-      @other_group.reload
-      @group.revoke_port_range(5000..6000, {:group => "#{@other_group.owner_id}:#{@other_group.group_id}"})
-      @group.reload
-      @group.ip_permissions.empty?
+    group_forms.each do |group_arg|
+      test("authorize port range access by another security group #{group_arg.inspect}") do
+        @other_group.reload
+        @group.authorize_port_range(5000..6000, {:group => group_arg})
+        @group.reload
+        @group.ip_permissions.size == 1
+      end
+
+      test("revoke port range access by another security group") do
+        @other_group.reload
+        @group.revoke_port_range(5000..6000, {:group => group_arg})
+        @group.reload
+        @group.ip_permissions.empty?
+      end
     end
 
     @other_group.destroy


### PR DESCRIPTION
Don't use a specially formatted string for passing two arguments. Use a
hash instead.

This changes the interface introduced in pull #986.

Default to using self.owner_id as the account if not specified.
