### PR TITLE
[ecloud|compute] Fixes missing value

### DIFF
--- a/lib/fog/ecloud/models/compute/environment.rb
+++ b/lib/fog/ecloud/models/compute/environment.rb
@@ -24,7 +24,7 @@ module Fog
         end
 
         def backup_internet_services
-          @backup_internet_services ||= Fog::Compute::Ecloud::BackupInternetServices.new(:connection, :href => "/cloudapi/ecloud/backupInternetServices/environments/#{id}")
+          @backup_internet_services ||= Fog::Compute::Ecloud::BackupInternetServices.new(:connection => connection, :href => "/cloudapi/ecloud/backupInternetServices/environments/#{id}")
         end
 
         def networks


### PR DESCRIPTION
`:connection` key was not paired with a value. Initializer just accepts
options hash as I read it so assume this was an oversight.
