### PR TITLE
Sync with latest OpenStack flavors extensions.

### DIFF
--- a/lib/fog/openstack/models/compute/flavor.rb
+++ b/lib/fog/openstack/models/compute/flavor.rb
@@ -14,6 +14,8 @@ module Fog
         attribute :swap
         attribute :rxtx_factor
         attribute :ephemeral, :aliases => 'OS-FLV-EXT-DATA:ephemeral'
+        attribute :is_public, :aliases => 'os-flavor-access:is_public'
+        attribute :disabled, :aliases => 'OS-FLV-DISABLED:disabled'
 
         def initialize(attributes)
           @connection = attributes[:connection]
@@ -23,8 +25,10 @@ module Fog
         def save
           requires :name, :ram, :vcpus, :disk
           attributes[:ephemeral] = self.ephemeral || 0
+          attributes[:is_public] = self.is_public || false
+          attributes[:disabled] = self.disabled || false
           attributes[:swap] = self.swap || 0
-          attributes[:rxtx_factor] = self.rxtx_factor || 1
+          attributes[:rxtx_factor] = self.rxtx_factor || 1.0
           merge_attributes(connection.create_flavor(self.attributes).body['flavor'])
           self
         end

--- a/lib/fog/openstack/requests/compute/create_flavor.rb
+++ b/lib/fog/openstack/requests/compute/create_flavor.rb
@@ -29,6 +29,7 @@ module Fog
               'id' => attributes[:flavor_id],
               'swap' => attributes[:swap],
               'OS-FLV-EXT-DATA:ephemeral' => attributes[:ephemeral],
+              'os-flavor-access:is_public' => attributes[:is_public],
               'rxtx_factor' => attributes[:rxtx_factor]
             }
           }
@@ -67,8 +68,10 @@ module Fog
                   "rel" => "bookmark"
                 }
               ],
-              "rxtx_factor" => attributes[:rxtx_factor] || 1,
+              "rxtx_factor" => attributes[:rxtx_factor] || 1.0,
               "OS-FLV-EXT-DATA:ephemeral" => attributes[:ephemeral] || 0,
+              "os-flavor-access:is_public" => attributes[:is_public] || false,
+              "OS-FLV-DISABLED:disabled" => attributes[:disabled] || false,
               "ram" => attributes[:ram],
               "id" => "11",
               "swap" => attributes[:swap] || ""

--- a/tests/openstack/requests/compute/flavor_tests.rb
+++ b/tests/openstack/requests/compute/flavor_tests.rb
@@ -6,9 +6,11 @@ Shindo.tests('Fog::Compute[:openstack] | flavor requests', ['openstack']) do
     'disk'        => Integer,
     'ram'         => Integer,
     'links'       => Array,
-    'swap'        => String,
+    'swap'        => Fog::Nullable::String,
     'rxtx_factor' => Fog::Nullable::Float,
     'OS-FLV-EXT-DATA:ephemeral'   => Integer,
+    'os-flavor-access:is_public'   => Fog::Nullable::Boolean,
+    'OS-FLV-DISABLED:disabled'   => Fog::Nullable::Boolean,
     'vcpus'       => Integer
   }
 
@@ -27,7 +29,7 @@ Shindo.tests('Fog::Compute[:openstack] | flavor requests', ['openstack']) do
     end
 
     tests('#create_flavor(attributes)').formats({'flavor' => @flavor_format}) do
-      attributes = {:flavor_id => '100', :name => 'shindo test flavor', :disk => 10, :ram => 10, :vcpus => 10, :swap => "0", :rxtx_factor => 1.0, :ephemeral => 0}
+      attributes = {:flavor_id => '100', :name => 'shindo test flavor', :disk => 10, :ram => 10, :vcpus => 10, :swap => "0", :rxtx_factor => 2.4, :ephemeral => 0, :is_public => false}
       Fog::Compute[:openstack].create_flavor(attributes).body
     end
 


### PR DESCRIPTION
Updates the OpenStack flavors model/request/and tests so
that they support the latest upstream flavor extensions in
Nova.

Also updated the Fog tests so they pass with both mocks and reals
(tested against OpenStack deployed on Fedora).
