### PR TITLE
OpenStack floating_ip (aka address) test fixes

### DIFF
--- a/lib/fog/openstack/requests/compute/release_address.rb
+++ b/lib/fog/openstack/requests/compute/release_address.rb
@@ -15,8 +15,20 @@ module Fog
 
       class Mock
 
+        def release_address(address_id)
+          response = Excon::Response.new
+          response.status = 202
+          response.headers = {
+            "Content-Type" => "text/html; charset=UTF-8",
+            "Content-Length" => "0",
+            "Date" => Date.new
+          }
+          response.body = {}
+          response
+        end
 
-      end
+      end # mock
+
     end
   end
 end

--- a/tests/openstack/requests/compute/address_tests.rb
+++ b/tests/openstack/requests/compute/address_tests.rb
@@ -1,16 +1,10 @@
 Shindo.tests('Fog::Compute[:openstack] | address requests', ['openstack']) do
-  # clean the servers
-=begin  
-  @servers = Fog::Compute[:openstack].servers.each do |server|
-    Fog::Compute[:openstack].list_all_addresses(server.id).body['floating_ips'].each do |ip_add|
-      Fog::Compute[:openstack].release_address(ip_add['id'])
-    end
 
-    Fog::Compute[:openstack].delete_server(server.id)
-  end
-=end
+  compute = Fog::Compute[:openstack]
+  flavor_ref = ENV['OPENSTACK_FLAVOR_REF'] || compute.list_flavors.body['flavors'].first['links'].first['href']
+  image_ref = ENV['OPENSTACK_IMAGE_REF'] || compute.list_images.body['images'].first['links'].first['href']
 
-  @server = Fog::Compute[:openstack].create_server("shindo_test_server", Fog::Compute[:openstack].list_images.body['images'].last['links'].first['href'], Fog::Compute[:openstack].list_flavors.body['flavors'].first['links'].first['href'])
+  @server_id = compute.create_server("shindo_test_server", image_ref, flavor_ref).body['server']['id']
 
   @address_format = {
     "instance_id" => NilClass,
@@ -21,29 +15,38 @@ Shindo.tests('Fog::Compute[:openstack] | address requests', ['openstack']) do
   }
 
   tests('success') do
+
     tests('#allocate_address').formats({"floating_ip" => @address_format}) do
-      Fog::Compute[:openstack].allocate_address.body
+      data = compute.allocate_address.body
+      @address_id = data['floating_ip']['id']
+      @address_ip = data['floating_ip']['ip']
+      data
     end
 
     tests('#list_all_addresses').formats({"floating_ips" => [@address_format]}) do
-      Fog::Compute[:openstack].list_all_addresses.body
+      compute.list_all_addresses.body
     end
 
     tests('#get_address(address_id)').formats({"floating_ip" => @address_format}) do
-      address_id = Fog::Compute[:openstack].addresses.all.first.id
-      Fog::Compute[:openstack].get_address(address_id).body
+      compute.get_address(@address_id).body
     end
 
-    Fog::Compute[:openstack].servers.get(@server.body['server']['id']).wait_for { ready? }
+    compute.servers.get(@server_id).wait_for { ready? }
 
     tests('#associate_address(server_id, ip_address)').succeeds do
-      address_ip = Fog::Compute[:openstack].addresses.all.first.ip
-      Fog::Compute[:openstack].associate_address(@server.body['server']['id'], address_ip).body
+      compute.associate_address(@server_id, @address_ip).body
     end
 
     tests('#disassociate_address(server_id, ip_address)').succeeds do
-      address_ip = Fog::Compute[:openstack].addresses.all.first.ip
-      Fog::Compute[:openstack].disassociate_address(@server.body['server']['id'], address_ip).body
+      compute.disassociate_address(@server_id, @address_ip).body
     end
+
+    tests('#release_address(ip_address)').succeeds do
+      compute.release_address(@address_id)
+    end
+
   end
+
+  compute.delete_server(@server_id)
+
 end


### PR DESCRIPTION
Updates to the OpenStack address tests so that:
- The tests cleanup after themselves when executed in Real mode.
  Previously running these tests in Real mode would leak servers
  and floating IPs.
- DRY things up a bit.
- Make use of the floating IP we create in subsequent tests. Previously
  the last floating IP in the full list was used. This could be
  problematic in some cases.
## 

Also adds a missing Mock class for the release_address request so
that FOG_MOCK tests continue to pass.
