### PR TITLE
OpenStack: updates to quota tests.

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -191,13 +191,13 @@ module Fog
               :addresses => {},
               :quota => {
                 'metadata_items' => 128,
+                'key_pairs' => 10,
                 'injected_file_content_bytes' => 10240,
+                'injected_file_path_bytes' => 256,
                 'injected_files' => 5,
-                'gigabytes' => 1000,
                 'ram' => 51200,
                 'floating_ips' => 10,
                 'instances' => 10,
-                'volumes' => 10,
                 'cores' => 20,
               }
             }

--- a/tests/openstack/requests/compute/quota_tests.rb
+++ b/tests/openstack/requests/compute/quota_tests.rb
@@ -2,14 +2,14 @@ Shindo.tests('Fog::Compute[:openstack] | quota requests', ['openstack']) do
 
   @tenant_id = Fog::Compute[:openstack].list_tenants.body['tenants'].first['id']
   @quota_set_format = {
+    'key_pairs' => Fixnum,
     'metadata_items' => Fixnum,
     'injected_file_content_bytes' => Fixnum,
+    'injected_file_path_bytes' => Fixnum,
     'injected_files' => Fixnum,
-    'gigabytes' => Fixnum,
     'ram' => Fixnum,
     'floating_ips' => Fixnum,
     'instances' => Fixnum,
-    'volumes' => Fixnum,
     'cores' => Fixnum,
     'security_groups' => Fog::Nullable::Integer,
     'security_group_rules' => Fog::Nullable::Integer,
@@ -17,6 +17,7 @@ Shindo.tests('Fog::Compute[:openstack] | quota requests', ['openstack']) do
   }
 
   tests('success') do
+
     tests('#get_quota_defaults').formats({ 'quota_set' => @quota_set_format }) do
       Fog::Compute[:openstack].get_quota_defaults(@tenant_id).body
     end
@@ -27,8 +28,9 @@ Shindo.tests('Fog::Compute[:openstack] | quota requests', ['openstack']) do
     end
 
     tests('#update_quota') do
+
       new_values = @quota.merge({
-        'volumes' => @quota['volumes']/2,
+        'floating_ips' => @quota['floating_ips']/2,
         'cores' => @quota['cores']/2
       })
 
@@ -39,6 +41,17 @@ Shindo.tests('Fog::Compute[:openstack] | quota requests', ['openstack']) do
       returns(new_values, 'returns new values') do
         Fog::Compute[:openstack].get_quota(@tenant_id).body['quota_set']
       end
+
+      # set quota back to old values
+      succeeds do
+        Fog::Compute[:openstack].update_quota(@tenant_id, @quota.clone)
+      end
+
+      # ensure old values are restored
+      returns(@quota, 'old values restored') do
+        Fog::Compute[:openstack].get_quota(@tenant_id).body['quota_set']
+      end
+
     end
 
   end


### PR DESCRIPTION
Updates to the OpenStack quota tests to support the latest
changes in Folsom/Grizzly. With these changes I am able to run
the _real_ tests again with the latest upstream OpenStack builds.

Also updates the quote tests so that they update quotas back to previous values for the tenant being tested. This makes it so the tests clean up after themselves... (thus subsequent runs give the same results).

This change has no functional effect on Fog users for previous
releases of OpenStack (Folsom, etc,) but should allow us to
support the latest upstream codebase and run Fog _real_ tests again.
