### PR TITLE
[AWS|RDS] expose the SnapshotType attribute & allow filtering by it

### DIFF
--- a/lib/fog/aws/models/rds/snapshot.rb
+++ b/lib/fog/aws/models/rds/snapshot.rb
@@ -17,6 +17,7 @@ module Fog
         attribute  :port, :aliases => 'Port', :type => :integer
         attribute  :allocated_storage, :aliases => 'AllocatedStorage', :type => :integer
         attribute  :availability_zone, :aliases => 'AvailabilityZone'
+        attribute  :type, :aliases => 'SnapshotType'
 
         def ready?
           state == 'available'

--- a/lib/fog/aws/models/rds/snapshots.rb
+++ b/lib/fog/aws/models/rds/snapshots.rb
@@ -15,6 +15,9 @@ module Fog
           if attributes[:server]
             filters[:identifier] = attributes[:server].id
           end
+          if attributes[:type]
+            filters[:type] = attributes[:type]
+          end
           super
         end
 

--- a/lib/fog/aws/parsers/rds/snapshot_parser.rb
+++ b/lib/fog/aws/parsers/rds/snapshot_parser.rb
@@ -30,6 +30,7 @@ module Fog
             when 'MasterUsername' then @db_snapshot['MasterUsername'] = value
             when 'Port' then @db_snapshot['Port'] = value.to_i
             when 'SnapshotCreateTime' then @db_snapshot['SnapshotCreateTime'] = Time.parse value
+            when 'SnapshotType' then @db_snapshot['SnapshotType'] = value
             when 'Status' then @db_snapshot['Status'] = value
             end
           end

--- a/lib/fog/aws/requests/rds/create_db_snapshot.rb
+++ b/lib/fog/aws/requests/rds/create_db_snapshot.rb
@@ -41,7 +41,7 @@ module Fog
 
           snapshot_data = {
             'Status'               => 'creating',
-            #'SnapshotType'         => 'manual', # In a newer RDS version
+            'SnapshotType'         => 'manual', 
             'DBInstanceIdentifier' => identifier,
             'DBSnapshotIdentifier' => name,
             'InstanceCreateTime'   => Time.now

--- a/lib/fog/aws/requests/rds/describe_db_snapshots.rb
+++ b/lib/fog/aws/requests/rds/describe_db_snapshots.rb
@@ -10,6 +10,7 @@ module Fog
         # ==== Parameters
         # * DBInstanceIdentifier <~String> - ID of instance to retrieve information for. if absent information for all instances is returned
         # * DBSnapshotIdentifier <~String> - ID of snapshot to retrieve information for. if absent information for all snapshots is returned
+        # * SnapshotType       <~String> - type of snapshot to retrive (automated|manual)
         # * Marker               <~String> - An optional marker provided in the previous DescribeDBInstances request
         # * MaxRecords           <~Integer> - Max number of records to return (between 20 and 100) 
         # Only one of DBInstanceIdentifier or DBSnapshotIdentifier can be specified
@@ -18,6 +19,7 @@ module Fog
         #   * body<~Hash>:
         def describe_db_snapshots(opts={})
           params = {}
+          params['SnapshotType'] = opts[:type] if opts[:type]
           params['DBInstanceIdentifier'] = opts[:identifier] if opts[:identifier]
           params['DBSnapshotIdentifier'] = opts[:snapshot_id] if opts[:snapshot_id]
           params['Marker'] = opts[:marker] if opts[:marker]

--- a/tests/aws/requests/rds/helper.rb
+++ b/tests/aws/requests/rds/helper.rb
@@ -96,7 +96,8 @@ class AWS
         'MasterUsername' => String,
         'Port' => Integer,
         'SnapshotCreateTime' => Fog::Nullable::Time,
-        'Status' => String
+        'Status' => String,
+        'SnapshotType' => String
       }
       INSTANCE = {
         'AllocatedStorage' => Integer,


### PR DESCRIPTION
As of d135486 we're using an RDS api version that returns the automated daily backups as snapshots. Snapshots gain an extra attribute (SnapshotType: automated or manual) and you can filter snapshots by type.

Maybe I'm just looking in the wrong place, but I couldn't find anywhere that said that changing to api version 2012-01-15 would result in these extra snapshots being returned or the extra data field. Does anyone know where this info can be had? And what should fog (if anything) do to warn users that the underlying apis have changed?
