### PR TITLE
Fixes fog/fog#1206

### DIFF
--- a/lib/fog/google/storage.rb
+++ b/lib/fog/google/storage.rb
@@ -243,7 +243,7 @@ DATA
           canonical_resource << "#{params[:path]}"
           canonical_resource << '?'
           for key in (params[:query] || {}).keys
-            if ['acl', 'location', 'logging', 'requestPayment', 'torrent', 'versions', 'versioning'].include?(key)
+            if ['acl', 'cors', 'location', 'logging', 'requestPayment', 'torrent', 'versions', 'versioning'].include?(key)
               canonical_resource << "#{key}&"
             end
           end


### PR DESCRIPTION
Google's [CORS implementation](https://developers.google.com/storage/docs/cross-origin) implements a canonical resource parameter that was not included in the hashed headers.
