### PR TITLE
For HP Compute model Server add method to return security groups

### DIFF
--- a/lib/fog/hp/models/compute/server.rb
+++ b/lib/fog/hp/models/compute/server.rb
@@ -129,6 +129,10 @@ module Fog
           @security_groups = new_security_groups
         end
 
+        def security_groups   
+          @security_groups
+        end
+        
         def ready?
           self.state == 'ACTIVE'
         end


### PR DESCRIPTION
For HP Compute model Server there was only a method to provide  new security groups. Added method to return security groups you can access the current security groups. 
