### PR TITLE
[compute|Ecloud] Fixed ecloud provider showing as available when no credentials were provided.

### DIFF
--- a/lib/fog/bin/ecloud.rb
+++ b/lib/fog/bin/ecloud.rb
@@ -1,6 +1,10 @@
 class Ecloud < Fog::Bin
   class << self
 
+    def available?
+      Fog::Ecloud::ECLOUD_OPTIONS.all? {|requirement| Fog.credentials.include?(requirement)}
+    end
+
     def class_for(key)
       case key
       when :compute

--- a/lib/fog/ecloud.rb
+++ b/lib/fog/ecloud.rb
@@ -9,3 +9,9 @@ module Fog
 
   end
 end
+
+module Fog
+  module Ecloud
+    ECLOUD_OPTIONS = [:ecloud_authentication_method]
+  end
+end


### PR DESCRIPTION
Ecloud provider will no longer show as an available provider when you have no credentials for it.
