### PR TITLE
Move ssh private_key, public_key, username to Server model to reduce duplication

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -47,7 +47,6 @@ module Fog
         attribute :vpc_id,                :aliases => 'vpcId'
 
         attr_accessor :password
-        attr_writer   :private_key, :private_key_path, :public_key, :public_key_path, :username
         attr_writer   :iam_instance_profile_name, :iam_instance_profile_arn
 
 
@@ -116,24 +115,6 @@ module Fog
 
         def key_pair=(new_keypair)
           self.key_name = new_keypair && new_keypair.name
-        end
-
-        def private_key_path
-          @private_key_path ||= Fog.credentials[:private_key_path]
-          @private_key_path &&= File.expand_path(@private_key_path)
-        end
-
-        def private_key
-          @private_key ||= private_key_path && File.read(private_key_path)
-        end
-
-        def public_key_path
-          @public_key_path ||= Fog.credentials[:public_key_path]
-          @public_key_path &&= File.expand_path(@public_key_path)
-        end
-
-        def public_key
-          @public_key ||= public_key_path && File.read(public_key_path)
         end
 
         def ready?
@@ -230,10 +211,6 @@ module Fog
           requires :id
           connection.stop_instances(id, force)
           true
-        end
-
-        def username
-          @username ||= 'root'
         end
 
         def volumes

--- a/lib/fog/aws/models/compute/spot_request.rb
+++ b/lib/fog/aws/models/compute/spot_request.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/compute/models/server'
 
 module Fog
   module Compute
     class AWS
       
-      class SpotRequest < Fog::Model
+      class SpotRequest < Fog::Compute::Server
 
         identity :id,                          :aliases => 'spotInstanceRequestId'
 
@@ -33,10 +33,6 @@ module Fog
         attribute :fault,                      :squash  => 'message'
         attribute :user_data
         
-        attr_writer   :private_key, :private_key_path, :public_key, :public_key_path
-
-        attr_writer :username
-
         def initialize(attributes={})
           self.groups ||= ["default"]
           self.flavor_id ||= 't1.micro'
@@ -73,24 +69,6 @@ module Fog
 
         def key_pair=(new_keypair)
           self.key_name = new_keypair && new_keypair.name
-        end
-        
-        def private_key_path
-          @private_key_path ||= Fog.credentials[:private_key_path]
-          @private_key_path &&= File.expand_path(@private_key_path)
-        end
-
-        def private_key
-          @private_key ||= private_key_path && File.read(private_key_path)
-        end
-
-        def public_key_path
-          @public_key_path ||= Fog.credentials[:public_key_path]
-          @public_key_path &&= File.expand_path(@public_key_path)
-        end
-
-        def public_key
-          @public_key ||= public_key_path && File.read(public_key_path)
         end
 
         def ready?

--- a/lib/fog/bluebox/models/compute/server.rb
+++ b/lib/fog/bluebox/models/compute/server.rb
@@ -23,7 +23,6 @@ module Fog
         attribute :template
 
         attr_accessor :hostname, :password, :lb_applications, :lb_services, :lb_backends
-        attr_writer :private_key, :private_key_path, :public_key, :public_key_path, :username
 
         def initialize(attributes={})
           self.flavor_id    ||= '94fd37a7-2606-47f7-84d5-9000deda52ae' # Block 1GB Virtual Server
@@ -57,26 +56,8 @@ module Fog
           nil
         end
 
-        def private_key_path
-          @private_key_path ||= Fog.credentials[:private_key_path]
-          @private_key_path &&= File.expand_path(@private_key_path)
-        end
-
-        def private_key
-          @private_key ||= private_key_path && File.read(private_key_path)
-        end
-
         def public_ip_address
           ips.first
-        end
-
-        def public_key_path
-          @public_key_path ||= Fog.credentials[:public_key_path]
-          @public_key_path &&= File.expand_path(@public_key_path)
-        end
-
-        def public_key
-          @public_key ||= public_key_path && File.read(public_key_path)
         end
 
         def ready?

--- a/lib/fog/compute/models/server.rb
+++ b/lib/fog/compute/models/server.rb
@@ -4,9 +4,30 @@ module Fog
   module Compute
     class Server < Fog::Model
 
-      def private_key=(key_data)
-        @private_key = key_data
+      attr_writer :username, :private_key, :private_key_path, :public_key, :public_key_path
+
+      def username
+        @username ||= 'root'
       end
