### PR TITLE
update bluebox createblock request to encode key values using CGI.escape, rather the URI.encode

### DIFF
--- a/lib/fog/bluebox/requests/compute/create_block.rb
+++ b/lib/fog/bluebox/requests/compute/create_block.rb
@@ -30,14 +30,12 @@ module Fog
             'location' => location_id
           }
 
-          body = URI.encode options.map {|k,v| "#{k}=#{v}"}.join('&')
-
           request(
             :expects  => 200,
             :method   => 'POST',
             :path     => '/api/blocks.json',
             :query    => query,
-            :body     => URI.encode(body)
+            :body     => options.map {|k,v| "#{CGI.escape(k)}=#{CGI.escape(v)}"}.join('&')
           )
         end
 


### PR DESCRIPTION
URI.encode was not encoding the '+' characters within ssh keys
