### PR TITLE
Add barebones configuration for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: ruby
+rvm:
+  - 1.9.3


### PR DESCRIPTION
Only mocked tests are run on Travis, but this still appears to be valuable. 

3 tests still failing per #1090.
