### PR TITLE
[Openstack|Compute] Security Groups are not assigned correctly to servers

### DIFF
--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -13,10 +13,16 @@ module Fog
           }
 
           vanilla_options = ['metadata', 'accessIPv4', 'accessIPv6',
-                             'availability_zone', 'user_data', 'key_name',
-                             'security_groups', 'adminPass']
+                             'availability_zone', 'user_data', 'key_name', 'adminPass']
           vanilla_options.select{|o| options[o]}.each do |key|
             data['server'][key] = options[key]
+          end
+
+          if options['security_groups']
+            # security names requires a hash with a name prefix
+            data['server']['security_groups'] = [options['security_groups']].flatten.map do |sg|
+              { :name => sg.is_a?(Fog::Compute::OpenStack::SecurityGroup) ? sg.name : sg }
+            end
           end
 
           if options['personality']


### PR DESCRIPTION
According to API, security groups needs to be appended with a name prefix, e.g.:

``` json
 {
    "server": {
        "name": "server-1",
        "imageRef": "cedef40a-ed67-4d10-800e-17455edce175",
        "flavorRef" : "1",
        "security_groups": [
            {"name": "sec-group-1"},
            {"name": "sec-group-2"}
        ],
        "config_drive": "0c5eb502-3ee7-42e2-acfc-399b67fe72db"
    }
}
```
