### PR TITLE
[aws|cdn] Add the missing get invalidation request

### DIFF
--- a/lib/fog/aws/cdn.rb
+++ b/lib/fog/aws/cdn.rb
@@ -17,6 +17,7 @@ module Fog
       request 'get_distribution'
       request 'get_distribution_list'
       request 'get_invalidation_list'
+      request 'get_invalidation'
       request 'get_streaming_distribution'
       request 'get_streaming_distribution_list'
       request 'post_distribution'

--- a/lib/fog/aws/parsers/cdn/get_invalidation.rb
+++ b/lib/fog/aws/parsers/cdn/get_invalidation.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Parsers
+    module CDN
+      module AWS
+
+        class GetInvalidation < Fog::Parsers::Base
+
+          def reset
+            @response = { 'InvalidationBatch' => [] }
+          end
+
+          def start_element(name, attrs = [])
+            super
+          end
+
+          def end_element(name)
+            case name
+            when 'Path'
+              @response['InvalidationBatch'] << @value
+            when 'Id', 'Status', 'CreateTime'
+              @response[name] = @value
+            end
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/cdn/get_invalidation.rb
+++ b/lib/fog/aws/requests/cdn/get_invalidation.rb
@@ -1,0 +1,34 @@
+module Fog
+  module CDN
+    class AWS
+      class Real
+
+        require 'fog/aws/parsers/cdn/get_invalidation'
+
+        # ==== Parameters
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'Id'<~String> - Invalidation id
+        #     * 'Status'<~String>
+        #     * 'CreateTime'<~String>
+        #     * 'InvalidationBatch'<~Array>:
+        #       * 'Path'<~String>
+        # ==== See Also
+        # http://docs.amazonwebservices.com/AmazonCloudFront/2010-11-01/APIReference/GetInvalidation.html
+
+        def get_invalidation(distribution_id, invalidation_id)
+          request({
+            :expects    => 200,
+            :idempotent => true,
+            :method   => 'GET',
+            :parser   => Fog::Parsers::CDN::AWS::GetInvalidation.new,
+            :path       => "/distribution/#{distribution_id}/invalidation/#{invalidation_id}"
+          })
+        end
+
+      end
+    end
+  end
+end

--- a/tests/aws/requests/cdn/cdn_tests.rb
+++ b/tests/aws/requests/cdn/cdn_tests.rb
@@ -101,6 +101,23 @@ Shindo.tests('Fog::CDN[:aws] | CDN requests', ['aws', 'cdn']) do
       result
     }
 
+    test("get invalidation information") {
+      pending if Fog.mocking?
+
+      result = false
+
+      response = @cf_connection.get_invalidation(@dist_id, @invalidation_id)
+      if response.status == 200
+        paths = response.body['InvalidationBatch'].sort
+        status = response.body['Status']
+        if status.length > 0 and paths == [ '/test.html', '/path/to/file.html' ].sort
+          result = true
+        end
+      end
+
+      result
+    }
+
     test("disable distribution #{@dist_id}") {
       pending if Fog.mocking?
 


### PR DESCRIPTION
Please find this patch adding test coverage to AWS/CDN, along with the get_invalidation request implementation.
