### PR TITLE
Changed the list server request to get details

### DIFF
--- a/lib/fog/rackspace/requests/compute_v2/list_servers.rb
+++ b/lib/fog/rackspace/requests/compute_v2/list_servers.rb
@@ -6,7 +6,7 @@ module Fog
           request(
             :expects => [200, 203, 300],
             :method => 'GET',
-            :path => 'servers'
+            :path => 'servers/detail'
           )
         end
       end


### PR DESCRIPTION
I need the state of the server on reach qetests. The simple request doesn't provide that.
