### PR TITLE
use CGI.escapeHTML instead of CGI.escape

### DIFF
--- a/lib/fog/aws/requests/storage/delete_multiple_objects.rb
+++ b/lib/fog/aws/requests/storage/delete_multiple_objects.rb
@@ -42,10 +42,10 @@ module Fog
           version_ids = options.delete('versionId')
           object_names.each do |object_name|
             data << "<Object>"
-            data << "<Key>#{CGI.escape(object_name)}</Key>"
+            data << "<Key>#{CGI.escapeHTML(object_name)}</Key>"
             object_version = version_ids.nil? ? nil : version_ids[object_name]
             if object_version
-              data << "<VersionId>#{CGI.escape(object_version)}</VersionId>"
+              data << "<VersionId>#{CGI.escapeHTML(object_version)}</VersionId>"
             end
             data << "</Object>"
           end


### PR DESCRIPTION
CGI.escape creates URL-safe encodings, but we need XML-safe encodings.
If the key name has a "/" in it (as for a directory structure) it gets
replaced with a URL-safe "%2F" which S3 treats as a literal part of the
key name. We only need to escape the parts of the key that could result
in malformed XML.
