### PR TITLE
IncludeAllInstances parameter added to Fog::Compute::AWS::Real.describe_instance_status

### DIFF
--- a/lib/fog/aws/requests/compute/describe_instance_status.rb
+++ b/lib/fog/aws/requests/compute/describe_instance_status.rb
@@ -11,6 +11,7 @@ module Fog
           raise ArgumentError.new("Filters must be a hash, but is a #{filters.class}.") unless filters.is_a?(Hash)
           next_token = filters.delete('nextToken') || filters.delete('NextToken')
           max_results = filters.delete('maxResults') || filters.delete('MaxResults')
+          all_instances = filters.delete('includeAllInstances') || filters.delete('IncludeAllInstances')
 
           params = Fog::AWS.indexed_request_param('InstanceId', filters.delete('InstanceId'))
 
@@ -18,6 +19,7 @@ module Fog
 
           params['NextToken'] = next_token if next_token
           params['MaxResults'] = max_results if max_results
+          params['IncludeAllInstances'] = all_instances if all_instances
 
           request({
             'Action'    => 'DescribeInstanceStatus',


### PR DESCRIPTION
Added a request parameter _IncludeAllInstances_ which was unsupported by fog - it is described in [AWS doc](http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeInstanceStatus.html), _Request Parameters_ section.
