### PR TITLE
Add a generic destroy operator on a bucket.

### DIFF
--- a/lib/fog/atmos/models/storage/directory.rb
+++ b/lib/fog/atmos/models/storage/directory.rb
@@ -1,10 +1,11 @@
 require 'fog/core/model'
+require 'fog/storage/models/directory'
 
 module Fog
   module Storage
     class Atmos
 
-      class Directory < Fog::Model
+      class Directory < Fog::Storage::Directory
 
         identity :key, :aliases => :Filename
         attribute :objectid, :aliases => :ObjectID
@@ -35,13 +36,7 @@ module Fog
         end
 
         def destroy(opts={})
-          if opts[:recursive]
-            files.each {|f| f.destroy }
-            directories.each do |d|
-              d.files.each {|f| f.destroy }
-              d.destroy(opts)
-            end
-          end
+          super(opts)
           connection.delete_namespace key
         end
 

--- a/lib/fog/aws/models/storage/directory.rb
+++ b/lib/fog/aws/models/storage/directory.rb
@@ -1,4 +1,5 @@
 require 'fog/core/model'
+require 'fog/storage/models/directory'
 require 'fog/aws/models/storage/files'
 require 'fog/aws/models/storage/versions'
 
@@ -6,7 +7,7 @@ module Fog
   module Storage
     class AWS
 
-      class Directory < Fog::Model
+      class Directory < Fog::Storage::Directory
         VALID_ACLS = ['private', 'public-read', 'public-read-write', 'authenticated-read']
 
         # See http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTBucketPUT.html
@@ -24,14 +25,6 @@ module Fog
           else
             @acl = new_acl
           end
-        end
-
-        def destroy
-          requires :key
-          connection.delete_bucket(key)
-          true
-        rescue Excon::Errors::NotFound
-          false
         end
 
         def location

--- a/lib/fog/google/models/storage/directory.rb
+++ b/lib/fog/google/models/storage/directory.rb
@@ -1,11 +1,12 @@
 require 'fog/core/model'
+require 'fog/storage/models/directory'
 require 'fog/google/models/storage/files'
 
 module Fog
   module Storage
     class Google
 
-      class Directory < Fog::Model
+      class Directory < Fog::Storage::Directory
 
         identity  :key,           :aliases => ['Name', 'name']
 
@@ -17,14 +18,6 @@ module Fog
             raise ArgumentError.new("acl must be one of [#{valid_acls.join(', ')}]")
           end
           @acl = new_acl
-        end
-
-        def destroy
-          requires :key
-          connection.delete_bucket(key)
-          true
-        rescue Excon::Errors::NotFound
-          false
         end
 
         def files

--- a/lib/fog/hp/models/storage/directory.rb
+++ b/lib/fog/hp/models/storage/directory.rb
@@ -1,11 +1,12 @@
 require 'fog/core/model'
+require 'fog/storage/models/directory'
 require 'fog/hp/models/storage/files'
 
 module Fog
   module Storage
     class HP
 
-      class Directory < Fog::Model
+      class Directory < Fog::Storage::Directory
 
         identity  :key, :aliases => 'name'
 
@@ -23,9 +24,8 @@ module Fog
           @acl = new_acl
         end
 
-        def destroy
-          requires :key
-          connection.delete_container(key)
+        def destroy(opts={})
+          super(opts)
           # If CDN service is available, try to delete the container if it was CDN-enabled
           if cdn_enabled?
             begin
@@ -35,8 +35,6 @@ module Fog
             end
           end
           true
-        rescue Excon::Errors::NotFound, Fog::Storage::HP::NotFound
-          false
         end
 
         def files

--- a/lib/fog/rackspace/models/storage/directory.rb
+++ b/lib/fog/rackspace/models/storage/directory.rb
@@ -1,11 +1,12 @@
 require 'fog/core/model'
+require 'fog/storage/models/directory'
 require 'fog/rackspace/models/storage/files'
 
 module Fog
   module Storage
     class Rackspace
 
-      class Directory < Fog::Model
+      class Directory < Fog::Storage::Directory
 
         identity  :key, :aliases => 'name'
 
@@ -13,9 +14,8 @@ module Fog
         attribute :count, :aliases => 'X-Container-Object-Count'
         attribute :cdn_cname
 
-        def destroy
-          requires :key
-          connection.delete_container(key)
+        def destroy(opts={})
+          super(opts)
           connection.cdn.post_container(key, 'X-CDN-Enabled' => 'False')
           true
         rescue Excon::Errors::NotFound

--- a/lib/fog/storage/models/directory.rb
+++ b/lib/fog/storage/models/directory.rb
@@ -1,0 +1,40 @@
+require 'fog/core/model'
+
+module Fog
+  module Storage
+    class Directory < Fog::Model
+      identity  :key, :aliases => ['Name', 'name']
+
+      # TODO: support for versioned buckets
+      def clear_directory
+        self.files.each do |file|
+          return false if !file.destroy
+        end
+        true
+      end
+
+      def destroy(opts = {})
+        requires :key
+        if opts[:recursive]
+          return false if !self.clear_directory
+          if self.respond_to?('directories')
+            self.directories.each do |dir|
+              dir.destroy(opts)
+            end
+          end
+        end
+        if self.connection.respond_to?('delete_bucket')
+          self.connection.delete_bucket(key)
+        elsif self.connection.respond_to?('delete_container')
+          self.connection.delete_container(key)
+        else
+          raise 'Delete container not implemented!'
+        end
+        true
+      rescue Excon::Errors::NotFound
+        false
+      end
+
+    end
+  end
+end

