### PR TITLE
[aws|compute] Fix #1245 - mock register_image fails with block device mapping

### DIFF
--- a/lib/fog/aws/requests/compute/register_image.rb
+++ b/lib/fog/aws/requests/compute/register_image.rb
@@ -102,7 +102,7 @@ module Fog
                 'ebs' => {}
               }
               ["DeviceName","VirtualName"].each do |n|
-                block_device_mapping = bd[n] if bd[n]
+                block_device_mapping[n] = bd[n] if bd[n]
               end
               ["SnapshotId","VolumeSize","NoDevice","DeleteOnTermination"].each do |n|
                 block_device_mapping['ebs'][n] = bd[n] if bd[n]

--- a/tests/aws/requests/compute/image_tests.rb
+++ b/tests/aws/requests/compute/image_tests.rb
@@ -73,6 +73,14 @@ Shindo.tests('Fog::Compute[:aws] | image requests', ['aws']) do
         @image = Fog::Compute[:aws].register_image('image', 'image', '/dev/sda1').body
       end
 
+      tests("#register_image - with ebs block device mapping").formats(@register_image_format) do
+        @ebs_image = Fog::Compute[:aws].register_image('image', 'image', '/dev/sda1', [ { 'DeviceName' => '/dev/sdh', "SnapshotId" => "snap-123456789", "VolumeSize" => "10G", "DeleteOnTermination" => true}]).body
+      end
+
+      tests("#register_image - with ephemeral block device mapping").formats(@register_image_format) do
+        @ephemeral_image = Fog::Compute[:aws].register_image('image', 'image', '/dev/sda1', [ { 'VirtualName' => 'ephemeral0', "DeviceName" => "/dev/sdb"} ]).body
+      end
+
       @image_id = @image['imageId']
       sleep 1
 


### PR DESCRIPTION
When calling register_image in mock mode with a block device mapping, it is failing with:

```
 undefined method `[]=' for nil:NilClass (NoMethodError)
        /Users/brice/devl/fog/lib/fog/aws/requests/compute/register_image.rb:108:in `register_image'
        /Users/brice/devl/fog/lib/fog/aws/requests/compute/register_image.rb:107:in `each'
        /Users/brice/devl/fog/lib/fog/aws/requests/compute/register_image.rb:107:in `register_image'
        /Users/brice/devl/fog/lib/fog/aws/requests/compute/register_image.rb:100:in `each'
        /Users/brice/devl/fog/lib/fog/aws/requests/compute/register_image.rb:100:in `register_image'
       ...
```

This changeset fixes the problem, and adds mock tests for register_image with block device mapping.
