### PR TITLE
OpenStack: Auth improvements

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -7,7 +7,8 @@ module Fog
 
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url,
-                 :persistent, :openstack_service_name, :openstack_tenant,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region
 
@@ -290,8 +291,9 @@ module Fog
           @openstack_auth_uri   = URI.parse(options[:openstack_auth_url])
           @openstack_management_url       = options[:openstack_management_url]
           @openstack_must_reauthenticate  = false
-          @openstack_service_name = options[:openstack_service_name] || ['nova', 'compute']
-          @openstack_identity_service_name = options[:openstack_identity_service_name] || 'identity'
+          @openstack_service_type = options[:openstack_service_type] || ['nova', 'compute']
+          @openstack_service_name = options[:openstack_service_name]
+          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
           @openstack_region      = options[:openstack_region]
 
           @connection_options = options[:connection_options] || {}
@@ -367,8 +369,9 @@ module Fog
               :openstack_auth_uri   => @openstack_auth_uri,
               :openstack_region     => @openstack_region,
               :openstack_tenant     => @openstack_tenant,
+              :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
-              :openstack_identity_service_name => @openstack_identity_service_name
+              :openstack_identity_service_type => @openstack_identity_service_type
             }
 
             if @openstack_auth_uri.path =~ /\/v2.0\//
@@ -400,9 +403,14 @@ module Fog
 
           @port   = uri.port
           @scheme = uri.scheme
-          @identity_connection = Fog::Connection.new(
-            @openstack_identity_public_endpoint,
-            false, @connection_options)
+           
+          # Not all implementations have identity service in the catalog
+          if @openstack_identity_public_endpoint
+            @identity_connection = Fog::Connection.new(
+              @openstack_identity_public_endpoint,
+              false, @connection_options)
+          end
+
           true
         end
 

--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -6,7 +6,7 @@ module Fog
 
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_name, :openstack_tenant,
+                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_current_user_id,
                  :current_user, :current_tenant
 
@@ -186,7 +186,8 @@ module Fog
           @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
           @openstack_management_url       = options[:openstack_management_url]
           @openstack_must_reauthenticate  = false
-          @openstack_service_name = options[:openstack_service_name] || ['identity']
+          @openstack_service_type = options[:openstack_service_type] || ['identity']
+          @openstack_service_name = options[:openstack_service_name]
 
           @connection_options = options[:connection_options] || {}
 
@@ -260,6 +261,7 @@ module Fog
               :openstack_auth_token => @openstack_auth_token,
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_tenant   => @openstack_tenant,
+              :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
               :openstack_endpoint_type => 'adminURL'
             }

--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -5,7 +5,7 @@ module Fog
     class OpenStack < Fog::Service
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_name, :openstack_tenant,
+                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username,
                  :current_user, :current_tenant
 
@@ -109,7 +109,8 @@ module Fog
           @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
           @openstack_management_url       = options[:openstack_management_url]
           @openstack_must_reauthenticate  = false
-          @openstack_service_name         = options[:openstack_service_name] || ['image']
+          @openstack_service_type         = options[:openstack_service_type] || ['image']
+          @openstack_service_name         = options[:openstack_service_name]
 
           @connection_options = options[:connection_options] || {}
 
@@ -179,6 +180,7 @@ module Fog
               :openstack_username => @openstack_username,
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_auth_token => @openstack_auth_token,
+              :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
               :openstack_endpoint_type => 'adminURL'
             }

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -6,7 +6,7 @@ module Fog
 
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_name, :openstack_tenant,
+                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username,
                  :current_user, :current_tenant
 
@@ -107,7 +107,8 @@ module Fog
           @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
           @openstack_management_url       = options[:openstack_management_url]
           @openstack_must_reauthenticate  = false
-          @openstack_service_name         = options[:openstack_service_name] || ['network']
+          @openstack_service_type         = options[:openstack_service_type] || ['network']
+          @openstack_service_name         = options[:openstack_service_name]
 
           @connection_options = options[:connection_options] || {}
 
