### PR TITLE
Do not add empty security group

### DIFF
--- a/lib/fog/cloudstack/models/compute/server.rb
+++ b/lib/fog/cloudstack/models/compute/server.rb
@@ -93,7 +93,7 @@ module Fog
           }
 
           options.merge!('networkids' => network_ids) if network_ids
-          options.merge!('securitygroupids' => security_group_ids) if security_group_ids
+          options.merge!('securitygroupids' => security_group_ids) unless security_group_ids.empty?
 
           data = connection.deploy_virtual_machine(options)
           merge_attributes(data['deployvirtualmachineresponse'])


### PR DESCRIPTION
Previously, not setting a security group leads to an invalid
signature (when using api keys). This was caused b/c
an extra securitygroupid was added with '' as its value.

This was calculated as a part of the signature, but dropped
from the request, leading to the error:
    unable to verify user credentials and/or request signature

This commit only adds a securtygroupid param if the result of
the querying for groups does not return []. This will prevent the
extra security group from being added.
