### PR TITLE
[rackspace] updated Rackspace to return a list of all services

### DIFF
--- a/lib/fog/bin/rackspace.rb
+++ b/lib/fog/bin/rackspace.rb
@@ -45,6 +45,13 @@ class Rackspace < Fog::Bin
         when :storage
           Fog::Logger.warning("Rackspace[:storage] is not recommended, use Storage[:rackspace] for portability")
           Fog::Storage.new(:provider => 'Rackspace')
+        when :identity
+          Fog::Logger.warning("Rackspace[:identity] is not recommended, use Identity[:rackspace] for portability")
+          Fog::Identity.new(:provider => 'Rackspace')
+        when :databases
+          Fog::Rackspace::Databases.new
+        when :block_storage
+          Fog::Rackspace::BlockStorage.new
         else
           raise ArgumentError, "Unrecognized service: #{key.inspect}"
         end

--- a/lib/fog/identity.rb
+++ b/lib/fog/identity.rb
@@ -8,6 +8,9 @@ module Fog
     def self.new(attributes)
       attributes = attributes.dup # Prevent delete from having side effects
       case provider = attributes.delete(:provider).to_s.downcase.to_sym
+      when :rackspace
+        require 'fog/rackspace/identity'
+        Fog::Rackspace::Identity.new(attributes)
       when :openstack
         require 'fog/openstack/identity'
         Fog::Identity::OpenStack.new(attributes)

--- a/lib/fog/rackspace/requests/load_balancers/set_ssl_termination.rb
+++ b/lib/fog/rackspace/requests/load_balancers/set_ssl_termination.rb
@@ -4,9 +4,9 @@ module Fog
       class Real
         def set_ssl_termination(load_balancer_id, securePort, privatekey, certificate, options = {})
           data = {
-            securePort: securePort,
-            privatekey: privatekey,
-            certificate: certificate
+            :securePort => securePort,
+            :privatekey => privatekey,
+            :certificate => certificate
           }
 
           if options.has_key? :intermediate_certificate


### PR DESCRIPTION
The Rackspace class did not return all service classes thus throwing errors when attempting to execute Rackspace.collection.
