### PR TITLE
Added SIGINT handler to the fog console

### DIFF
--- a/bin/fog
+++ b/bin/fog
@@ -37,6 +37,10 @@ else
   @irb.context.prompt_mode = :FOG
   @irb.context.workspace = IRB::WorkSpace.new(binding)
 
+  trap 'INT' do
+    @irb.signal_handle
+  end
+
   Formatador.display_line('Welcome to fog interactive!')
   Formatador.display_line(":#{Fog.credential} provides #{providers}")
   providers = Fog.providers


### PR DESCRIPTION
Previously ^C would exit the fog console.

Now ^C is handled and ^D, exit or quit must by typed to exit the
console.  This fixes a major personal annoyance of mine as the fog
console did not behave like IRB or like the shell when you wanted to use
^C to clear what you had just typed.
