### PR TITLE
[openstack|image] Fixes #1383

### DIFF
--- a/lib/fog/openstack/requests/image/create_image.rb
+++ b/lib/fog/openstack/requests/image/create_image.rb
@@ -16,11 +16,13 @@ module Fog
             'x-image-meta-checksum' => attributes[:checksum],
             'x-image-meta-owner' => attributes[:owner],
             'x-glance-api-copy-from' => attributes[:copy_from]
-          }
+          }.reject { |k,v| v.nil? }
 
           body = String.new
           if attributes[:location]
             body = File.open(attributes[:location], "rb")
+            # Make sure the image file size is always present
+            data['x-image-meta-size'] = File.size(body)
           end
 
           unless attributes[:properties].nil?


### PR DESCRIPTION
ruby 1.8.7 compat fixes for OpenStack Image Service uploads.

Fixes #1383
