### PR TITLE
[docs] question about how to format AWS nested responses

### DIFF
--- a/lib/fog/aws/requests/storage/complete_multipart_upload.rb
+++ b/lib/fog/aws/requests/storage/complete_multipart_upload.rb
@@ -12,13 +12,12 @@ module Fog
         # @param [String] upload_id Id of upload to add part to
         # @param [Array<String>] parts Array of etags as Strings for parts
         #
-        # ==== Returns
-        # * response<~Excon::Response>:
-        #   * headers<~Hash>:
-        #     * 'Bucket'<~String> - bucket of new object
-        #     * 'ETag'<~String> - etag of new object (will be needed to complete upload)
-        #     * 'Key'<~String> - key of new object
-        #     * 'Location'<~String> - location of new object
+        # @return Excon::Response
+        #   * headers (Hash)
+        #     * Bucket (String) -- bucket of new object
+        #     * ETag (String) -- etag of new object (will be needed to complete upload)
+        #     * Key (String) -- key of new object
+        #     * Location (String) -- location of new object
         #
         # @see http://docs.amazonwebservices.com/AmazonS3/latest/API/mpUploadComplete.html
         #


### PR DESCRIPTION
Fog::AWS responses typically return HTTP header hashes (from what I can tell).   I didn't see a intuitive way to format a method's semi nested @return. This PR contains a rough draft documenting it. Is this the best way to format it?  

PLEASE DO NOT MERGE TO MASTER. 

This PR should be closed and I'll apply feedback to rest of Fog::AWS's methods.

To see formating,
`yard -n --single-db && yard server`
http://localhost:8808/docs/Fog/Storage/AWS/Real:complete_multipart_upload
