### PR TITLE
[openstack|image] Configurable :openstack_endpoint_type

### DIFF
--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -7,7 +7,7 @@ module Fog
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant
+                 :current_user, :current_tenant, :openstack_endpoint_type
 
       model_path 'fog/openstack/models/image'
 
@@ -111,6 +111,7 @@ module Fog
           @openstack_must_reauthenticate  = false
           @openstack_service_type         = options[:openstack_service_type] || ['image']
           @openstack_service_name         = options[:openstack_service_name]
+          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
 
           @connection_options = options[:connection_options] || {}
 
@@ -182,7 +183,7 @@ module Fog
               :openstack_auth_token => @openstack_auth_token,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => 'adminURL'
+              :openstack_endpoint_type => @openstack_endpoint_type 
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)


### PR DESCRIPTION
:openstack_endpoint_type is missing as a recognized parameter. This
patch fixes that, and allows the :openstack_endpoint_type to be
configurable instead of hardcoding the value to 'adminURL'

That is, you can create the connection to the service as follows now:

require 'fog'
conn = Fog::Image.new({
  :provider => 'OpenStack',
  :openstack_api_key => ENV['OS_PASSWORD'],
  :openstack_username => ENV["OS_USERNAME"],
  :openstack_auth_url => ENV["OS_AUTH_URL"]
  :openstack_tenant => ENV["OS_TENANT_NAME"],
  :openstack_endpoint_type => 'publicURL', #publicURL, adminURL, internalURL
})

Defaults to adminURL to maintain backwards compatibility.
