### PR TITLE
Openstack provider fixes to work with Rackspace open cloud

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -135,7 +135,8 @@ module Fog
           detect{|x| @service_name.include?(x['type']) }
       end
 
-      svc['endpoints'] = svc['endpoints'].select{ |x| x['region'] == @openstack_region } if @openstack_region
+      # Rackspace doesn't return the region in the endpoints if we already include it in the query
+      svc['endpoints'] = svc['endpoints'].select{ |x| x['region'].nil? or x['region'] == @openstack_region } if @openstack_region
       if svc['endpoints'].count > 1
          regions = svc["endpoints"].map { |x| x['region'] }.uniq.join(',')
          raise Errors::NotFound.new("Multiple regions available choose one of these '#{regions}'")

--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -86,11 +86,13 @@ module Fog
         def private_ip_address
           if addresses['private']
             #assume only a single private
-            return addresses['private'].first
+            address = addresses['private'].first
           elsif addresses['internet']
             #assume no private IP means private cloud
-            return addresses['internet'].first
+            address = addresses['internet'].first
           end
+          # rackspace returns a hash {"version", "addr"}
+          return address.kind_of?(Hash) ? address["addr"] : address
         end
 
         def private_key_path
@@ -105,11 +107,13 @@ module Fog
         def public_ip_address
           if addresses['public']
             #assume last is either original or assigned from floating IPs
-            return addresses['public'].last
+            address = addresses['public'].last
           elsif addresses['internet']
             #assume no public IP means private cloud
-            return addresses['internet'].first
+            address = addresses['internet'].first
           end
+          # rackspace returns a hash {"version", "addr"}
+          return address.kind_of?(Hash) ? address["addr"] : address
         end
 
         def public_key_path


### PR DESCRIPTION
Fix some issues to use openstack provider on the Rackspace open cloud.

I got it to work using my rackspace password (not the api key) and region is mandatory (DFW or ORD)

I kept the existing behavior intact so it should still work with other implementations, but fixed some cases where rackspace causes errors. I have commented the code with the specifics.

identity_public_endpoint is returned nil from Rackspace so the hack I found to work was to strip the last part of the openstack_management_url

Some times I get the error "OpenStack binding only supports version 2 (a.k.a. 1.1)", traced it and is indeed Rackspace returning the v1.1 urls for openstack_management_url, but just some times
