### PR TITLE
Issue/1350 [doc] added more options for aws/storage/file#save

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -112,6 +112,14 @@ module Fog
 
         # 
         # @param [Hash] options  
+        # @option options [String] acl sets x-amz-acl HTTP header. Valid values include, private | public-read | public-read-write | authenticated-read | bucket-owner-read | bucket-owner-full-control
+        # @option options [String] cache_controle sets Cache-Control header. For example, 'No-cache'
+        # @option options [String] content_disposition sets Content-Disposition HTTP header. For exampple, 'attachment; filename=testing.txt'
+        # @option options [String] content_encoding sets Content-Encoding HTTP header. For example, 'x-gzip'
+        # @option options [String] content_md5 sets Content-MD5. For example, '79054025255fb1a26e4bc422aef54eb4'
+        # @option options [String] content_type Content-Type. For example, 'text/plain'
+        # @option options [String] expires sets Expires HTTP header. For example, 'Thu, 01 Dec 1994 16:00:00 GMT'
+        # @option options [String] storage_class sets x-amz-storage-class HTTP header. Defaults to 'STANDARD'. Or, 'REDUCED_REDUNDANCY'
         # @option options [String] encryption sets HTTP encryption header. Set to 'AES256' to encrypt files at rest on S3
         # 
         def save(options = {})


### PR DESCRIPTION
merge https://github.com/fog/fog/pull/1394 before this PR.

This is an example // rough draft for how to doc technical details. This might help address goal to describe vendor/service specific details (see https://github.com/fog/fog/issues/1280). Specifically, @rupakg's  #_2 comment, 

> 2) Separate README per vendor including anything specific to the provider above and beyond base > doc.

Open to thoughts and opinions.
