### PR TITLE
[Core] fix format_helper assuming p returns nil

### DIFF
--- a/tests/helpers/formats_helper.rb
+++ b/tests/helpers/formats_helper.rb
@@ -48,7 +48,8 @@ module Shindo
         format.delete(key)
         case value
         when Array
-          valid &&= datum.is_a?(Array) || p("#{key.inspect} not Array: #{datum.inspect}")
+          p("#{key.inspect} not Array: #{datum.inspect}") unless datum.is_a?(Array)
+          valid &&= datum.is_a?(Array)
           if datum.is_a?(Array) && !value.empty?
             for element in datum
               type = value.first
@@ -60,7 +61,8 @@ module Shindo
             end
           end
         when Hash
-          valid &&= datum.is_a?(Hash) || p("#{key.inspect} not Hash: #{datum.inspect}")
+          p("#{key.inspect} not Hash: #{datum.inspect}") unless datum.is_a?(Hash)
+          valid &&= datum.is_a?(Hash)
           valid &&= formats_kernel(datum, value, false, strict)
         else
           p "#{key.inspect} not #{value.inspect}: #{datum.inspect}" unless datum.is_a?(value)

--- a/tests/helpers/formats_helper_tests.rb
+++ b/tests/helpers/formats_helper_tests.rb
@@ -40,6 +40,15 @@ Shindo.tests('test_helper', 'meta') do
         !formats_kernel({}, {:a => String})
       end
 
+      test('when an array is expected but another data type is found') do
+        !formats_kernel({:a => 'not an array'}, {:a => []})
+      end
+
+      test('when a hash is expected but another data type is found') do
+        !formats_kernel({:a => 'not a hash'}, {:a => {}}, true, false)
+      end
+
+
       test('non strict extra data') do
         !formats_kernel({:a => :b, :b => :c}, {:z => Symbol}, true, false)
       end


### PR DESCRIPTION
As discussed here: https://groups.google.com/forum/#!topic/ruby-fog/_jZMqWTW2GI

This could make some of the non mocked tests fail, although only in that it would reveal failures that had been hidden on 1.9 until now.
