### PR TITLE
For HP comment metatada attribute of image.rb in model

### DIFF
--- a/lib/fog/hp/models/compute/image.rb
+++ b/lib/fog/hp/models/compute/image.rb
@@ -16,7 +16,7 @@ module Fog
         attribute :minDisk,     :aliases => 'min_disk'
         attribute :minRam,      :aliases => 'min_ram'
         attribute :server,   :aliases => 'server'
-        #attribute :metadata       #TODO: Need to add it back when Metadata API is done
+        attribute :metadata       
         attribute :links
 
         def destroy


### PR DESCRIPTION
In the HP support put back the metadata attribute for the image.rb in the model 
