### PR TITLE
Public URL and File Destroy

### DIFF
--- a/lib/fog/atmos/models/storage/file.rb
+++ b/lib/fog/atmos/models/storage/file.rb
@@ -57,11 +57,8 @@ module Fog
 
         # By default, expire in 5 years
         def public_url(expires = (Time.now + 5 * 365 * 24 * 60 * 60))
-          if self.objectid.blank?
-            file = directory.files.head(key)
-            self.objectid = file.attributes['x-emc-meta'].scan(/objectid=(\w+),/).flatten[0] if file.present?
-          end
-
+          file = directory.files.head(key)
+          self.objectid = if file.present? then file.attributes['x-emc-meta'].scan(/objectid=(\w+),/).flatten[0] else nil end
           if self.objectid.present?
             uri = URI::HTTP.build(:scheme => connection.ssl? ? "http" : "https" , :host => connection.host, :port => connection.port.to_i, :path => "/rest/objects/#{self.objectid}" )
 


### PR DESCRIPTION
I recently started using CarrierWave and had great success using AWS for storage. Although it was successful its performance wasn't suitable for an application I was developing for the Australian market. Hence I started to have a look at Ninefold (who uses Atmos) but found Fog failed to work with CarrierWave.

I'm relatively new to cloud storage so after a few of days of research and reverse engineering I identified that the public_url method didn't seem to work as expected. I've made some changes to get it working as expected and done some rudimentary manual testing. Ideally automated testing (ie RSpec) would be more desirable but without the background in cloud storage I found it difficult to do.

I've also identified a problem with file deletion where a Fog::Storage::Atmos::NotFound exception occurs if the file doesn't exist.  I figured if you wanted to delete the file then the fact it didn't exist doesn't really matter because you got what you wanted: the file is gone so why throw an exception.  To that effect I've changed the File.destroy method.  

Let me know what you think.
