### PR TITLE
[dns] Add more record tests

### DIFF
--- a/tests/dns/models/record_tests.rb
+++ b/tests/dns/models/record_tests.rb
@@ -7,10 +7,22 @@ for provider, config in dns_providers
 
   Shindo.tests("Fog::DNS[:#{provider}] | record", [provider.to_s]) do
 
-    record_attributes = {
-      :name   => 'www.' + domain_name,
+    a_record_attributes = {
+      :name   => 'a.' + domain_name,
       :type   => 'A',
       :value  => '1.2.3.4'
+    }.merge!(config[:record_attributes] || {})
+
+    aaaa_record_attributes = {
+      :name   => 'aaaa.' + domain_name,
+      :type   => 'AAAA',
+      :value  => '2001:0db8:0000:0000:0000:ff00:0042:8329'
+    }.merge!(config[:record_attributes] || {})
+
+    cname_record_attributes = {
+      :name   => 'cname.' + domain_name,
+      :type   => 'CNAME',
+      :value  => 'real.' + domain_name
     }.merge!(config[:record_attributes] || {})
 
     if !Fog.mocking? || config[:mocked]
@@ -20,7 +32,9 @@ for provider, config in dns_providers
 
       @zone = Fog::DNS[provider].zones.create(zone_attributes)
 
-      model_tests(@zone.records, record_attributes, config[:mocked])
+      model_tests(@zone.records, a_record_attributes, config[:mocked])
+      model_tests(@zone.records, aaaa_record_attributes, config[:mocked])
+      model_tests(@zone.records, cname_record_attributes, config[:mocked])
 
       @zone.destroy
     end


### PR DESCRIPTION
@geemus Is this a good idea?  Not for sure if this will break other providers, but this test currently breaks (and hence will verify the success of #1141)

Wouldn't be too hard to make this Rackspace specific but I figured it could make sense for other providers if they all support AAAA and CNAME.
