### PR TITLE
Added Marker to Elasticache and RDS describe_events

### DIFF
--- a/lib/fog/aws/parsers/elasticache/event_list.rb
+++ b/lib/fog/aws/parsers/elasticache/event_list.rb
@@ -27,6 +27,8 @@ module Fog
               @event[name] = value ? value.strip : name
             when 'Event'
               @response['Events'] << @event unless @event.empty?
+            when 'IsTruncated', 'Marker', 'NextMarker'
+              @response[name] = value
             else
               super
             end

--- a/lib/fog/aws/parsers/rds/event_list.rb
+++ b/lib/fog/aws/parsers/rds/event_list.rb
@@ -27,6 +27,8 @@ module Fog
               @event[name] = value ? value.strip : name
             when 'Event'
               @response['Events'] << @event unless @event.empty?
+            when 'IsTruncated', 'Marker', 'NextMarker'
+              @response[name] = value
             else
               super
             end


### PR DESCRIPTION
Added parsing for Marker.  AWS limits response to 100 lines and gives you a marker to get the next batch with
