### PR TITLE
Correct the handling of the power_on option for vsphere clone_vm request

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -123,7 +123,7 @@ module Fog
           end
           # And the clone specification
           clone_spec = RbVmomi::VIM.VirtualMachineCloneSpec(:location => relocation_spec,
-                                                            :powerOn  => options['power_on'] || true,
+                                                            :powerOn  => options.has_key?('power_on') ? options['power_on'] : true,
                                                             :template => false)
           task = vm_mob_ref.CloneVM_Task(:folder => vm_mob_ref.parent, :name => options['name'], :spec => clone_spec)
           # Waiting for the VM to complete allows us to get the VirtulMachine


### PR DESCRIPTION
The current code ignore the actual option passed on for 'power_on' and always goes with 'true' because of the OR

Have fixed this so that the option passed in is always considered

Also, have no clue on how to test this... (looked at the test code; but it didn't seem very apparent.)
