### PR TITLE
RackspaceV2 bootstrap, setup, public_ip_address

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -145,6 +145,20 @@ module Fog
           @password = password
           true
         end
+        
+        def setup(credentials = {})
+          requires :public_ip_address, :identity, :public_key, :username
+          Fog::SSH.new(public_ip_address, username, credentials).run([
+            %{mkdir .ssh},
+            %{echo "#{public_key}" >> ~/.ssh/authorized_keys},
+            %{passwd -l #{username}},
+            %{echo "#{Fog::JSON.encode(attributes)}" >> ~/attributes.json},
+            %{echo "#{Fog::JSON.encode(metadata)}" >> ~/metadata.json}
+          ])
+        rescue Errno::ECONNREFUSED
+          sleep(1)
+          retry
+        end
 
         private
 

--- a/lib/fog/rackspace/models/compute_v2/servers.rb
+++ b/lib/fog/rackspace/models/compute_v2/servers.rb
@@ -4,6 +4,7 @@ require 'fog/rackspace/models/compute_v2/server'
 module Fog
   module Compute
     class RackspaceV2
+
       class Servers < Fog::Collection
 
         model Fog::Compute::RackspaceV2::Server
@@ -11,6 +12,13 @@ module Fog
         def all
           data = connection.list_servers.body['servers']
           load(data)
+        end
+
+        def bootstrap(new_attributes = {})
+          server = create(new_attributes)
+          server.wait_for { ready? }
+          server.setup(:password => server.password)
+          server
         end
 
         def get(server_id)


### PR DESCRIPTION
I was looking at [1141](https://github.com/fog/fog/pull/1141), which adds bootstrap method, but it does not implement the setup step, which is needed to add public_key to the new remote server on RackspaceV2.  Also, currently `server.sshable?` and `server.ssh` are not supported because method public_ip_address is missing from Fog::Compute::RackspaceV2::Server.  So I have added
- _lib/fog/rackspace/models/compute_v2/server.rb_
  - _public_ip_address_ - required by server.setup, server.sshable?, server.ssh, etc
  - _setup_ - used to add public_key to authorized_keys on new server, as well as JSON attributes and metadata
- _lib/fog/rackspace/models/compute_v2/servers.rb_
  - _bootstrap_ - convenient and consistent way to initialize servers across providers
