### PR TITLE
[AWS|Glacier] Fix description header not being passed through Fog.escape

### DIFF
--- a/lib/fog/aws/requests/glacier/create_archive.rb
+++ b/lib/fog/aws/requests/glacier/create_archive.rb
@@ -26,7 +26,7 @@ module Fog
             'x-amz-content-sha256' => Digest::SHA256.hexdigest(body),
             'x-amz-sha256-tree-hash' => Fog::AWS::Glacier::TreeHash.digest(body)
           }
-          headers['x-amz-archive-description'] = options['description'] if options['description']
+          headers['x-amz-archive-description'] = Fog::AWS.escape(options['description']) if options['description']
 
           request(
             :expects  => 201,

--- a/lib/fog/aws/requests/glacier/initiate_multipart_upload.rb
+++ b/lib/fog/aws/requests/glacier/initiate_multipart_upload.rb
@@ -23,7 +23,7 @@ module Fog
           path = "/#{account_id}/vaults/#{Fog::AWS.escape(name)}/multipart-uploads"
 
           headers = {'x-amz-part-size' => part_size.to_s}
-          headers['x-amz-archive-description'] = options['description'] if options['description']
+          headers['x-amz-archive-description'] = Fog::AWS.escape(options['description']) if options['description']
           request(
             :expects  => 201,
             :headers => headers,


### PR DESCRIPTION
This fixes #1202 for me . I think this is the right think to do - escaping header values systematically seemed to produce invalid signatures too.
