### PR TITLE
Support for metadata in Rackspace compute_v2

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -56,6 +56,7 @@ module Fog
           requires :name, :image_id, :flavor_id
           options = {}
           options[:disk_config] = disk_config unless disk_config.nil?
+          options[:metadata] = metadata unless metadata.nil?
           data = connection.create_server(name, image_id, flavor_id, 1, 1, options)
           merge_attributes(data.body['server'])
           true

--- a/lib/fog/rackspace/requests/compute_v2/create_server.rb
+++ b/lib/fog/rackspace/requests/compute_v2/create_server.rb
@@ -13,6 +13,7 @@ module Fog
             }
           }
 
+          data['server']['metadata'] = options[:metadata]  unless options[:metadata].nil?
           data['server']['OS-DCF:diskConfig'] = options[:disk_config] unless options[:disk_config].nil?
 
           request(


### PR DESCRIPTION
Metadata for Rackspace compute_v2 nodes was previously not being passed in the requests for create_server.
