### PR TITLE
[AWS|Compute] Add the ablity to pass :version and use newer AWS API

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -7,7 +7,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :endpoint, :region, :host, :path, :port, :scheme, :persistent, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name
+      recognizes :endpoint, :region, :host, :path, :port, :scheme, :persistent, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at, :instrumentor, :instrumentor_name, :version
 
       secrets    :aws_secret_access_key, :hmac, :aws_session_token
 
@@ -317,6 +317,7 @@ module Fog
           @region                 = options[:region] ||= 'us-east-1'
           @instrumentor           = options[:instrumentor]
           @instrumentor_name      = options[:instrumentor_name] || 'fog.aws.compute'
+          @version                = options[:version]     ||  '2012-07-20'
 
           if @endpoint = options[:endpoint]
             endpoint = URI.parse(@endpoint)
@@ -362,7 +363,7 @@ module Fog
               :host               => @host,
               :path               => @path,
               :port               => @port,
-              :version            => '2012-07-20'
+              :version            => @version
             }
           )
 

--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -9,9 +9,6 @@ module Fog
       attributes = attributes.dup # prevent delete from having side effects
       provider = attributes.delete(:provider).to_s.downcase.to_sym
 
-      version = attributes.delete(:version)
-      version = version.to_s.downcase.to_sym unless version.nil?
-
       case provider
       when :aws
         require 'fog/aws/compute'
@@ -69,6 +66,8 @@ module Fog
         require 'fog/ovirt/compute'
         Fog::Compute::Ovirt.new(attributes)
       when :rackspace
+        version = attributes.delete(:version) 
+        version = version.to_s.downcase.to_sym unless version.nil?
         if version == :v2
           require 'fog/rackspace/compute_v2'
           Fog::Compute::RackspaceV2.new(attributes)

--- a/tests/aws/requests/compute/instance_tests.rb
+++ b/tests/aws/requests/compute/instance_tests.rb
@@ -167,7 +167,7 @@ Shindo.tests('Fog::Compute[:aws] | instance requests', ['aws']) do
       'ami-6bbb1302' # ubuntu 12.04 daily build 20120728
     else
       # Use a MS Windows AMI to test #get_password_data
-      'ami-c941efa0' # Amazon Public Images - Windows_Server-2008-SP2-English-64Bit-Base-2012.07.11
+      'ami-71b50018' # Amazon Public Images - Windows_Server-2008-SP2-English-64Bit-Base-2012.07.11
     end
 
     # Create a keypair for decrypting the password


### PR DESCRIPTION
So the main gist of the change is the ability to use :version so you can use newer AWS API.  This is useful for new features AWS add that you can use without any fog changes like the new ebs_optimzed flag.  Not having this feature has caused a patch to Opscode Knife to be blocked till a new fog release, http://tickets.opscode.com/browse/KNIFE_EC2-79

So now you can write code like this:
connection = Fog::Compute.new({
  :provider                 => 'AWS',
  :aws_access_key_id        => 'XXXXXXXX',
  :aws_secret_access_key    => 'XXXXXXXXXX',
  :region                   => 'us-west-1',
  :version                  => '2012-07-20'
})

server = connection.servers.create({:flavor_id => 'm1.large',:ebs_optimized => true})

But to get this change to work I was required to modify /fog/compute.rb as it turned out some bad code was added that stripped out :version since it was used for Rackspace version switching. I pushed that code inside the case statement for when Rackspace is used as I see no one else uses :versions in the way Rackspace does.

I dont have a Rackspace Cloud Server account right now so I cant test but I am pretty confident on a pure code level it is safe.

Also during compute testing I found that the test had a deleted Window AMI used and this caused the test to hang for me.  I updated the AMI to the latest but I see a few other failures not related to the code I touched so I left it alone.  Looks like the test code can use some TLC.

And lastest, where is my fog t-shirt from my last commits ;)
