### PR TITLE
Properly return all alarms

### DIFF
--- a/lib/fog/aws/models/cloud_watch/alarms.rb
+++ b/lib/fog/aws/models/cloud_watch/alarms.rb
@@ -12,9 +12,9 @@ module Fog
           data = []
           next_token = nil
           loop do
-            result = service.describe_alarms('NextToken' => next_token).body['DescribeAlarmsResult']
-            data += result['MetricAlarms']
-            next_token = result['NextToken']
+            body = service.describe_alarms('NextToken' => next_token).body
+            data += body['DescribeAlarmsResult']['MetricAlarms']
+            next_token = body['ResponseMetadata']['NextToken']
             break if next_token.nil?
           end
           load(data)


### PR DESCRIPTION
The alarms model was not properly checking for NextToken and was therefore only returning the first 50 alarms. This change fixes that.
