### PR TITLE
[hp|storage] Use response_block param, as excon has deprecated implicit blocks

### DIFF
--- a/lib/fog/hp/requests/storage/get_object.rb
+++ b/lib/fog/hp/requests/storage/get_object.rb
@@ -10,12 +10,18 @@ module Fog
         # * object<~String> - Name of object to look for
         #
         def get_object(container, object, &block)
-          response = request({
+          params = {}
+
+          if block_given?
+            params[:response_block] = Proc.new
+          end
+
+          response = request(params.merge!({
             :block    => block,
             :expects  => 200,
             :method   => 'GET',
             :path     => "#{Fog::HP.escape(container)}/#{Fog::HP.escape(object)}"
-          }, false, &block)
+          }), false)
           response
         end
 


### PR DESCRIPTION
Excon has deprecated implicit blocks (geemus/excon@2a67955ed84056d5cb5a9e61a9fe63d22a4b3014)
