### PR TITLE
use 10.04 instead of 12.04

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -64,7 +64,7 @@ module Fog
             when 'eu-west-1'
               'ami-3d1f2b49'
             when 'sa-east-1'
-              'ami-5c03dd41'
+              'ami-d0429ccd'
             when 'us-east-1'
               'ami-3202f25b'
             when 'us-west-1'


### PR DESCRIPTION
If I had read the comment above I would have picked the correct ami (10.04 LTS)
