### PR TITLE
[core] Adds fog User-Agent header

### DIFF
--- a/lib/fog/core/connection.rb
+++ b/lib/fog/core/connection.rb
@@ -2,6 +2,7 @@ module Fog
   class Connection
 
     def initialize(url, persistent=false, params={})
+      Excon.defaults[:headers]['User-Agent'] ||= "fog/#{Fog::VERSION}"
       @excon = Excon.new(url, params)
       @persistent = persistent
     end


### PR DESCRIPTION
As discussed in #1026 this adds a User Agent HTTP header to help identify
the version of fog is accessing APIs.
