### PR TITLE
[openstack|volume] Configurable :openstack_endpoint_type

### DIFF
--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -187,7 +187,7 @@ module Fog
               :openstack_auth_token => @openstack_auth_token,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type,
+              :openstack_endpoint_type => @openstack_endpoint_type
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)


### PR DESCRIPTION
:openstack_endpoint_type is missing as a recognized parameter. This
patch fixes that, and allows the :openstack_endpoint_type to be
configurable instead of hardcoding the value to 'adminURL'

That is, you can create the connection to the service as follows:

require 'fog'

conn = Fog::Volume.new({
  :provider => 'OpenStack',
  :openstack_api_key => ENV['OS_PASSWORD'],
  :openstack_username => ENV["OS_USERNAME"],
  :openstack_auth_url => ENV["OS_AUTH_URL"]
  :openstack_tenant => ENV["OS_TENANT_NAME"],
  :openstack_endpoint_type => 'publicURL', # publicURL, adminURL, etc
})

Defaults to adminURL to maintain backwards compatibility.
