### PR TITLE
Fog::AWS::CloudWatch#all follows NextToken

### DIFF
--- a/lib/fog/aws/models/cloud_watch/metrics.rb
+++ b/lib/fog/aws/models/cloud_watch/metrics.rb
@@ -9,7 +9,15 @@ module Fog
         model Fog::AWS::CloudWatch::Metric
         
         def all(conditions={})
-          data = connection.list_metrics(conditions).body['ListMetricsResult']['Metrics']
+          data = []
+          result = connection.list_metrics(conditions).body['ListMetricsResult']
+          data += result['Metrics']
+
+          while next_token = result["NextToken"]
+            result = connection.list_metrics(conditions.merge("NextToken" => next_token)).body['ListMetricsResult']
+            data += result['Metrics']
+          end
+
           load(data) # data is an array of attribute hashes
         end
         

--- a/lib/fog/aws/requests/cloud_watch/list_metrics.rb
+++ b/lib/fog/aws/requests/cloud_watch/list_metrics.rb
@@ -33,6 +33,33 @@ module Fog
         end
 
       end
+
+      class Mock
+        def list_metrics(options={})
+          body = case options["NextToken"]
+                 when nil
+                   { "ListMetricsResult" => {
+                      "Metrics" => (0...500).map{ {} },
+                      "NextToken" => '1'
+                   }}
+                 when "1"
+                   { "ListMetricsResult" => {
+                      "Metrics" => (0...500).map{ {} },
+                      "NextToken" => '2'
+                   }}
+                 when "2"
+                   { "ListMetricsResult" => {
+                      "Metrics" => (0...1).map{ {} },
+                   }}
+                 end
+
+          Excon::Response.new.tap do |response|
+            response.body = body
+            response.status = 200
+          end
+        end
+      end
+
     end
   end
 end

--- a/tests/aws/models/cloud_watch/metrics_tests.rb
+++ b/tests/aws/models/cloud_watch/metrics_tests.rb
@@ -14,4 +14,11 @@ Shindo.tests("AWS::CloudWatch | metrics", ['aws', 'cloudwatch']) do
     
   end
 
+  tests('handle NextToken') do
+    Fog.mock!
+    tests("#all").returns(1001) do
+      Fog::AWS[:cloud_watch].metrics.all.size
+    end
+  end
+
 end


### PR DESCRIPTION
I'm not sure about the general idea of following NextToken without any constraints. This seems like it has the potential to eat up a lot of memory and time. However, having #all not return all of the available results seems to lead to confusion.