@@ -178,6 +179,7 @@ module Fog
               :openstack_username => @openstack_username,
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_auth_token => @openstack_auth_token,
+              :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
               :openstack_endpoint_type => 'adminURL'
             }

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -6,7 +6,7 @@ module Fog
 
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_name, :openstack_tenant,
+                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username,
                  :current_user, :current_tenant
 
@@ -111,7 +111,8 @@ module Fog
           @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
           @openstack_management_url       = options[:openstack_management_url]
           @openstack_must_reauthenticate  = false
-          @openstack_service_name         = options[:openstack_service_name] || ['volume']
+          @openstack_service_type         = options[:openstack_service_type] || ['volume']
+          @openstack_service_name         = options[:openstack_service_name]
 
           @connection_options = options[:connection_options] || {}
 
@@ -182,6 +183,7 @@ module Fog
               :openstack_username => @openstack_username,
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_auth_token => @openstack_auth_token,
+              :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
               :openstack_endpoint_type => 'adminURL'
             }

--- a/tests/openstack/authenticate_tests.rb
+++ b/tests/openstack/authenticate_tests.rb
@@ -85,7 +85,7 @@ Shindo.tests('OpenStack | authenticate', ['openstack']) do
         Fog::OpenStack.authenticate_v2(
           :openstack_auth_uri     => URI('http://example/v2.0/tokens'),
           :openstack_tenant       => 'admin',
-          :openstack_service_name => %w[compute])
+          :openstack_service_type => %w[compute])
       end
     end
 
@@ -98,9 +98,42 @@ Shindo.tests('OpenStack | authenticate', ['openstack']) do
         Fog::OpenStack.authenticate_v2(
           :openstack_auth_uri     => URI('http://example/v2.0/tokens'),
           :openstack_tenant       => 'admin',
-          :openstack_service_name => %w[network])
+          :openstack_service_type => %w[network])
       end
     end
+
+    tests("v2 auth with two compute services") do
+      body_clone = body.clone
+      body_clone["access"]["serviceCatalog"] << 
+        {
+        "endpoints" => [{
+          "adminURL" =>
+            "http://example2:8774/v2/#{tenant_token}",
+            "region" => "RegionOne",
+          "internalURL" =>
+            "http://example2:8774/v2/#{tenant_token}",
+          "id" => Fog::Mock.random_numbers(8).to_s,
+          "publicURL" =>
+           "http://example2:8774/v2/#{tenant_token}"
+        }],
+        "endpoints_links" => [],
+        "type" => "compute",
+        "name" => "nova2"
+        }
+
+      Excon.stub({ :method => 'POST', :path => "/v2.0/tokens" },
+                 { :status => 200, :body => Fog::JSON.encode(body_clone) })
+
+      returns("http://example2:8774/v2/#{tenant_token}") do
+        Fog::OpenStack.authenticate_v2(
+          :openstack_auth_uri     => URI('http://example/v2.0/tokens'),
+          :openstack_tenant       => 'admin',
+          :openstack_service_type => %w[compute],
+          :openstack_service_name => 'nova2')[:server_management_url]
+      end
+
+    end
+
   ensure
     Excon.stubs.clear
     Excon.defaults[:mock] = @old_mock_value


### PR DESCRIPTION
OpenStack auth updates to select by service name.

This patch updates the OpenStack auth implementation so that  it supports selecting API service by both 'name' and 'type'. This makes Fog's openstack implementation usable with providers which have multiple services for a given type (compute for example).

 Previously the implementation was confusing because it used a config param called :openstack_service_name to select the service 'type' from the catalog. This patch  swaps it so that :openstack_service_name actually selects  by 'name'.

 The previous logic to select service by type ('compute' for example) has been preserved in a new :openstack_service_type parameter. This option is used just as it was before for backwards compatibility.

 This change is potentially breaking for anyone previously using :openstack_service_name directly (which I don't think is that common). As such we should probably make a release note saying that previous users of :openstack_service_name should migrate to use :openstack_service_type instead.

---

This patch also fixes some exception class names and cleans up some unused exceptions in the OpenStack implementation.
