### PR TITLE
Revert 530122d

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -241,9 +241,7 @@ module Fog
         # Currently only one ip address is returned, but in the future this could be multiple
         # if the server has multiple network interface
         def addresses(connection=connection, options={})
-          unless mac = self.mac
-            mac = Nokogiri::XML(`virsh dumpxml #{self.name}`).xpath('//domain/devices/interface/mac').first.attribute('address').content
-          end
+          mac=self.mac
 
           # Aug 24 17:34:41 juno arpwatch: new station 10.247.4.137 52:54:00:88:5a:0a eth0.4
           # Aug 24 17:37:19 juno arpwatch: changed ethernet address 10.247.4.137 52:54:00:27:33:00 (52:54:00:88:5a:0a) eth0.4


### PR DESCRIPTION
This commit reverts commit 530122d. Commit 530122d contained changes to
how the mac address for an domain's interfaces was retrieved.  The
change was made due to an broken development environment and was
unnecessary.
