### PR TITLE
Fix for RDS VPC subnet groups

### DIFF
--- a/lib/fog/aws/requests/rds/create_db_instance.rb
+++ b/lib/fog/aws/requests/rds/create_db_instance.rb
@@ -102,7 +102,8 @@ module Fog
                  "PreferredBackupWindow"=>"08:00-08:30",
 #                 "ReadReplicaSourceDBInstanceIdentifier" => nil,
 #                 "LatestRestorableTime" => nil,
-                 "AvailabilityZone" => options["AvailabilityZone"]
+                 "AvailabilityZone" => options["AvailabilityZone"],
+                 "DBSubnetGroupName" => options["DBSubnetGroupName"]
              }
 
 


### PR DESCRIPTION
Although the db_subnet_group_name option is available in the AWS::RDS::Server model, it's not currently being passed through to the actual request.
