### PR TITLE
Submit password/ssh_key/username through POST body

### DIFF
--- a/lib/fog/bluebox/requests/compute/create_block.rb
+++ b/lib/fog/bluebox/requests/compute/create_block.rb
@@ -6,8 +6,9 @@ module Fog
         # Create a new block
         #
         # ==== Parameters
-        # * product_id<~Integer> - Id of product to create block with
-        # * template_id<~Integer> - Id of template to create block with
+        # * product_id<~String> - ID of product to create block with
+        # * template_id<~String> - ID of template to create block with
+        # * location_id<~String> - ID of location to create block in
         # * options<~Hash>:
         #     * password<~String> - Password for block
         #   or
@@ -17,13 +18,26 @@ module Fog
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
-        # TODO
         def create_block(product_id, template_id, location_id, options = {})
+
+          unless options.has_key?(:password) || options.has_key?(:ssh_key)
+            raise ArgumentError, 'Either password or ssh_key must be supplied'
+          end
+
+          query = {
+            'product'  => product_id,
+            'template' => template_id,
+            'location' => location_id
+          }
+
+          body = URI.encode options.map {|k,v| "#{k}=#{v}"}.join('&')
+
           request(
             :expects  => 200,
             :method   => 'POST',
             :path     => '/api/blocks.json',
-            :query    => {'product' => product_id, 'template' => template_id, 'location' => location_id}.merge!(options)
+            :query    => query,
+            :body     => URI.encode(body)
           )
         end
 


### PR DESCRIPTION
Password or ssh_key, and username are currently submitted through the
request's querystring, which means they will appear in server logs.

This change moves the sensitive parameters to the request body, adds
client-side checking of the required parameters, and corrects the method
documentation to reflect addition of location_id parameter and specify
the parameter types as strings (they are alpha-numeric UUIDs).