+
+      def private_key_path
+        @private_key_path ||= Fog.credentials[:private_key_path]
+        @private_key_path &&= File.expand_path(@private_key_path)
+      end
+
+      def private_key
+        @private_key ||= private_key_path && File.read(private_key_path)
+      end
+
+      def public_key_path
+        @public_key_path ||= Fog.credentials[:public_key_path]
+        @public_key_path &&= File.expand_path(@public_key_path)
+      end
+
+      def public_key
+        @public_key ||= public_key_path && File.read(public_key_path)
+      end
+
 
       def scp(local_path, remote_path, upload_options = {})
         require 'net/scp'

--- a/lib/fog/go_grid/models/compute/server.rb
+++ b/lib/fog/go_grid/models/compute/server.rb
@@ -84,10 +84,6 @@ module Fog
           retry
         end
 
-        def username
-          @username ||= 'root'
-        end
-
         private
 
         def adminPass=(new_admin_pass)

--- a/lib/fog/hp/models/compute/server.rb
+++ b/lib/fog/hp/models/compute/server.rb
@@ -31,7 +31,7 @@ module Fog
         attribute :public_ip_address
 
         attr_reader :password
-        attr_writer :private_key, :private_key_path, :public_key, :public_key_path, :username, :image_id, :flavor_id
+        attr_writer :image_id, :flavor_id
 
         def initialize(attributes = {})
           # assign these attributes first to prevent race condition with new_record?
@@ -67,15 +67,6 @@ module Fog
           addr["addr"] if addr
         end
 
-        def private_key_path
-          @private_key_path ||= Fog.credentials[:private_key_path]
-          @private_key_path &&= File.expand_path(@private_key_path)
-        end
-
-        def private_key
-          @private_key ||= private_key_path && File.read(private_key_path)
-        end
-
         def public_ip_address
           # FIX: Both the private and public ips are bundled under "private" network name
           # So hack to get to the public ip address
@@ -90,15 +81,6 @@ module Fog
           else
             nil
           end
-        end
-
-        def public_key_path
-          @public_key_path ||= Fog.credentials[:public_key_path]
-          @public_key_path &&= File.expand_path(@public_key_path)
-        end
-
-        def public_key
-          @public_key ||= public_key_path && File.read(public_key_path)
         end
 
         def image_id
@@ -209,10 +191,6 @@ module Fog
         rescue Errno::ECONNREFUSED
           sleep(1)
           retry
-        end
-
-        def username
-          @username ||= 'root'
         end
 
         private

--- a/lib/fog/joyent/models/compute/server.rb
+++ b/lib/fog/joyent/models/compute/server.rb
@@ -18,6 +18,10 @@ module Fog
         attribute :created, :type => :time
         attribute :updated, :type => :time
 
+        def public_ip_address
+          ips.empty? ? nil : ips.first
+        end
+
         def ready?
           self.state == 'running'
         end

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -38,7 +38,6 @@ module Fog
         attr_accessor :network_interface_type ,:network_nat_network, :network_bridge_name
         attr_accessor :volume_format_type, :volume_allocation,:volume_capacity, :volume_name, :volume_pool_name, :volume_template_name, :volume_path
         attr_accessor :password
-        attr_writer   :private_key, :private_key_path, :public_key, :public_key_path, :username
 
         # Can be created by passing in :xml => "<xml to create domain/server>"
         # or by providing :template_options => {
@@ -65,10 +64,6 @@ module Fog
           reload
         rescue => e
           raise Fog::Errors::Error.new("Error saving the server: #{e}")
-        end
-
-        def username
-          @username ||= 'root'
         end
 
         def start
@@ -139,35 +134,14 @@ module Fog
           ip_address(:public)
         end
 
-        def private_key_path
-          @private_key_path ||= Fog.credentials[:private_key_path]
-          @private_key_path &&= File.expand_path(@private_key_path)
-        end
-
-        def private_key
-          @private_key ||= private_key_path && File.read(private_key_path)
-        end
-
-        def public_key_path
-          @public_key_path ||= Fog.credentials[:public_key_path]
-          @public_key_path &&= File.expand_path(@public_key_path)
-        end
-
-        def public_key
-          @public_key ||= public_key_path && File.read(public_key_path)
-        end
-
         def ssh(commands)
           requires :public_ip_address, :username
 
-          #requires :password, :private_key
           ssh_options={}
           ssh_options[:password] = password unless password.nil?
-          ssh_options[:key_data] = [private_key] if private_key
           ssh_options[:proxy]= ssh_proxy unless ssh_proxy.nil?
 
