### PR TITLE
Added ParameterValue to aws/elasticache engine_defaults_parser

### DIFF
--- a/lib/fog/aws/parsers/elasticache/engine_defaults_parser.rb
+++ b/lib/fog/aws/parsers/elasticache/engine_defaults_parser.rb
@@ -40,7 +40,7 @@ module Fog
                 @engine_defaults["#{name}s"] << @parameter
               end
             when 'AllowedValues', 'DataType', 'Description', 'IsModifiable',
-              'MinimumEngineVersion', 'ParameterName', 'Source'
+              'MinimumEngineVersion', 'ParameterName', 'ParameterValue', 'Source'
               @parameter[name] = value
             when 'CacheNodeType', 'Value'
               @node_specific_value[name] = value


### PR DESCRIPTION
DescribeCacheParameters action was not displaying the ParameterValue because it was missing as a tag in the parser.  Tag was added into aws/parsers/elasticache/engine_defaults_parser.rb and value is displayed correctly.
