### PR TITLE
OpenStack server test updates for real mode.

### DIFF
--- a/tests/openstack/requests/compute/address_tests.rb
+++ b/tests/openstack/requests/compute/address_tests.rb
@@ -1,10 +1,8 @@
 Shindo.tests('Fog::Compute[:openstack] | address requests', ['openstack']) do
 
   compute = Fog::Compute[:openstack]
-  flavor_ref = ENV['OPENSTACK_FLAVOR_REF'] || compute.list_flavors.body['flavors'].first['links'].first['href']
-  image_ref = ENV['OPENSTACK_IMAGE_REF'] || compute.list_images.body['images'].first['links'].first['href']
 
-  @server_id = compute.create_server("shindo_test_server", image_ref, flavor_ref).body['server']['id']
+  @server_id = compute.create_server("shindo_test_server", get_image_ref, get_flavor_ref).body['server']['id']
 
   @address_format = {
     "instance_id" => NilClass,

--- a/tests/openstack/requests/compute/helper.rb
+++ b/tests/openstack/requests/compute/helper.rb
@@ -15,3 +15,23 @@ class OpenStack
   end
 
 end
+
+def get_flavor_ref
+  compute = Fog::Compute[:openstack]
+  ENV['OPENSTACK_FLAVOR_REF'] || compute.list_flavors.body['flavors'].first['id']
+end
+
+def get_image_ref
+  compute = Fog::Compute[:openstack]
+  ENV['OPENSTACK_IMAGE_REF'] || compute.list_images.body['images'].first['id']
+end
+
+def get_flavor_ref_resize
+  # by default we simply add one to the default flavor ref
+  ENV['OPENSTACK_FLAVOR_REF_RESIZE'] || (get_flavor_ref.to_i + 1).to_s
+end
+
+def set_password_enabled
+  pw_enabled = ENV['OPENSTACK_SET_PASSWORD_ENABLED'] || "true"
+  return pw_enabled == "true"
+end


### PR DESCRIPTION
Updates to the OpenStack server tests to get things running in _real_
test mode.

This patch also adds some useful helper functions which
are now used to:
 -get the flavor ref for testing
 -get the image ref for testing
 -get the resize flavor ref for testing (defaults to flavor + 1)
 -disable password testing (not all hypervisors support this in OS)
