### PR TITLE
Introduce Fog::AWS.compliant_bucket_names reader.

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -28,6 +28,10 @@ module Fog
     service(:sts,             'aws/sts',              'STS')
     service(:storage,         'aws/storage',          'Storage')
 
+    def self.compliant_bucket_names
+      COMPLIANT_BUCKET_NAMES
+    end
+
     def self.indexed_param(key, values)
       params = {}
       unless key.include?('%d')


### PR DESCRIPTION
Attempts to access Fog::AWS::COMPLIANT_BUCKET_NAMES from
outside fog (e.g. carrierwave) result in uninialized constant error.

Impetus for this change is that carrierwave defines slightly different regex
(https://github.com/jnicklas/carrierwave/blob/master/lib/carrierwave/storage/fog.rb#L293)
to determine whether to use path or subdomain style bucket access and
it seems better to re-use this constant from fog. However attempts
to access the COMPLIANT_BUCKET_NAMES constant via ::Fog::AWS::COMPLIANT_BUCKET_NAMES fail.

Am I missing something or does this change make sense?
