### PR TITLE
OpenStack: Remove volumes from limits tests.

### DIFF
--- a/lib/fog/openstack/requests/compute/get_limits.rb
+++ b/lib/fog/openstack/requests/compute/get_limits.rb
@@ -63,19 +63,15 @@ module Fog
             'maxPersonalitySize'       => 10240,
             'maxSecurityGroupRules'    => 20,
             'maxTotalKeypairs'         => 100,
-            'maxTotalVolumes'          => 10,
             'maxSecurityGroups'        => 10,
             'maxTotalCores'            => 20,
             'maxTotalFloatingIps'      => 10,
-            'maxTotalVolumeGigabytes'  => 1000,
             'maxTotalRAMSize'          => 51200,
 
             # Used
-            'totalVolumesUsed'         => 0,
             'totalCoresUsed'           => -1,
             'totalRAMUsed'             => -2048,
             'totalInstancesUsed'       => -1,
-            'totalVolumeGigabytesUsed' => 0,
             'totalSecurityGroupsUsed'  => 0,
             'totalKeyPairsUsed'        => 0
           }

--- a/tests/openstack/requests/compute/limit_tests.rb
+++ b/tests/openstack/requests/compute/limit_tests.rb
@@ -21,17 +21,13 @@ Shindo.tests('Fog::Compute[:openstack] | limits requests', ['openstack']) do
     'maxPersonalitySize'        => Fixnum,
     'maxSecurityGroupRules'     => Fixnum,
     'maxTotalKeypairs'          => Fixnum,
-    'maxTotalVolumes'           => Fixnum,
     'maxSecurityGroups'         => Fixnum,
     'maxTotalCores'             => Fixnum,
     'maxTotalFloatingIps'       => Fixnum,
-    'maxTotalVolumeGigabytes'   => Fixnum,
     'maxTotalRAMSize'           => Fixnum,
-    'totalVolumesUsed'          => Fixnum,
     'totalCoresUsed'            => Fixnum,
     'totalRAMUsed'              => Fixnum,
     'totalInstancesUsed'        => Fixnum,
-    'totalVolumeGigabytesUsed'  => Fixnum,
     'totalSecurityGroupsUsed'   => Fixnum,
     'totalKeyPairsUsed'         => Fixnum
   }


### PR DESCRIPTION
In OpenStack Grizzly Nova no longer supports volumes directly. This has been moved to another service called Cinder. This removes the volume specific settings from the OpenStack compute limits tests and Mock.

This change has will has no effect on users of previous of Fog for previous releases (Folsom, etc) but should allow us to easily support the latest upstream codebase and run Fog _real_ tests.
