### PR TITLE
Allows tests to run against FOG_RC setting

### DIFF
--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -1,5 +1,5 @@
-ENV['FOG_RC']         = File.expand_path '../.fog', __FILE__
-ENV['FOG_CREDENTIAL'] = 'default'
+ENV['FOG_RC']         = ENV['FOG_RC'] || File.expand_path('../.fog', __FILE__)
+ENV['FOG_CREDENTIAL'] = ENV['FOG_CREDENTIAL'] || 'default'
 
 require 'fog'
 require 'fog/bin' # for available_providers and registered_providers


### PR DESCRIPTION
https://github.com/fog/fog/commit/dce5e800fdebefdb64ea5ccd3418c80518d43276 introduced
changes in the test helper to use a specific test file (`tests/.fog`)
and set of credentials (`default`) for tests.

This changes this to honour the existing environment variables if set.

I use multiple configs to test against different versions of endpoints and the original change messes up that workflow and some of our CI settings.
