### PR TITLE
Fix describe_instances stateReason handling

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_instances.rb
+++ b/lib/fog/aws/parsers/compute/describe_instances.rb
@@ -41,7 +41,9 @@ module Fog
             when *@contexts
               @context.pop
             when 'code'
-              @instance[@context.last][name] = value.to_i
+              @instance[@context.last][name] = @context.last == 'stateReason' ? value : value.to_i
+            when 'message'
+              @instance[@context.last][name] = value
             when 'deleteOnTermination'
               @block_device_mapping[name] = (value == 'true')
             when 'deviceName', 'status', 'volumeId'


### PR DESCRIPTION
Before this the state_reason code was always 0 ('..'.to_i) and message was
lost