-          Fog::SSH.new(public_ip_address, @username, ssh_options).run(commands)
-
+          super(commands, ssh_options)
         end
 
         def ssh_proxy

--- a/lib/fog/linode/models/compute/server.rb
+++ b/lib/fog/linode/models/compute/server.rb
@@ -5,7 +5,6 @@ module Fog
     class Linode
       class Server < Fog::Compute::Server
         attr_reader :stack_script
-        attr_accessor :private_key, :username
         identity :id
         attribute :name
         attribute :status

--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -40,7 +40,7 @@ module Fog
         attribute :os_ext_sts_vm_state, :aliases => 'OS-EXT-STS:vm_state'
 
         attr_reader :password
-        attr_writer :private_key, :private_key_path, :public_key, :public_key_path, :username, :image_ref, :flavor_ref, :os_scheduler_hints
+        attr_writer :image_ref, :flavor_ref, :os_scheduler_hints
 
 
         def initialize(attributes={})
@@ -95,15 +95,6 @@ module Fog
           end
         end
 
-        def private_key_path
-          @private_key_path ||= Fog.credentials[:private_key_path]
-          @private_key_path &&= File.expand_path(@private_key_path)
-        end
-
-        def private_key
-          @private_key ||= private_key_path && File.read(private_key_path)
-        end
-
         def public_ip_address
           if addresses['public']
             #assume last is either original or assigned from floating IPs
@@ -112,15 +103,6 @@ module Fog
             #assume no public IP means private cloud
             return addresses['internet'].first
           end
-        end
-
-        def public_key_path
-          @public_key_path ||= Fog.credentials[:public_key_path]
-          @public_key_path &&= File.expand_path(@public_key_path)
-        end
-
-        def public_key
-          @public_key ||= public_key_path && File.read(public_key_path)
         end
 
         def image_ref
@@ -262,10 +244,6 @@ module Fog
         rescue Errno::ECONNREFUSED
           sleep(1)
           retry
-        end
-
-        def username
-          @username ||= 'root'
         end
 
         private

--- a/lib/fog/rackspace/models/compute/server.rb
+++ b/lib/fog/rackspace/models/compute/server.rb
@@ -19,7 +19,6 @@ module Fog
         attribute :state,       :aliases => 'status'
 
         attr_reader :password
-        attr_writer :private_key, :private_key_path, :public_key, :public_key_path, :username
 
         def initialize(attributes={})
           self.flavor_id  ||= 1  # 256 server
@@ -52,26 +51,8 @@ module Fog
           nil
         end
 
-        def private_key_path
-          @private_key_path ||= Fog.credentials[:private_key_path]
-          @private_key_path &&= File.expand_path(@private_key_path)
-        end
-
-        def private_key
-          @private_key ||= private_key_path && File.read(private_key_path)
-        end
-
         def public_ip_address
           addresses['public'].first
-        end
-
-        def public_key_path
-          @public_key_path ||= Fog.credentials[:public_key_path]
-          @public_key_path &&= File.expand_path(@public_key_path)
-        end
-
-        def public_key
-          @public_key ||= public_key_path && File.read(public_key_path)
         end
 
         def ready?
@@ -110,10 +91,6 @@ module Fog
         rescue Errno::ECONNREFUSED
           sleep(1)
           retry
-        end
-
-        def username
-          @username ||= 'root'
         end
 
         private

--- a/lib/fog/storm_on_demand/models/compute/server.rb
+++ b/lib/fog/storm_on_demand/models/compute/server.rb
@@ -26,7 +26,7 @@ module Fog
         attribute :zone
         attribute :active
 
-        attr_writer :password, :username
+        attr_writer :password
 
         def initialize(attributes={})
           super
@@ -51,10 +51,6 @@ module Fog
           requires :identity
           connection.reboot_server(:uniq_id => identity)
           true
-        end
-
-        def username
-          @username ||= 'root'
         end
 
         def clone(options)

--- a/lib/fog/virtual_box/models/compute/server.rb
+++ b/lib/fog/virtual_box/models/compute/server.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/compute/models/server'
 
 module Fog
   module Compute
     class VirtualBox
 
-      class Server < Fog::Model
+      class Server < Fog::Compute::Server
 
         identity :id
 
@@ -69,8 +69,6 @@ module Fog
         # property :usb_controller, :USBController, :readonly => true
         # property :vrde_server, :VRDEServer, :readonly => true
 
-        attr_writer :private_key, :private_key_path, :public_key, :public_key_path, :username
-
         def initialize(attributes={})
           self.memory_size = 256
           self.rtc_use_utc = true
