### PR TITLE
Fog is set to require multi_json 1.0, which does not have dump/load methods

### DIFF
--- a/lib/fog/core/json.rb
+++ b/lib/fog/core/json.rb
@@ -21,24 +21,12 @@ module Fog
     # Do the MultiJson introspection at this level so we can define our encode/decode methods and perform
     # the introspection only once rather than once per call.
 
-    if MultiJson.respond_to?(:dump)
-      def self.encode(obj)
-        MultiJson.encode(obj)
-      end
-    else
-      def self.encode(obj)
-        MultiJson.encode(obj)
-      end
+    def self.encode(obj)
+      MultiJson.encode(obj)
     end
 
-    if MultiJson.respond_to?(:load)
-      def self.decode(obj)
-        MultiJson.decode(obj)
-      end
-    else
-      def self.decode(obj)
-        MultiJson.decode(obj)
-      end
+    def self.decode(obj)
+      MultiJson.decode(obj)
     end
 
 


### PR DESCRIPTION
From ref https://github.com/intridea/multi_json/blob/v1.0.4/lib/multi_json.rb methods are later renamed and aliased from encode/decode to dump/load. If the gem restrictions are set loosely you must use the old method names.
