### PR TITLE
CloudStack: images.get always returns nil

### DIFF
--- a/lib/fog/cloudstack/models/compute/images.rb
+++ b/lib/fog/cloudstack/models/compute/images.rb
@@ -10,23 +10,32 @@ module Fog
         model Fog::Compute::Cloudstack::Image
 
         def all(filters={})
-          options = {
-            'templatefilter' => 'self'
-          }.merge(filters)
+          options = get_filter_options(filters)
 
           data = connection.list_templates(options)["listtemplatesresponse"]["template"] || []
           load(data)
         end
 
-        def get(template_id)
-          if template = connection.list_templates('id' => template_id)["listtemplatesresponse"]["template"].first
+        def get(template_id, filters={})
+          filter_option = get_filter_options(filters)
+          options = filter_option.merge('id' => template_id)
+
+          if template = connection.list_templates(options)["listtemplatesresponse"]["template"].first
             new(template)
           end
         rescue Fog::Compute::Cloudstack::BadRequest
           nil
         end
-      end
 
+        private
+
+        def get_filter_options(filters)
+          default_filter = {
+              'templatefilter' => 'self'
+          }
+          default_filter.merge(filters)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Here is the test code:

```
> compute.images.all
=> <Fog::Compute::Cloudstack::Images
[
  <Fog::Compute::Cloudstack::Image
    id=1003,
    ...
]

> compute.images.get 1003
=> nil
```

This happens because according to the [CloudFoundry API Reference for method listTemplates](http://download.cloud.com/releases/3.0.0/api_3.0.0/user/listTemplates.html) it has required parameter _templatefilter_ that is not specified in the _get_ method implementation.
