### PR TITLE
Bug fix: Ensure Fog::VERSION gets defined

### DIFF
--- a/lib/fog/version.rb
+++ b/lib/fog/version.rb
@@ -1,5 +1,3 @@
 module Fog
-  unless const_defined?(:VERSION, false)
-    VERSION = '1.8.0'
-  end
+  VERSION = '1.8.0'
 end


### PR DESCRIPTION
In the case where the constant `VERSION` is defined at global scope (in the application or due to some gem that pollutes the global namespace), `Fog::VERSION` would not get defined.   This caused a failure in `core/connection.rb` 

Simple fix: specify `false` for the second argument to `const_defined?` to restrict it to local scope.

(An even simpler fix would be to remove the `const_defined?` guard.  I don't know what it's there for, but leaving it in place in case there's a reason for it.)
