### PR TITLE
[vsphere] searching for VM improved to search whole cluster instead of current folder.

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
+++ b/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
@@ -3,6 +3,7 @@ module Fog
     class Vsphere
       class Real
         def get_virtual_machine(id, datacenter_name = nil)
+          # The larger the VM list the longer it will take if not searching based on UUID.
           convert_vm_mob_ref_to_attr_hash(get_vm_ref(id, datacenter_name))
         end
 
@@ -16,12 +17,16 @@ module Fog
                  else
                    # try to find based on VM name
                    if dc
-                     get_raw_datacenter(dc).find_vm(id)
+                     get_vm_by_name(id, dc)
                    else
-                     raw_datacenters.map { |d| d.find_vm(id) }.compact.first
+                     raw_datacenters.map { |d| get_vm_by_name(id, d["name"])}.compact.first
                    end
                end
           vm ? vm : raise(Fog::Compute::Vsphere::NotFound, "#{id} was not found")
+        end
+        def get_vm_by_name(name, dc)
+          vms = raw_list_all_virtual_machines(dc)
+          vms.keep_if { |v| v["name"] == name }.first
         end
       end
 

--- a/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
+++ b/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
@@ -17,6 +17,7 @@ module Fog
           end
         end
 
+
         private
 
         def list_all_virtual_machines_in_folder(path, datacenter_name)
@@ -26,23 +27,26 @@ module Fog
         end
 
         def list_all_virtual_machines(options = { })
-          datacenters = find_datacenters(options[:datacenter])
-
-          vms = datacenters.map do |dc|
-            @connection.serviceContent.viewManager.CreateContainerView({
-              :container  => dc.vmFolder,
-              :type       =>  ["VirtualMachine"],
-              :recursive  => true
-            }).view
-          end.flatten
-          # remove all template based virtual machines
+          vms = raw_list_all_virtual_machines(options[:datacenter])
           vms.delete_if { |v| v.config.template }
 
           vms.map do |vm_mob|
             convert_vm_mob_ref_to_attr_hash(vm_mob)
           end
         end
-
+        def raw_list_all_virtual_machines(datacenter_name = nil)
+          ## Moved this to its own function since trying to get a list of all virtual machines
+          ## to parse for a find function took way too long. The raw list returned will make it
+          ## much faster to interact for some functions.
+          datacenters = find_datacenters(datacenter_name)
+          datacenters.map do |dc|
+            @connection.serviceContent.viewManager.CreateContainerView({
+                                                                           :container  => dc.vmFolder,
+                                                                           :type       =>  ["VirtualMachine"],
+                                                                           :recursive  => true
+                                                                       }).view
+          end.flatten
+        end
         def get_folder_path(folder, root = nil)
           if (not folder.methods.include?('parent')) or (folder == root)
             return


### PR DESCRIPTION
Sorry for the duplicate, the other one closed when I was trying to rebase an update to the pull request.

The current search options will either only find based on UUID or by VM name. The issue with the VM name is it will only check the top level folder instead of the whole datacenter which means if you use folders for organization the VM will never be found unless at top level. I also moved some functionality to a new function so other functions can take advantage of it without having to duplicate code. Like if I want to just verify that a VM exists and a method can be created to call and verify that a VM was returned as oppose to going through the hash build.

The only caveat is the get_virtual_machine will take a while depending on how many VMs are returned because the attribute of the name appears to not be included as part of the view created and accessing that property looks like it makes another call which slows down the entire process.

raw_list_all_virtual_machines method was created and list_all_virtual_machines calls it so methods like the get_vm_by_name do not have to wait for the hash build from list_all_virtual_machines because the hash build is very slow depending on the VMs returned. An example would be, in my environment we have 600 VMs and just searching for a name takes about ~30 seconds, to build the hash takes about ~4 minutes.
