### PR TITLE
Added some task descriptions so they show up with 'rake -T'

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -141,6 +141,7 @@ task :build => :gemspec do
   sh "gem build #{gemspec_file}"
   sh "mv #{gem_file} pkg"
 end
+task :gem => :build
 
 desc "Updates the gemspec and runs 'validate'"
 task :gemspec => :validate do


### PR DESCRIPTION
I guess it does no harm to have some additional task descriptions
and help our memory.

Before:

```
rake changelog  # Update the changelog since the last release
rake console    # Open an irb session preloaded with this library
rake test       # Run the mocked tests
rake yard       # Generate YARD Documentation
```

Now:

```
rake build      # Build fog-1.8.0.gem
rake changelog  # Update the changelog since the last release
rake console    # Open an irb session preloaded with this library
rake gemspec    # Updates the gemspec and runs 'validate'
rake test       # Run the mocked tests
rake validate   # Run before pushing out the code
rake yard       # Generate YARD Documentation
```

Didn't want to describe all since some of them look potentially
unsafe for non core devs. I can document them otherwise.
