### PR TITLE
OpenStack servers can now retrieve security groups

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -187,7 +187,24 @@ module Fog
               },
               :servers => {},
               :key_pairs => {},
-              :security_groups => {},
+              :security_groups => {
+                0 => {
+                  "id"          => 0,
+                  "tenant_id"   => Fog::Mock.random_hex(8),
+                  "name"        => "default",
+                  "description" => "default",
+                  "rules"       => [
+                    { "id"              => 0,
+                      "parent_group_id" => 0,
+                      "from_port"       => 68,
+                      "to_port"         => 68,
+                      "ip_protocol"     => "udp",
+                      "ip_range"        => { "cidr" => "0.0.0.0/0" },
+                      "group"           => {}, },
+                  ],
+                },
+              },
+              :server_security_group_map => {},
               :addresses => {},
               :quota => {
                 'security_group_rules' => 20,

--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -155,6 +155,18 @@ module Fog
           true
         end
 
+        def security_groups
+          requires :id
+
+          groups = connection.list_security_groups(id).body['security_groups']
+
+          groups.map do |group|
+            sg = Fog::Compute::OpenStack::SecurityGroup.new group
+            sg.connection = connection
+            sg
+          end
+        end
+
         def security_groups=(new_security_groups)
           @security_groups = new_security_groups
         end

--- a/lib/fog/openstack/requests/compute/delete_security_group.rb
+++ b/lib/fog/openstack/requests/compute/delete_security_group.rb
@@ -15,6 +15,8 @@ module Fog
 
       class Mock
         def delete_security_group(security_group_id)
+          self.data[:security_groups].delete security_group_id
+
           response = Excon::Response.new
           response.status = 202
           response.headers = {

--- a/lib/fog/openstack/requests/compute/list_security_groups.rb
+++ b/lib/fog/openstack/requests/compute/list_security_groups.rb
@@ -18,9 +18,24 @@ module Fog
       end
 
       class Mock
-        def list_security_groups
+        def list_security_groups(server_id = nil)
+          security_groups = self.data[:security_groups].values
+
+          groups = if server_id then
+                     server_group_names =
+                       self.data[:server_security_group_map][server_id]
+
+                     server_group_names.map do |name|
+                       security_groups.find do |sg|
+                         sg['name'] == name
+                       end
+                     end.compact
+                   else
+                     security_groups
+                   end
+
           Excon::Response.new(
-            :body     => { 'security_groups' => self.data[:security_groups].values },
+            :body     => { 'security_groups' => groups },
             :headers  => {
               "X-Compute-Request-Id" => "req-#{Fog::Mock.random_base64(36)}",
               "Content-Type" => "application/json",

--- a/tests/openstack/models/compute/server_tests.rb
+++ b/tests/openstack/models/compute/server_tests.rb
@@ -1,0 +1,45 @@
+Shindo.tests("Fog::Compute[:openstack] | server", ['openstack']) do
+
+  tests('success') do
+    tests('#security_groups').succeeds do
+      fog = Fog::Compute[:openstack]
+
+      begin
+        my_group = fog.security_groups.create(:name => 'my_group',
+                                              :description => 'my group')
+
+        flavor = fog.flavors.first.id
+        image  = fog.images.first.id
+
+        server = fog.servers.new(:name       => 'test server',
+                                 :flavor_ref => flavor,
+                                 :image_ref  => image)
+
+        server.security_groups = my_group
+
+        server.save
+
+        found_groups = server.security_groups
+
+        returns(1) { found_groups.length }
+
+        group = found_groups.first
+        returns('my_group') { group.name }
+        returns(server.connection) { group.connection }
+      ensure
+        unless Fog.mocking? then
+          server.destroy if server
+
+          begin
+            fog.servers.get(server.id).wait_for do false end
+          rescue Fog::Errors::Error
+            # ignore, server went away
+          end
+        end
+
+        my_group.destroy if my_group
+      end
+    end
+  end
+end
+

--- a/tests/openstack/requests/compute/security_group_tests.rb
+++ b/tests/openstack/requests/compute/security_group_tests.rb
@@ -44,8 +44,16 @@ Shindo.tests('Fog::Compute[:openstack] | security group requests', ['openstack']
     end
 
     tests('#delete_security_group(security_group_id)').succeeds do
-      group_id = Fog::Compute[:openstack].list_security_groups.body['security_groups'].last['id']
-      Fog::Compute[:openstack].delete_security_group(group_id)
+      compute = Fog::Compute[:openstack]
+
+      group_id = compute.list_security_groups.body['security_groups'].last['id']
+
+      compute.delete_security_group(group_id)
+
+      returns(false) {
+        groups = compute.list_security_groups.body['security_groups']
+        groups.any? { |group| group['id'] == group_id }
+      }
     end
   end # tests('success')
 end


### PR DESCRIPTION
This functionality was missing from the Server models. Extracting it by hand from the list_security_groups request is annoying and the missing functionality on the mock version of the request doubly so.

In support of this change:

Added default security group to the OpenStack compute mocks.

OpenStack server creation mock now stores the security groups for the
created server.

OpenStack security group mock deletion now deletes created security
groups.

OpenStack security group mock list now accepts a server id like the real
implementation.
