### PR TITLE
Make private IP address available in Rackspace server

### DIFF
--- a/lib/fog/rackspace/models/compute/server.rb
+++ b/lib/fog/rackspace/models/compute/server.rb
@@ -49,7 +49,7 @@ module Fog
         end
 
         def private_ip_address
-          nil
+          addresses['private'].first
         end
 
         def private_key_path


### PR DESCRIPTION
These seems like a simple update to me, but, I'm new to this. Does anyone have any constructive feedback? The method originally returned nil, but the value is present in the source array (implementation as in the public_ip_address method).
