### PR TITLE
Addressing issue #1049: When using mock mode, Range header is ignored in get_object()

### DIFF
--- a/tests/aws/requests/storage/object_tests.rb
+++ b/tests/aws/requests/storage/object_tests.rb
@@ -26,6 +26,14 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
       data
     end
 
+    tests("#get_object('#{@directory.identity}', 'fog_object', {'Range' => 'bytes=0-20'})").returns(lorem_file.read[0..20]) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', {'Range' => 'bytes=0-20'}).body
+    end
+
+    tests("#get_object('#{@directory.identity}', 'fog_object', {'Range' => 'bytes=0-0'})").returns(lorem_file.read[0..0]) do
+      Fog::Storage[:aws].get_object(@directory.identity, 'fog_object', {'Range' => 'bytes=0-0'}).body
+    end
+
     tests("#head_object('#{@directory.identity}', 'fog_object')").succeeds do
       Fog::Storage[:aws].head_object(@directory.identity, 'fog_object')
     end


### PR DESCRIPTION
Now the Range header is accepted and it returns subset of data according to byte range. Range header parsing is implemented using Rack::Utils#byte_ranges code.

It solves issue: https://github.com/fog/fog/issues/1049
