### PR TITLE
[glesys] Add description to server model

### DIFF
--- a/lib/fog/glesys/models/compute/server.rb
+++ b/lib/fog/glesys/models/compute/server.rb
@@ -25,6 +25,7 @@ module Fog
         attribute :iplist
         attribute :ipversion
         attribute :ip
+        attribute :description
 
         def ready?
           state == 'running'


### PR DESCRIPTION
On Glesys it is possible to add a description to servers. Make that description available through fog.
