### PR TITLE
fix reboot guest in vsphere to reboot rather than shutdown guest

### DIFF
--- a/lib/fog/aws/requests/elb/create_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer.rb
@@ -77,7 +77,7 @@ module Fog
             'AvailabilityZones' => availability_zones,
             'Subnets' => options[:subnet_ids],
             'Scheme' => options[:scheme].nil? ? 'internet-facing' : options[:scheme],
-            'SecurityGroups' => options[:security_groups],
+            'SecurityGroups' => options[:security_groups].nil? ? [] : options[:security_groups],
             'CanonicalHostedZoneName' => '',
             'CanonicalHostedZoneNameID' => '',
             'CreatedTime' => Time.now,

--- a/lib/fog/vsphere/requests/compute/vm_reboot.rb
+++ b/lib/fog/vsphere/requests/compute/vm_reboot.rb
@@ -15,7 +15,7 @@ module Fog
             task.wait_for_completion
             { 'task_state' => task.info.result, 'reboot_type' => 'reset_power' }
           else
-            vm_mob_ref.ShutdownGuest
+            vm_mob_ref.RebootGuest
             { 'task_state' => "running", 'reboot_type' => 'reboot_guest' }
           end
         end


### PR DESCRIPTION
fix reboot guest in vsphere to reboot rather than shutdown guest, also fixes a mocking test in aws security groups.
