### PR TITLE
Bugfix for Storage::Rackspace::File#save with etag attribute

### DIFF
--- a/lib/fog/rackspace/models/storage/file.rb
+++ b/lib/fog/rackspace/models/storage/file.rb
@@ -124,7 +124,7 @@ module Fog
         end
 
         def metadata_attributes
-          if etag
+          if last_modified
             headers = connection.head_object(directory.key, self.key).headers
             headers.reject! {|k, v| !metadata_attribute?(k)}
           else

--- a/tests/rackspace/models/storage/file_tests.rb
+++ b/tests/rackspace/models/storage/file_tests.rb
@@ -26,6 +26,12 @@ Shindo.tests('Fog::Rackspace::Storage | file', ['rackspace']) do
     directories.
     create(directory_attributes)
 
+  model_tests(@directory.files, file_attributes.merge(:etag => 'foo'), Fog.mocking?) do
+    tests('#save should not blow up with etag') do
+      @instance.save
+    end
+  end
+
   model_tests(@directory.files, file_attributes, Fog.mocking?) do
 
     tests("#metadata should load empty metadata").returns({}) do


### PR DESCRIPTION
fixed bug where Fog::Storage::Rackspace::File raised Fog::Storage::Rackspace::NotFound if file was created with passed etag attribute. Changed to check existence based on `#last_modified` instead of `#etag`.

@geemus initially recommended that I use either one for pull request #1251. I opted for `#etag`, but this wasn't a good choice because the user may want to set that when creating a file to ensure that the entire file was received by the server. `#last_modified` should not be set by the user. 
