### PR TITLE
Add support for volume_pool_name

### DIFF
--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -335,6 +335,7 @@ module Fog
             end
           else
             # If no template volume was given, let's create our own volume
+            options[:pool_name]   = volume_pool_name   if volume_pool_name
             options[:format_type] = volume_format_type if volume_format_type
             options[:capacity]    = volume_capacity    if volume_capacity
             options[:allocation]  = volume_allocation  if volume_allocation


### PR DESCRIPTION
This is related to the issue #1304. This adds support to volume_pool_name for Libvirt.
