### PR TITLE
Supported AWS regions in #supported_regions helper

### DIFF
--- a/lib/fog/aws/auto_scaling.rb
+++ b/lib/fog/aws/auto_scaling.rb
@@ -258,7 +258,7 @@ module Fog
           setup_credentials(options)
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-1', 'us-west-2'].include?(@region)
+          unless supported_regions.include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end
@@ -279,6 +279,10 @@ module Fog
           @aws_access_key_id = options[:aws_access_key_id]
         end
 
+        def supported_regions
+          @supported_regions ||= ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2',
+            'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-1', 'us-west-2']
+        end
       end
 
     end

--- a/lib/fog/aws/cloud_watch.rb
+++ b/lib/fog/aws/cloud_watch.rb
@@ -55,7 +55,7 @@ module Fog
 
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-1', 'us-west-2'].include?(@region)
+          unless supported_regions.include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end
@@ -66,6 +66,11 @@ module Fog
 
         def reset_data
           self.class.data[@region].delete(@aws_access_key_id)
+        end
+
+        def supported_regions
+          @supported_regions ||= ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2',
+            'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-1', 'us-west-2']
         end
       end
 

--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -221,7 +221,7 @@ module Fog
           setup_credentials(options)
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(@region)
+          unless supported_regions.include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end
@@ -283,6 +283,11 @@ module Fog
 
         def setup_credentials(options)
           @aws_access_key_id = options[:aws_access_key_id]
+        end
+
+        def supported_regions
+          @supported_regions ||= ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2',
+            'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-1', 'us-west-2']
         end
       end
 

--- a/lib/fog/aws/elasticache.rb
+++ b/lib/fog/aws/elasticache.rb
@@ -147,8 +147,7 @@ module Fog
           @aws_credentials_expire_at = Time::now + 20
           setup_credentials(options)
           @region = options[:region] || 'us-east-1'
-          unless ['ap-northeast-1', 'ap-southeast-1', 'eu-west-1', 'us-east-1',
-                  'us-west-1', 'us-west-2', 'sa-east-1'].include?(@region)
+          unless supported_regions.include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end
@@ -183,6 +182,11 @@ module Fog
                 "#{cluster_id}.#{node_id}.use1.cache.amazonaws.com"
             }
           end
+        end
+
+        def supported_regions
+          @supported_regions ||= ['ap-northeast-1', 'ap-southeast-1', 'eu-west-1', 
+            'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1']
         end
       end
 

--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -81,7 +81,7 @@ module Fog
 
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'].include?(@region)
+          unless supported_regions.include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end
@@ -96,6 +96,11 @@ module Fog
 
         def reset_data
           self.class.data[@region].delete(@aws_access_key_id)
+        end
+
+        def supported_regions
+          @supported_regions ||= ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2',
+            'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2']
         end
       end
 

--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -101,7 +101,7 @@ module Fog
           @use_iam_profile = options[:use_iam_profile]
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(@region)
+          unless supported_regions.include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
 
@@ -119,6 +119,10 @@ module Fog
           @aws_access_key_id = options[:aws_access_key_id]
         end
 
+        def supported_regions
+          @supported_regions ||= ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2',
+            'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1']
+        end
       end
 
       class Real

--- a/lib/fog/aws/sqs.rb
+++ b/lib/fog/aws/sqs.rb
@@ -40,7 +40,7 @@ module Fog
           setup_credentials(options)
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(@region)
+          unless supported_regions.include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end
@@ -55,6 +55,11 @@ module Fog
 
         def setup_credentials(options)
           @aws_access_key_id = options[:aws_access_key_id]
+        end
+
+        def supported_regions
+          @supported_regions ||= ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2',
+            'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1']
         end
       end
 


### PR DESCRIPTION
The supported_regions helper is a wrapper around an instance variable
so that in future, fog users can self-modify the list as data
to support newly available services in regions, or newly available
regions; without waiting for fog version releases.
