### PR TITLE
OpenStack: Drop unused server_format hash.

### DIFF
--- a/tests/openstack/requests/compute/server_tests.rb
+++ b/tests/openstack/requests/compute/server_tests.rb
@@ -1,10 +1,5 @@
 Shindo.tests('Fog::Compute[:openstack] | server requests', ['openstack']) do
 
-  @server_format = {
-    'id'         => String,
-    'links'      => Array,
-  }
-
   @detailed_server_format = {
     'id'         => String,
     'addresses'  => Hash,


### PR DESCRIPTION
Updates the compute server request tests to drop an unused
hash.
