### PR TITLE
[rackspace|compute] Set password attribute on V2 servers.

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -41,6 +41,8 @@ module Fog
         attribute :flavor_id, :aliases => 'flavor', :squash => 'id'
         attribute :image_id, :aliases => 'image', :squash => 'id'
 
+        attr_reader :password
+
         def save
           if identity
             update
@@ -121,7 +123,14 @@ module Fog
           requires :identity
           connection.change_server_password(identity, password)
           self.state = PASSWORD
+          @password = password
           true
+        end
+
+        private
+
+        def adminPass=(new_admin_pass)
+          @password = new_admin_pass
         end
       end
     end

--- a/tests/rackspace/models/compute_v2/server_tests.rb
+++ b/tests/rackspace/models/compute_v2/server_tests.rb
@@ -54,6 +54,7 @@ Shindo.tests('Fog::Compute::RackspaceV2 | server', ['rackspace']) do
     tests('#change_admin_password').succeeds do
       @instance.change_admin_password('somerandompassword')
       returns('PASSWORD') { @instance.state }
+      returns('somerandompassword') { @instance.password }
     end
 
     @instance.wait_for { ready? }


### PR DESCRIPTION
I missed this during my first pass on Rackspace Cloud Servers v2.