--- a/tests/atmos/models/storage/directory_tests.rb
+++ b/tests/atmos/models/storage/directory_tests.rb
@@ -1,0 +1,23 @@
+Shindo.tests("Storage[:atmos] | directory", ["atmos"]) do
+
+  directory_attributes = {
+    :key => 'fogdirectorytests'
+  }
+
+  model_tests(Fog::Storage[:atmos].directories, directory_attributes, Fog.mocking?) do
+
+    tests("#directory_lifecycle") do
+      tests("creates a directory, puts files in it, destroys it").returns(true) do
+        directory = Fog::Storage[:atmos].directories.create(:key => 'directory_test')
+        return false if directory.nil?
+        10.times do |id|
+          ret = directory.connection.put_object(directory.key, "#{@instance.key}-#{id}", 'test')
+          return false if !ret
+        end
+        directory.destroy(:recursive => true)
+      end
+    end
+
+  end
+
+end

--- a/tests/aws/models/storage/directory_tests.rb
+++ b/tests/aws/models/storage/directory_tests.rb
@@ -48,4 +48,20 @@ Shindo.tests("Storage[:aws] | directory", ["aws"]) do
 
   end
 
+  model_tests(Fog::Storage[:aws].directories, directory_attributes, Fog.mocking?) do
+
+    tests("#directory_lifecycle") do
+      tests("creates a directory, puts files in it, destroys it").returns(true) do
+        directory = Fog::Storage[:aws].directories.create(:key => 'directory_test')
+        return false if directory.nil?
+        10.times do |id|
+          ret = directory.connection.put_object(directory.key, "#{@instance.key}-#{id}", 'test')
+          return false if !ret
+        end
+        directory.destroy(:recursive => true)
+      end
+    end
+
+  end
+
 end

--- a/tests/google/models/storage/directory_tests.rb
+++ b/tests/google/models/storage/directory_tests.rb
@@ -1,0 +1,23 @@
+Shindo.tests("Storage[:google] | directory", ["google"]) do
+
+  directory_attributes = {
+    :key => 'fogdirectorytests'
+  }
+
+  model_tests(Fog::Storage[:google].directories, directory_attributes, Fog.mocking?) do
+
+    tests("#directory_lifecycle") do
+      tests("creates a directory, puts files in it, destroys it").returns(true) do
+        directory = Fog::Storage[:google].directories.create(:key => 'directory_test')
+        return false if directory.nil?
+        10.times do |id|
+          ret = directory.connection.put_object(directory.key, "#{@instance.key}-#{id}", 'test')
+          return false if !ret
+        end
+        directory.destroy(:recursive => true)
+      end
+    end
+
+  end
+
+end

--- a/tests/hp/models/storage/directory_tests.rb
+++ b/tests/hp/models/storage/directory_tests.rb
@@ -1,0 +1,23 @@
+Shindo.tests("Storage[:hp] | directory", ["hp"]) do
+
+  directory_attributes = {
+    :key => 'fogdirectorytests'
+  }
+
+  model_tests(Fog::Storage[:hp].directories, directory_attributes, Fog.mocking?) do
+
+    tests("#directory_lifecycle") do
+      tests("creates a directory, puts files in it, destroys it").returns(true) do
+        directory = Fog::Storage[:hp].directories.create(:key => 'directory_test')
+        return false if directory.nil?
+        10.times do |id|
+          ret = directory.connection.put_object(directory.key, "#{@instance.key}-#{id}", 'test')
+          return false if !ret
+        end
+        directory.destroy(:recursive => true)
+      end
+    end
+
+  end
+
+end

--- a/tests/rackspace/models/storage/directory_tests.rb
+++ b/tests/rackspace/models/storage/directory_tests.rb
@@ -1,0 +1,23 @@
+Shindo.tests("Storage[:rackspace] | directory", ["rackspace"]) do
+
+  directory_attributes = {
+    :key => 'fogdirectorytests'
+  }
+
+  model_tests(Fog::Storage[:rackspace].directories, directory_attributes, Fog.mocking?) do
+
+    tests("#directory_lifecycle") do
+      tests("creates a directory, puts files in it, destroys it").returns(true) do
+        directory = Fog::Storage[:rackspace].directories.create(:key => 'directory_test')
+        return false if directory.nil?
+        10.times do |id|
+          ret = directory.connection.put_object(directory.key, "#{@instance.key}-#{id}", 'test')
+          return false if !ret
+        end
+        directory.destroy(:recursive => true)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
Atmos already implements a recursive delete operation and it would
be nice to implement similar functionality for ever provider. Ths
consolidates the deletion code, removes the duplicated effort, and
makes it straigtforward to improve the delete operation (to make it
multi-threaded, for example).
