### PR TITLE
[rackspace|dns] creating a record now uses specified ttl

### DIFF
--- a/lib/fog/rackspace/models/dns/record.rb
+++ b/lib/fog/rackspace/models/dns/record.rb
@@ -51,6 +51,10 @@ module Fog
             :data => value
           }
 
+          if ttl
+            options[:ttl] = ttl
+          end
+
           if priority
             options[:priority] = priority
           end
@@ -80,6 +84,7 @@ module Fog
           options[:type] = type if type
           options[:data] = value if value
           options[:priority] = priority if priority
+          options[:ttl] = ttl if ttl
 
           wait_for_job connection.modify_record(@zone.identity, identity, options).body['jobId']
           true

--- a/lib/fog/rackspace/requests/dns/add_records.rb
+++ b/lib/fog/rackspace/requests/dns/add_records.rb
@@ -13,7 +13,11 @@ module Fog
                 'type' => record[:type],
                 'data' => record[:data]
               }
-
+              
+              if record.has_key? :ttl
+                record_data['ttl'] = record[:ttl]
+              end
+              
               if record.has_key? :priority
                 record_data['priority'] = record[:priority]
               end

--- a/tests/rackspace/requests/dns/records_tests.rb
+++ b/tests/rackspace/requests/dns/records_tests.rb
@@ -12,8 +12,8 @@ Shindo.tests('Fog::DNS[:rackspace] | dns records requests', ['rackspace', 'dns']
         Fog::DNS[:rackspace].list_records(@domain_id).body
       end
 
-      tests("add_records(#{@domain_id}, [{ :name => 'test1.#{domain_name}', :type => 'A', :data => '192.168.2.1'}])").formats(RECORD_LIST_FORMAT) do
-        response = wait_for Fog::DNS[:rackspace], Fog::DNS[:rackspace].add_records(@domain_id, [{ :name => 'test1.' + domain_name, :type => 'A', :data => '192.168.2.1'}])
+      tests("add_records(#{@domain_id}, [{ :name => 'test1.#{domain_name}', :type => 'A', :data => '192.168.2.1', :ttl => 550}])").formats(RECORD_LIST_FORMAT) do
+        response = wait_for Fog::DNS[:rackspace], Fog::DNS[:rackspace].add_records(@domain_id, [{ :name => 'test1.' + domain_name, :type => 'A', :data => '192.168.2.1', :ttl => 550}])
         @record_id = response.body['response']['records'].first['id']
         response.body['response']
       end


### PR DESCRIPTION
TTL value for DNS entries will no longer be ignored by Rackspace DNS model and request.
TTL is still optional.
