### PR TITLE
[vsphere] fixed an issue introduced in commit e8630a0 where @service is nil

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
+++ b/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
@@ -12,7 +12,7 @@ module Fog
           vm = case id
                  # UUID based
                  when /[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}/
-                   @service.searchIndex.FindByUuid :uuid => id, :vmSearch => true, :instanceUuid => true, :datacenter => dc
+                   @connection.searchIndex.FindByUuid :uuid => id, :vmSearch => true, :instanceUuid => true, :datacenter => dc
                  else
                    # try to find based on VM name
                    if dc


### PR DESCRIPTION
There appears to have been a bug that made its way in that causes this error when attempting to find a VM by UUID. This change I submitted reverts the specific line to before commit SHA: e8630a00831cc17d61d48af9501773002dccc165 .

NoMethodError: undefined method `searchIndex' for nil:NilClass
    from /Users/mblack/.rvm/gems/ruby-1.9.3-p125/gems/fog-1.8.0/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:15:in`get_vm_ref'
    from /Users/mblack/.rvm/gems/ruby-1.9.3-p125/gems/fog-1.8.0/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:6:in `get_virtual_machine'
    from (irb):5
