### PR TITLE
[AWS|DynamoDB] Default to HTTPS

### DIFF
--- a/lib/fog/aws/dynamodb.rb
+++ b/lib/fog/aws/dynamodb.rb
@@ -86,7 +86,7 @@ module Fog
           @path       = options[:path]        || '/'
           @persistent = options[:persistent]  || false
           @port       = options[:port]        || '80' #443
-          @scheme     = options[:scheme]      || 'http' #'https'
+          @scheme     = options[:scheme]      || 'https'
 
           @connection = Fog::Connection.new("#{@scheme}://#{@host}:#{@port}#{@path}", @persistent, @connection_options)
         end


### PR DESCRIPTION
I'm not sure if there was a reason that this wasn't defaulting to HTTPS, but figured it should.
