### PR TITLE
Make use of #persisted? method

### DIFF
--- a/lib/fog/aws/models/cdn/invalidation.rb
+++ b/lib/fog/aws/models/cdn/invalidation.rb
@@ -29,7 +29,7 @@ module Fog
 
         def save
           requires :paths, :caller_reference
-          raise "Submitted invalidation cannot be submitted again" if identity
+          raise "Submitted invalidation cannot be submitted again" if persisted?
           response = connection.post_invalidation(distribution.identity, paths, caller_reference)
           merge_attributes(invalidation_to_attributes(response.body))
           true

--- a/lib/fog/aws/models/compute/address.rb
+++ b/lib/fog/aws/models/compute/address.rb
@@ -39,7 +39,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           data = connection.allocate_address(domain).body
           new_attributes = data.reject {|key,value| key == 'requestId'}
           merge_attributes(new_attributes)

--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -130,7 +130,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :image_id
 
           options = {
@@ -224,7 +224,7 @@ module Fog
         #but in #save a merge_attribute is called after run_instance
         #thus making an un-necessary request. Use this until finding a clever solution
         def monitor=(new_monitor)
-          if identity
+          if persisted?
             case new_monitor
             when true
               response = connection.monitor_instances(identity)

--- a/lib/fog/aws/models/compute/snapshot.rb
+++ b/lib/fog/aws/models/compute/snapshot.rb
@@ -29,7 +29,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :volume_id
 
           data = connection.create_snapshot(volume_id, description).body

--- a/lib/fog/aws/models/compute/volume.rb
+++ b/lib/fog/aws/models/compute/volume.rb
@@ -39,7 +39,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :availability_zone
           requires_one :size, :snapshot_id
 

--- a/lib/fog/bluebox/models/compute/server.rb
+++ b/lib/fog/bluebox/models/compute/server.rb
@@ -71,11 +71,11 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :flavor_id, :image_id, :location_id
           options = {}
 
-          if identity.nil?  # new record
+          unless persisted?  # new record
             raise(ArgumentError, "password or public_key is required for this operation") if !password && !public_key
             options['ssh_public_key'] = public_key if public_key
             options['password'] = password if @password

--- a/lib/fog/brightbox/models/compute/api_client.rb
+++ b/lib/fog/brightbox/models/compute/api_client.rb
@@ -10,7 +10,7 @@ module Fog
         attribute :account_id
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           options = {
             :name => name,
             :description => description

--- a/lib/fog/brightbox/models/compute/application.rb
+++ b/lib/fog/brightbox/models/compute/application.rb
@@ -12,7 +12,7 @@ module Fog
         attribute :secret
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           options = {
             :name => name
           }.delete_if {|k,v| v.nil? || v == "" }

--- a/lib/fog/brightbox/models/compute/firewall_policy.rb
+++ b/lib/fog/brightbox/models/compute/firewall_policy.rb
@@ -21,7 +21,7 @@ module Fog
 
         # Sticking with existing Fog behaviour, save does not update but creates a new resource
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           options = {
             :server_group => server_group_id,
             :name => name,

--- a/lib/fog/brightbox/models/compute/firewall_rule.rb
+++ b/lib/fog/brightbox/models/compute/firewall_rule.rb
@@ -24,7 +24,7 @@ module Fog
 
         # Sticking with existing Fog behaviour, save does not update but creates a new resource
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :firewall_policy_id
           options = {
             :firewall_policy => firewall_policy_id,

--- a/lib/fog/brightbox/models/compute/image.rb
+++ b/lib/fog/brightbox/models/compute/image.rb
@@ -39,7 +39,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :source, :arch
           options = {
             :source => source,

--- a/lib/fog/brightbox/models/compute/load_balancer.rb
+++ b/lib/fog/brightbox/models/compute/load_balancer.rb
@@ -32,7 +32,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :nodes, :listeners, :healthcheck
           options = {
             :nodes => nodes,

--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -156,7 +156,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :image_id
           options = {
             :image => image_id,
@@ -190,7 +190,7 @@ module Fog
           # FIXME Using side effect of wait_for's (evaluated block) to detect timeouts
           begin
             wait_for(20) { ! ready? }
-            start            
+            start
           rescue Fog::Errors::Timeout => e
             false
           end

--- a/lib/fog/clodo/models/compute/server.rb
+++ b/lib/fog/clodo/models/compute/server.rb
@@ -88,7 +88,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :image_id
           data = connection.create_server(image_id, attributes)
           merge_attributes(data.body['server'])

--- a/lib/fog/go_grid/models/compute/image.rb
+++ b/lib/fog/go_grid/models/compute/image.rb
@@ -45,7 +45,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :server_id
 
           data = connection.grid_server_add(server_id, 'name' => name)

--- a/lib/fog/go_grid/models/compute/password.rb
+++ b/lib/fog/go_grid/models/compute/password.rb
@@ -35,7 +35,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :password_id
           data = connection.support_password_list()
           merge_attributes(data.body)

--- a/lib/fog/go_grid/models/compute/server.rb
+++ b/lib/fog/go_grid/models/compute/server.rb
@@ -58,7 +58,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :name, :image_id, :memory, :public_ip_address
           options = {
             'isSandbox'   => sandbox,

--- a/lib/fog/hp/models/compute/address.rb
+++ b/lib/fog/hp/models/compute/address.rb
@@ -34,7 +34,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           data = connection.allocate_address.body['floating_ip']
           new_attributes = data.reject {|key,value| !['id', 'instance_id', 'ip', 'fixed_ip'].include?(key)}
           merge_attributes(new_attributes)

--- a/lib/fog/hp/models/compute/server.rb
+++ b/lib/fog/hp/models/compute/server.rb
@@ -161,7 +161,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :flavor_id, :image_id, :name
           options = {
             'metadata'    => metadata,

--- a/lib/fog/ibm/models/storage/volume.rb
+++ b/lib/fog/ibm/models/storage/volume.rb
@@ -81,7 +81,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :name, :offering_id, :format, :location_id, :size
           data = connection.create_volume(name, offering_id, format, location_id, size)
           merge_attributes(data.body)

--- a/lib/fog/linode/models/compute/disk.rb
+++ b/lib/fog/linode/models/compute/disk.rb
@@ -10,7 +10,7 @@ module Fog
 
         def save
           requires :server
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           @type, @image, @stack_script, @name, @password, @size =
             attributes.values_at :type, :image, :stack_script, :name, :password, :size
           create_disk

--- a/lib/fog/linode/models/compute/ip.rb
+++ b/lib/fog/linode/models/compute/ip.rb
@@ -10,7 +10,7 @@ module Fog
 
         def save
           requires :server
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           
           connection.linode_ip_addprivate server.id
           server.ips.all.find { |ip| !ip.public }

--- a/lib/fog/linode/models/compute/server.rb
+++ b/lib/fog/linode/models/compute/server.rb
@@ -43,7 +43,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           @data_center, @flavor, @image, @kernel, @type, @payment_terms, @stack_script, @name, @password, @callback =
             attributes.values_at :data_center, :flavor, :image, :kernel, :type, :payment_terms, :stack_script, :name, :password, :callback
 

--- a/lib/fog/openstack/models/compute/address.rb
+++ b/lib/fog/openstack/models/compute/address.rb
@@ -34,7 +34,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           data = connection.allocate_address(pool).body['floating_ip']
           new_attributes = data.reject {|key,value| !['id', 'instance_id', 'ip', 'fixed_ip'].include?(key)}
           merge_attributes(new_attributes)

--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -226,7 +226,7 @@ module Fog
 
         # TODO: Implement /os-volumes-boot support with 'block_device_mapping'
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :flavor_ref, :image_ref, :name
           meta_hash = {}
           metadata.each { |meta| meta_hash.store(meta.key, meta.value) }

--- a/lib/fog/openstack/models/identity/user.rb
+++ b/lib/fog/openstack/models/identity/user.rb
@@ -25,7 +25,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :name, :tenant_id, :password
           enabled = true if enabled.nil?
           data = connection.create_user(name, password, email, tenant_id, enabled)

--- a/lib/fog/ovirt/models/compute/server.rb
+++ b/lib/fog/ovirt/models/compute/server.rb
@@ -116,7 +116,7 @@ module Fog
         end
 
         def save
-          if identity
+          if persisted?
             connection.update_vm(attributes)
           else
             self.id = connection.create_vm(attributes).id

--- a/lib/fog/ovirt/models/compute/template.rb
+++ b/lib/fog/ovirt/models/compute/template.rb
@@ -45,7 +45,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           connection.client.create_template(attributes)
         end
 

--- a/lib/fog/rackspace/models/block_storage/snapshot.rb
+++ b/lib/fog/rackspace/models/block_storage/snapshot.rb
@@ -26,7 +26,7 @@ module Fog
 
         def save(force = false)
           requires :volume_id
-          raise IdentifierTaken.new('Resaving may cause a duplicate snapshot to be created') if identity
+          raise IdentifierTaken.new('Resaving may cause a duplicate snapshot to be created') if persisted?
           data = connection.create_snapshot(volume_id, {
             :display_name => display_name,
             :display_description => display_description,

--- a/lib/fog/rackspace/models/block_storage/volume.rb
+++ b/lib/fog/rackspace/models/block_storage/volume.rb
@@ -42,7 +42,7 @@ module Fog
 
         def save
           requires :size
-          raise IdentifierTaken.new('Resaving may cause a duplicate volume to be created') if identity
+          raise IdentifierTaken.new('Resaving may cause a duplicate volume to be created') if persisted?
           data = connection.create_volume(size, {
             :display_name => display_name,
             :display_description => display_description,

--- a/lib/fog/rackspace/models/compute/image.rb
+++ b/lib/fog/rackspace/models/compute/image.rb
@@ -33,7 +33,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :server_id
 
           data = connection.create_image(server_id, 'name' => name)

--- a/lib/fog/rackspace/models/compute/server.rb
+++ b/lib/fog/rackspace/models/compute/server.rb
@@ -66,7 +66,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :flavor_id, :image_id
           options = {
             'metadata'    => metadata,

--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -45,7 +45,7 @@ module Fog
         attr_reader :password
 
         def save
-          if identity
+          if persisted?
             update
           else
             create

--- a/lib/fog/rackspace/models/dns/record.rb
+++ b/lib/fog/rackspace/models/dns/record.rb
@@ -33,7 +33,7 @@ module Fog
         end
 
         def save
-          if identity
+          if persisted?
             update
           else
             create

--- a/lib/fog/rackspace/models/dns/zone.rb
+++ b/lib/fog/rackspace/models/dns/zone.rb
@@ -35,7 +35,7 @@ module Fog
         end
 
         def save
-          if identity
+          if persisted?
             update
           else
             create

--- a/lib/fog/rackspace/models/identity/user.rb
+++ b/lib/fog/rackspace/models/identity/user.rb
@@ -15,7 +15,7 @@ module Fog
 
         def save
           requires :username, :email, :enabled
-          if identity.nil?
+          unless persisted?
             data = connection.create_user(username, email, enabled, :password => password)
           else
             data = connection.update_user(identity, username, email, enabled, :password => password)

--- a/lib/fog/rackspace/models/load_balancers/access_rule.rb
+++ b/lib/fog/rackspace/models/load_balancers/access_rule.rb
@@ -17,7 +17,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :load_balancer, :address, :type
           connection.create_access_rule(load_balancer.id, address, type)
 

--- a/lib/fog/rackspace/models/load_balancers/load_balancer.rb
+++ b/lib/fog/rackspace/models/load_balancers/load_balancer.rb
@@ -164,7 +164,7 @@ module Fog
         end
 
         def save
-          if identity
+          if persisted?
             update
           else
             create

--- a/lib/fog/rackspace/models/load_balancers/node.rb
+++ b/lib/fog/rackspace/models/load_balancers/node.rb
@@ -20,7 +20,7 @@ module Fog
         end
 
         def save
-          if identity
+          if persisted?
             update
           else
             create

--- a/lib/fog/rackspace/models/load_balancers/virtual_ip.rb
+++ b/lib/fog/rackspace/models/load_balancers/virtual_ip.rb
@@ -18,7 +18,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :load_balancer, :type
           data = connection.create_virtual_ip(load_balancer.id, type)
           merge_attributes(data.body)

--- a/lib/fog/voxel/models/compute/server.rb
+++ b/lib/fog/voxel/models/compute/server.rb
@@ -54,7 +54,7 @@ module Fog
         end
 
         def save
-          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if identity
+          raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :name, :image_id, :processing_cores, :facility, :disk_size
 
           data = connection.voxcloud_create({

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -165,7 +165,7 @@ module Fog
 
         def save
           requires :name, :cluster, :datacenter
-          if identity
+          if persisted?
             raise "update is not supported yet"
            # connection.update_vm(attributes)
           else

--- a/lib/fog/zerigo/models/dns/record.rb
+++ b/lib/fog/zerigo/models/dns/record.rb
@@ -45,7 +45,7 @@ module Fog
           options[:priority]  = priority if priority
           options[:ttl]       = ttl if ttl
 
-          if identity
+          if persisted?
             options[:host_type] = type
             options[:data]      = value
             connection.update_host(identity, options)


### PR DESCRIPTION
In many places we were checking for identity which was the shorthand for
checking if the resource had been saved by the service.

The #persisted? method was added to show a clearer intent and also offer
minimal ActiveModel interface
