### PR TITLE
Bumped mocked maximum value for Provisioned IOPS

### DIFF
--- a/lib/fog/aws/requests/compute/create_volume.rb
+++ b/lib/fog/aws/requests/compute/create_volume.rb
@@ -83,8 +83,8 @@ module Fog
                 raise Fog::Compute::AWS::Error.new("VolumeIOPSLimit => Volume iops of #{iops} is too low; minimum is 100.")
               end
 
-              if iops > 1000
-                raise Fog::Compute::AWS::Error.new("VolumeIOPSLimit => Volume iops of #{iops} is too high; maximum is 1000.")
+              if iops > 2000
+                raise Fog::Compute::AWS::Error.new("VolumeIOPSLimit => Volume iops of #{iops} is too high; maximum is 2000.")
               end
             end
 

--- a/tests/aws/requests/compute/volume_tests.rb
+++ b/tests/aws/requests/compute/volume_tests.rb
@@ -184,9 +184,9 @@ Shindo.tests('Fog::Compute[:aws] | volume requests', ['aws']) do
       Fog::Compute[:aws].create_volume(@server.availability_zone, 10, 'VolumeType' => 'io1', 'Iops' => 99)
     end
 
-    # iops invalid value (greater than 1000)
-    tests("#create_volume('#{@server.availability_zone}', 10, 'VolumeType' => 'io1', 'Iops' => 1001)").raises(Fog::Compute::AWS::Error) do
-      Fog::Compute[:aws].create_volume(@server.availability_zone, 1000, 'VolumeType' => 'io1', 'Iops' => 1001)
+    # iops invalid value (greater than 2000)
+    tests("#create_volume('#{@server.availability_zone}', 1024, 'VolumeType' => 'io1', 'Iops' => 2001)").raises(Fog::Compute::AWS::Error) do
+      Fog::Compute[:aws].create_volume(@server.availability_zone, 1024, 'VolumeType' => 'io1', 'Iops' => 2001)
     end
 
     @volume.destroy


### PR DESCRIPTION
This change only affects the mock for AWS volumes. AWS announced today that they are going to increase the maximum soon.
