### PR TITLE
OpenStack: security group test fixes.

### DIFF
--- a/lib/fog/openstack/requests/compute/create_security_group.rb
+++ b/lib/fog/openstack/requests/compute/create_security_group.rb
@@ -41,7 +41,7 @@ module Fog
             'Content-Length' => Fog::Mock.random_numbers(3).to_s,
             'Date'           => Date.new}
           response.body = {
-            'security_group' => self.data[:security_groups].values
+            'security_group' => self.data[:security_groups][security_group_id]
           }
           response
         end

--- a/tests/openstack/requests/compute/security_group_tests.rb
+++ b/tests/openstack/requests/compute/security_group_tests.rb
@@ -20,7 +20,7 @@ Shindo.tests('Fog::Compute[:openstack] | security group requests', ['openstack']
   }
 
   tests('success') do
-    tests('#create_security_group(name, description)').formats({"security_group" => [@security_group_format]}) do
+    tests('#create_security_group(name, description)').formats({"security_group" => @security_group_format}) do
       Fog::Compute[:openstack].create_security_group('from_shindo_test', 'this is from the shindo test').body
     end
 


### PR DESCRIPTION
Update the OpenStack security group test to support the correct
format for create_security_group responses. This patch
removes the extra [] wrapping the response and makes it so the
real tests run once again.

Also updates the existing Mock for create_security_response so
it handles it properly as well.
