### PR TITLE
Rackspace API error messages are not set correctly in exceptions

### DIFF
--- a/lib/fog/hp.rb
+++ b/lib/fog/hp.rb
@@ -15,6 +15,9 @@ module Fog
           else
             data = Fog::JSON.decode(error.response.body)
             message = data['message']
+            if message.nil? and !data.values.first.nil?
+              message = data.values.first['message']
+            end
           end
 
           new_error = super(error, message)
@@ -33,8 +36,8 @@ module Fog
 
         def self.slurp(error)
           new_error = super(error)
-          unless new_error.response_data.nil?
-            new_error.instance_variable_set(:@validation_errors, new_error.response_data['validationErrors'])
+          unless new_error.response_data.nil? or new_error.response_data['badRequest'].nil?
+            new_error.instance_variable_set(:@validation_errors, new_error.response_data['badRequest']['validationErrors'])
           end
           new_error
         end

--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -15,6 +15,9 @@ module Fog
           else
             data = Fog::JSON.decode(error.response.body)
             message = data['message']
+            if message.nil? and !data.values.first.nil?
+              message = data.values.first['message']
+            end
           end
 
           new_error = super(error, message)
@@ -33,8 +36,8 @@ module Fog
 
         def self.slurp(error)
           new_error = super(error)
-          unless new_error.response_data.nil?
-            new_error.instance_variable_set(:@validation_errors, new_error.response_data['validationErrors'])
+          unless new_error.response_data.nil? or new_error.response_data['badRequest'].nil?
+            new_error.instance_variable_set(:@validation_errors, new_error.response_data['badRequest']['validationErrors'])
           end
           new_error
         end

--- a/lib/fog/rackspace.rb
+++ b/lib/fog/rackspace.rb
@@ -15,6 +15,9 @@ module Fog
           else
             data = Fog::JSON.decode(error.response.body)
             message = data['message']
+            if message.nil? and !data.values.first.nil?
+              message = data.values.first['message']
+            end
           end
 
           new_error = super(error, message)
@@ -29,13 +32,13 @@ module Fog
       class ServiceUnavailable < ServiceError; end
 
       class BadRequest < ServiceError
-        #TODO - Need to find a bette way to print out these validation errors when they are thrown
+        #TODO - Need to find a better way to print out these validation errors when they are thrown
         attr_reader :validation_errors
 
         def self.slurp(error)
           new_error = super(error)
-          unless new_error.response_data.nil?
-            new_error.instance_variable_set(:@validation_errors, new_error.response_data['validationErrors'])
+          unless new_error.response_data.nil? or new_error.response_data['badRequest'].nil?
+            new_error.instance_variable_set(:@validation_errors, new_error.response_data['badRequest']['validationErrors'])
           end
           new_error
         end


### PR DESCRIPTION
Rackspace error responses don't have a top level 'message' field, but it is nested in the specific error

ie http://docs.rackspace.com/servers/api/v2/cs-devguide/content/Synchronous_Faults-d1e1729.html
or http://docs.openstack.org/api/openstack-compute/programmer/content/creating-servers.html

```
{
  "badRequest": {
    "message": "Invalid flavorRef provided.", 
    "code": 400
  }
}
```

The HP and openstack providers had the exact same code, so I updated them too. They should extend Fog::Openstack::Errors::\* but that's a different discussion
