### PR TITLE
[Rackspace|Compute] updated server.create_image to return Image Object

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -113,7 +113,12 @@ module Fog
         def create_image(name, options = {})
           requires :identity
           response = service.create_image(identity, name, options)
-          response.headers["Location"].match(/\/([^\/]+$)/)[1] rescue nil
+          begin 
+            image_id = response.headers["Location"].match(/\/([^\/]+$)/)[1]
+            Fog::Compute::RackspaceV2::Image.new(:collection => service.images, :service => service, :id => image_id)
+          rescue
+            nil
+          end
         end
 
         def attachments

--- a/lib/fog/rackspace/requests/compute_v2/create_image.rb
+++ b/lib/fog/rackspace/requests/compute_v2/create_image.rb
@@ -72,7 +72,7 @@ module Fog
             "minRam"   => 256,
             "name"     => "Ubuntu 11.10",
             "progress" => 100,
-            "status"   => "ACTIVE",
+            "status"   => "SAVING",
             "updated"  => "2012-02-28T19:39:05Z"
           }
 

--- a/tests/rackspace/models/compute_v2/image_tests.rb
+++ b/tests/rackspace/models/compute_v2/image_tests.rb
@@ -15,8 +15,7 @@ Shindo.tests('Fog::Compute::RackspaceV2 | image', ['rackspace']) do
     begin
       server = service.servers.create(options)
       server.wait_for { ready? }
-      image_id = server.create_image("fog_image_#{test_time}")
-      image = service.images.get(image_id)
+      image = server.create_image("fog_image_#{test_time}")
 
       tests("destroy").succeeds do
         image.destroy

--- a/tests/rackspace/models/compute_v2/server_tests.rb
+++ b/tests/rackspace/models/compute_v2/server_tests.rb
@@ -23,6 +23,18 @@ Shindo.tests('Fog::Compute::RackspaceV2 | server', ['rackspace']) do
       @instance.reboot('HARD')
       returns('HARD_REBOOT') { @instance.state }
     end
+    
+    @instance.wait_for(timeout=1500)  { ready? }
+    @test_image = nil
+    begin
+      tests('#create_image').succeeds do
+        @test_image = @instance.create_image('fog-test-image')
+        @test_image.reload
+        returns('SAVING') { @test_image.state }
+      end
+    ensure
+      @test_image.destroy unless @test_image.nil? || Fog.mocking?
+    end
 
     @instance.wait_for(timeout=1500)  { ready? }
     tests('#rebuild').succeeds do


### PR DESCRIPTION
Updated create_image method on Fog::Compute::RackspaceV2::Server to return Image object instead of the object id.

The current Fog release does not contain this method and I wanted to make this change before a release was cut.
