### PR TITLE
remove repository_url from notification template

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ notifications:
     channels:
       - "irc.freenode.org#ruby-fog"
     template:
-      - "%{repository_url} (%{commit}) : %{message} %{foo} "
-      - "Build details: %{build_url}"
+      - "[#%{build_number}] %{message} %{build_url}"
+      - "[#%{build_number}] %{commit} on %{branch} by %{author}"
+      - "[#%{build_number}] %{compare_url}"
     on_success: always
     on_failure: always
     use_notice: false


### PR DESCRIPTION
Interpolation of %{repository_url} is currently broken on Travis CI. See [travis-ci #669](https://github.com/travis-ci/travis-ci/issues/669)
