### PR TITLE
Move Dynect endpoint from api2 to api-v4

### DIFF
--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -65,7 +65,7 @@ module Fog
           @dynect_password = options[:dynect_password]
 
           @connection_options = options[:connection_options] || {}
-          @host       = 'api2.dynect.net'
+          @host       = 'api-v4.dynect.net'
           @port       = options[:port]        || 443
           @path       = options[:path]        || '/REST'
           @persistent = options[:persistent]  || false


### PR DESCRIPTION
I've had the problem before that Dynects api2 will fail when being called from a system that has both, IPv6 and IPv4 connectivity.
The message returned looks something like this:

```
@body="{\"status\": \"failure\", \"data\": {}, \"job_id\": 1234567890, \"msgs\": [{\"INFO\": \"login: IP address does not match current session\", \"SOURCE\": \"BLL\", \"ERR_CD\": \"INVALID_DATA\", \"LVL\": \"ERROR\"}, {\"INFO\": \"login: There was a problem with your credentials\", \"SOURCE\": \"BLL\", \"ERR_CD\": null, \"LVL\": \"INFO\"}]}", @status=400>
```

For our own (custom) library this was fixed by just moving from the 'api2.dynect.net' endpoint to 'api-v4.dynect.net'. We didn't change anything else and it just worked for us.
I just tried this locally and switching the endpoint solved the problem in fog for me.
