### PR TITLE
Rewrite tests to use 1.8 compatible Hash syntax

### DIFF
--- a/tests/aws/models/iam/policies_tests.rb
+++ b/tests/aws/models/iam/policies_tests.rb
@@ -14,7 +14,7 @@ Shindo.tests("Fog::Compute[:iam] | policies", ['aws','iam']) do
   
   tests('#create') do 
     tests('a valid policy').succeeds do
-      policy = @user.policies.create(id: @policy_name, document: @policy_document)
+      policy = @user.policies.create(:id => @policy_name, :document => @policy_document)
       policy.id == @policy_name
       policy.username == @username
       policy.document == @policy_document
@@ -26,7 +26,7 @@ Shindo.tests("Fog::Compute[:iam] | policies", ['aws','iam']) do
     #end
   end
   
-  @user.policies.create(id: 'another-policy', document: {})
+  @user.policies.create(:id => 'another-policy', :document => {})
   
   tests('#all','there are two policies').succeeds do
     @user.policies.size == 2

--- a/tests/aws/models/storage/url_tests.rb
+++ b/tests/aws/models/storage/url_tests.rb
@@ -5,13 +5,13 @@ Shindo.tests('AWS | url') do
   @expires = DateTime.parse('2013-01-01T00:00:00Z').to_time.utc.to_i
 
   @storage = Fog::Storage.new(
-    provider: 'AWS',
-    aws_access_key_id: '123',
-    aws_secret_access_key: 'abc',
-    region: 'us-east-1'
+    :provider => 'AWS',
+    :aws_access_key_id => '123',
+    :aws_secret_access_key => 'abc',
+    :region => 'us-east-1'
   )
   
-  @file = @storage.directories.new(key: 'fognonbucket').files.new(key: 'test.txt')
+  @file = @storage.directories.new(:key => 'fognonbucket').files.new(:key => 'test.txt')
 
   if Fog.mock?
     signature = Fog::Storage::AWS.new.signature(nil)
@@ -22,7 +22,7 @@ Shindo.tests('AWS | url') do
   tests('#url w/ response-cache-control').returns(
     "https://fognonbucket.s3.amazonaws.com/test.txt?response-cache-control=No-cache&AWSAccessKeyId=123&Signature=#{signature}&Expires=1356998400"
   ) do
-    @file.url(@expires, query: { 'response-cache-control' => 'No-cache' })
+    @file.url(@expires, :query => { 'response-cache-control' => 'No-cache' })
   end
 
 end


### PR DESCRIPTION
Some Ruby 1.9 style hashes were used in some tests meaning syntax errors when attempting to run with 1.8.

I've rewritten them to the older form and things are testable again.
