### PR TITLE
[rackspace|compute] Fix bug in bootstrap method

### DIFF
--- a/lib/fog/core/scp.rb
+++ b/lib/fog/core/scp.rb
@@ -52,6 +52,7 @@ module Fog
           raise ArgumentError.new(':key_data, :keys, :password or a loaded ssh-agent is required to initialize SSH')
         end
 
+        options[:timeout] = 30
         if options[:key_data] || options[:keys]
           options[:keys_only] = true
           #Explicitly set these so net-ssh doesn't add the default keys

--- a/lib/fog/core/ssh.rb
+++ b/lib/fog/core/ssh.rb
@@ -46,6 +46,7 @@ module Fog
           raise ArgumentError.new(':key_data, :keys, :password or a loaded ssh-agent is required to initialize SSH')
         end
 
+        options[:timeout] = 30
         if options[:key_data] || options[:keys]
           options[:keys_only] = true
           #Explicitly set these so net-ssh doesn't add the default keys

--- a/lib/fog/rackspace/models/compute_v2/servers.rb
+++ b/lib/fog/rackspace/models/compute_v2/servers.rb
@@ -31,7 +31,7 @@ module Fog
         #        
         def bootstrap(new_attributes = {})
           server = create(new_attributes)
-          server.wait_for(1500) { ready? && !ipv4_address.empty? }
+          server.wait_for(1500) { ready? && !public_ip_address.empty? }
           server.setup(:password => server.password)
           server
         end


### PR DESCRIPTION
 fixed issue with bootstrap method where server was ready, but it had not received an ipv4 address yet. Added check for ip address in server ready block as well as a timeout parameter
