### PR TITLE
Add Accept header with application/json media type to OpenStack requests

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -113,6 +113,7 @@ module Fog
             "#{uri.scheme}://#{uri.host}:#{uri.port}/v2.0/tenants", false, connection_options).request({
             :expects => [200, 204],
             :headers => {'Content-Type' => 'application/json',
+                         'Accept' => 'application/json',
                          'X-Auth-Token' => body['access']['token']['id']},
             :host    => uri.host,
             :method  => 'GET'

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -282,6 +282,7 @@ module Fog
             response = @connection.request(params.merge({
               :headers  => {
                 'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
                 'X-Auth-Token' => @auth_token
               }.merge!(params[:headers] || {}),
               :host     => @host,

--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -154,6 +154,7 @@ module Fog
             response = @connection.request(params.merge({
               :headers  => {
                 'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
                 'X-Auth-Token' => @auth_token
               }.merge!(params[:headers] || {}),
               :host     => @host,

--- a/lib/fog/openstack/requests/compute/list_tenants.rb
+++ b/lib/fog/openstack/requests/compute/list_tenants.rb
@@ -6,6 +6,7 @@ module Fog
           response = @identity_connection.request({
             :expects => [200, 204],
             :headers => {'Content-Type' => 'application/json',
+                         'Accept' => 'application/json',
                          'X-Auth-Token' => @auth_token},
             :method  => 'GET',
             :path    => '/v2.0/tenants'

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -132,6 +132,7 @@ module Fog
             response = @connection.request(params.merge({
               :headers  => {
                 'Content-Type' => 'application/json',
+                'Accept' => 'application/json',
                 'X-Auth-Token' => @auth_token
               }.merge!(params[:headers] || {}),
               :host     => @host,


### PR DESCRIPTION
The Fog code expects JSON data to be returned, and in some cases enforces this by appending `.json` to the URI. However, this is not employed consistently. Since the OpenStack  specification does not require JSON to be the default media type many calls will fail if connecting to an implementation that returns XML or even some other media as a default.

I have added an Accept header to the requests for compute, identity and volume services, set to `application/json`. This has been tested on an OpenStack implementation configured to default to XML representations.
