### PR TITLE
[Brightbox] Adds #dns_name to server

### DIFF
--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -129,6 +129,14 @@ module Fog
           connection.images.get(image_id)
         end
 
+        # Returns the public DNS name of the server
+        #
+        # @return [String]
+        #
+        def dns_name
+          ["public", fqdn].join(".")
+        end
+
         def private_ip_address
           unless interfaces.empty?
             interfaces.first["ipv4_address"]

--- a/tests/brightbox/models/compute/server_tests.rb
+++ b/tests/brightbox/models/compute/server_tests.rb
@@ -1,0 +1,21 @@
+Shindo.tests("Fog::Compute[:brightbox] | Server model", ["brightbox"]) do
+
+  pending if Fog.mocking?
+
+  tests("success") do
+
+    unless Fog.mocking?
+      @server = Brightbox::Compute::TestSupport.get_test_server
+      server_id = @server.id
+    end
+
+    tests("#dns_name") do
+      pending if Fog.mocking?
+      returns("public.#{@server.fqdn}") { @server.dns_name }
+    end
+
+    unless Fog.mocking?
+      @server.destroy
+    end
+  end
+end


### PR DESCRIPTION
Little known fact is that the public version of the domain name of a
Brightbox cloud server is the `fqdn` prefixed with public.

This is now fixed here until it is fixed in the main API and the value
can be referenced directly from the response.
