### PR TITLE
Enable AWS spot requests in a VPC by specifying subnet_id

### DIFF
--- a/lib/fog/aws/parsers/compute/spot_instance_requests.rb
+++ b/lib/fog/aws/parsers/compute/spot_instance_requests.rb
@@ -48,7 +48,7 @@ module Fog
                 @response['spotInstanceRequestSet'] << @spot_instance_request
                 @spot_instance_request = { 'launchSpecification' => { 'blockDeviceMapping' => [], 'groupSet' => [] } }
               end
-            when 'imageId', 'instanceType', 'keyname'
+            when 'imageId', 'instanceType', 'keyname', 'subnetId'
               @spot_instance_request['launchSpecification'][name] = value
             when 'enabled'
               @spot_instance_request['launchSpecification']['monitoring'] = (value == 'true')

--- a/lib/fog/aws/requests/compute/describe_spot_instance_requests.rb
+++ b/lib/fog/aws/requests/compute/describe_spot_instance_requests.rb
@@ -25,6 +25,7 @@ module Fog
         #         * 'imageId'<~String> - AMI for instance
         #         * 'instanceType'<~String> - type for instance
         #         * 'monitoring'<~Boolean> - monitoring status for instance
+        #         * 'subnetId'<~String> - VPC subnet ID for instance
         #       * 'productDescription'<~String> - general description of AMI
         #       * 'spotInstanceRequestId'<~String> - id of spot instance request
         #       * 'spotPrice'<~Float> - maximum price for instances to be launched

--- a/lib/fog/aws/requests/compute/request_spot_instances.rb
+++ b/lib/fog/aws/requests/compute/request_spot_instances.rb
@@ -24,6 +24,7 @@ module Fog
         #     * 'Ebs.DeleteOnTermination'<~String> - specifies whether or not to delete the volume on instance termination
         #   * 'LaunchSpecification.KeyName'<~String> - Name of a keypair to add to booting instances
         #   * 'LaunchSpecification.Monitoring.Enabled'<~Boolean> - Enables monitoring, defaults to disabled
+        #   * 'LaunchSpecification.SubnetId'<~String> - VPC subnet ID in which to launch the instance
         #   * 'LaunchSpecification.Placement.AvailabilityZone'<~String> - Placement constraint for instances
         #   * 'LaunchSpecification.SecurityGroup'<~Array> or <~String> - Name of security group(s) for instances, not supported in VPC
         #   * 'LaunchSpecification.SecurityGroupId'<~Array> or <~String> - Id of security group(s) for instances, use this or LaunchSpecification.SecurityGroup
@@ -47,6 +48,7 @@ module Fog
         #         * 'imageId'<~String> - AMI for instance
         #         * 'instanceType'<~String> - type for instance
         #         * 'monitoring'<~Boolean> - monitoring status for instance
+        #         * 'subnetId'<~String> - VPC subnet ID for instance
         #       * 'productDescription'<~String> - general description of AMI
         #       * 'spotInstanceRequestId'<~String> - id of spot instance request
         #       * 'spotPrice'<~Float> - maximum price for instances to be launched

--- a/tests/aws/requests/compute/spot_instance_tests.rb
+++ b/tests/aws/requests/compute/spot_instance_tests.rb
@@ -11,7 +11,8 @@ Shindo.tests('Fog::Compute[:aws] | spot instance requests', ['aws']) do
         'keyName'             => Fog::Nullable::String,
         'imageId'             => String,
         'instanceType'        => String,
-        'monitoring'          => Fog::Boolean
+        'monitoring'          => Fog::Boolean,
+        'subnetId'            => String
       },
       'productDescription'        => String,
       'spotInstanceRequestId'     => String,


### PR DESCRIPTION
Adding the "subnet_id" attribute for spot requests so they can be created in a VPC.