@@ -102,26 +100,8 @@ module Fog
           nil
         end
 
-        def private_key_path
-          @private_key_path ||= Fog.credentials[:private_key_path]
-          @private_key_path &&= File.expand_path(@private_key_path)
-        end
-
-        def private_key
-          @private_key ||= private_key_path && File.read(private_key_path)
-        end
-
         def public_ip_address
           nil
-        end
-
-        def public_key_path
-          @public_key_path ||= Fog.credentials[:public_key_path]
-          @public_key_path &&= File.expand_path(@public_key_path)
-        end
-
-        def public_key
-          @public_key ||= public_key_path && File.read(public_key_path)
         end
 
         def ready?
@@ -151,15 +131,6 @@ module Fog
           end
         end
 
-        def scp(local_path, remote_path, upload_options = {})
-          raise 'Not Implemented'
-          # requires :addresses, :username
-          #
-          # options = {}
-          # options[:key_data] = [private_key] if private_key
-          # Fog::SCP.new(addresses['public'].first, username, options).upload(local_path, remote_path, scp_options)
-        end
-
         def setup(credentials = {})
           raise 'Not Implemented'
         #   requires :addresses, :identity, :public_key, :username
@@ -173,15 +144,6 @@ module Fog
         # rescue Errno::ECONNREFUSED
         #   sleep(1)
         #   retry
-        end
-
-        def ssh(commands)
-          raise 'Not Implemented'
-          # requires :addresses, :identity, :username
-          #
-          # options = {}
-          # options[:key_data] = [private_key] if private_key
-          # Fog::SSH.new(addresses['public'].first, username, options).run(commands)
         end
 
         def start(type = 'headless')
@@ -202,10 +164,6 @@ module Fog
             :connection => connection,
             :machine    => self
           )
-        end
-
-        def username
-          @username ||= 'root'
         end
 
         private

--- a/lib/fog/vmfusion/models/compute/server.rb
+++ b/lib/fog/vmfusion/models/compute/server.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/compute/models/server'
 
 module Fog
   module Compute
     class Vmfusion
 
-      class Server < Fog::Model
+      class Server < Fog::Compute::Server
 
         identity :name
 
@@ -14,7 +14,6 @@ module Fog
         attribute :path
 
         attr_accessor :password
-        attr_writer   :private_key, :private_key_path, :public_key, :public_key_path, :username
 
         # There is currently no documented model of creating VMs from scratch
         # sans Fusion's wizard.
@@ -179,21 +178,9 @@ module Fog
         # Sets up a conveinent way to SSH into a Fusion VM using credentials
         # stored in your .fog file.
 
-        def username
-          @username ||= 'root'
-        end
-
         # Simply spawn an SSH session.
         def ssh(commands)
-          requires :ipaddress, :username
-
-          #requires :password, :private_key
-          ssh_options={}
-          ssh_options[:password] = password unless password.nil?
-          ssh_options[:key_data] = [private_key] if private_key
-
-          Fog::SSH.new(ipaddress, @username, ssh_options).run(commands)
-
+          super(commands, password ? {:password => password} : {})
         end
 
         # SCP something to our VM.
@@ -236,26 +223,6 @@ module Fog
             end
           end
           Fog::SSH.new(ipaddress, username, credentials).run(commands)
-        end
-
-        # Just setting local versions of some variables that were going to use
-        # for SSH operations.
-        def private_key_path
-          @private_key_path ||= Fog.credentials[:private_key_path]
-          @private_key_path &&= File.expand_path(@private_key_path)
-        end
-
-        def private_key
-          @private_key ||= private_key_path && File.read(private_key_path)
-        end
-
-        def public_key_path
-          @public_key_path ||= Fog.credentials[:public_key_path]
-          @public_key_path &&= File.expand_path(@public_key_path)
-        end
-
-        def public_key
-          @public_key ||= public_key_path && File.read(public_key_path)
         end
 
         private

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -24,7 +24,7 @@ module Fog
         attribute :instance_uuid
         attribute :hostname
         attribute :operatingsystem
-        attribute :ipaddress
+        attribute :ipaddress,     :aliases => 'public_ip_address'
         attribute :power_state,   :aliases => 'power'
         attribute :tools_state,   :aliases => 'tools'
         attribute :tools_version


### PR DESCRIPTION
Based on comment in https://github.com/fog/fog/pull/1224

Implement ssh capabilities for all providers as long as they provide the ssh keys and public_ip_address
