### PR TITLE
Update public_url to handle new header casings from Rackspace

### DIFF
--- a/lib/fog/rackspace/models/storage/directory.rb
+++ b/lib/fog/rackspace/models/storage/directory.rb
@@ -39,11 +39,11 @@ module Fog
           requires :key
           @public_url ||= begin
             begin response = connection.cdn.head_container(key)
-              if response.headers['X-CDN-Enabled'] == 'True'
+              if response.headers['X-Cdn-Enabled'] == 'True'
                 if connection.rackspace_cdn_ssl == true
-                  response.headers['X-CDN-SSL-URI']
+                  response.headers['X-Cdn-Ssl-Uri']
                 else
-                  cdn_cname || response.headers['X-CDN-URI']
+                  cdn_cname || response.headers['X-Cdn-Uri']
                 end
               end
             rescue Fog::Service::NotFound


### PR DESCRIPTION
For some reason here in the past week or so Rackspace decided to start returning the `X-CDN-URI` headers as `X-Cdn-Uri`, which causes the `public_url` methods to return `nil`.

This patch fixes that, but I'm worried they'll arbitrarily switch back at some point or do something equally as inane.
