### PR TITLE
expect public_key option instead of ssh_key on block create

### DIFF
--- a/lib/fog/bluebox/requests/compute/create_block.rb
+++ b/lib/fog/bluebox/requests/compute/create_block.rb
@@ -6,22 +6,22 @@ module Fog
         # Create a new block
         #
         # ==== Parameters
-        # * product_id<~String> - ID of product to create block with
-        # * template_id<~String> - ID of template to create block with
-        # * location_id<~String> - ID of location to create block in
+        # * product_id<~String>   - ID of block product (size)
+        # * template_id<~String>  - ID of block OS/build template
+        # * location_id<~String>  - ID of deployment location
         # * options<~Hash>:
-        #     * password<~String> - Password for block
+        #     * password<~String>   - Password for block
         #   or
-        #     * ssh_key<~String> - ssh public key
-        #   * username<~String> - optional, defaults to deploy
+        #     * public_key<~String> - SSH public key
+        #     * username<~String>   - Defaults to deploy
         #
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
         def create_block(product_id, template_id, location_id, options = {})
 
-          unless options.has_key?('password') || options.has_key?('ssh_key')
-            raise ArgumentError, 'Either password or ssh_key must be supplied'
+          unless options.has_key?('password') || options.has_key?('public_key')
+            raise ArgumentError, 'Either password or public_key must be supplied'
           end
 
           query = {


### PR DESCRIPTION
Bugfix for regression introduced by explicitly defining options passed to block creation endpoint.
