### PR TITLE
notify #ruby-fog on freenode instead of emailing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,15 @@ rvm:
   - 1.9.3
 
 script: FOG_MOCK=true bundle exec shindont
+
+notifications:
+  email: false
+  irc: 
+    channels:
+      - "irc.freenode.org#ruby-fog"
+    template:
+      - "%{repository_url} (%{commit}) : %{message} %{foo} "
+      - "Build details: %{build_url}"
+    on_success: always
+    on_failure: always
+    use_notice: false


### PR DESCRIPTION
Travis occasionally sends emails to the wrong address when a repo is owned by a group. This sends notifications to the already existing freenode room, and does not send emails.
