### PR TITLE
removed Fog::AWS[:rds] this was creating issues with AWS security creden...

### DIFF
--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -158,7 +158,7 @@ module Fog
         end
 
         def owner_id
-          @owner_id ||= Fog::AWS[:rds].security_groups.get('default').owner_id
+          @owner_id ||= security_groups.get('default').owner_id
         end
 
         def reload


### PR DESCRIPTION
Removed Fog::AWS[:rds] portion on the owner_id method. On instance creation this was causing an AWS permission error stating that  :aws_access_key_id and :aws_secret_access_key where not defined. 

Benton Roberts(a fog contributor) broberts@mdsol.com whom originally submitted the tagging addition has approved this patch.
