### PR TITLE
allow port to be included in queue_url

### DIFF
--- a/lib/fog/aws/sqs.rb
+++ b/lib/fog/aws/sqs.rb
@@ -107,7 +107,7 @@ module Fog
         end
 
         def path_from_queue_url(queue_url)
-          queue_url.split('.com', 2).last
+          queue_url.split('.com', 2).last.sub(/^:[0-9]+/, '')
         end
 
         def request(params)


### PR DESCRIPTION
The method currently fails when we use the QueueUrl provided from SQS list_queues {"QueueUrls"=>["https://sqs.us-east-1.amazonaws.com:443/77XXXXXXXX/sample-queue"], ...}
