### PR TITLE
[openstack] Ensure String Username for Authentication

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -95,7 +95,7 @@ module Fog
         req_body = {
           'auth' => {
             'passwordCredentials'  => {
-              'username' => @openstack_username,
+              'username' => @openstack_username.to_s,
               'password' => @openstack_api_key.to_s
             }
           }


### PR DESCRIPTION
When username is composed of only integers, openstack raises a
ProgrammingError when trying to authenticate user.

-- I am actually even unsure if it should be allowed that a user to have a username composed of all numbers, anyway OpenStack allows it, so here's the pull request.
