### PR TITLE
[openstack|identity] Configurable :openstack_endpoint_type

### DIFF
--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -8,7 +8,8 @@ module Fog
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_current_user_id,
-                 :current_user, :current_tenant
+                 :current_user, :current_tenant,
+                 :openstack_endpoint_type
 
       model_path 'fog/openstack/models/identity'
       model       :tenant
@@ -192,6 +193,8 @@ module Fog
           @connection_options = options[:connection_options] || {}
 
           @openstack_current_user_id = options[:openstack_current_user_id]
+          
+          @openstack_endpoint_type = options[:openstack_endpoint_type] || 'adminURL'
 
           @current_user = options[:current_user]
           @current_tenant = options[:current_tenant]
@@ -263,7 +266,7 @@ module Fog
               :openstack_tenant   => @openstack_tenant,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => 'adminURL'
+              :openstack_endpoint_type => @openstack_endpoint_type
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)


### PR DESCRIPTION
:openstack_endpoint_type is missing as a recognized parameter. This
patch fixes that, and allows the :openstack_endpoint_type to be
configurable instead of hardcoding the value to 'adminURL'

That is, you can create the connection to the service as follows:

require 'fog'

conn = Fog::Identity.new({
:provider => 'OpenStack',
:openstack_api_key => ENV['OS_PASSWORD'],
:openstack_username => ENV["OS_USERNAME"],
:openstack_auth_url => ENV["OS_AUTH_URL"]
:openstack_tenant => ENV["OS_TENANT_NAME"],
:openstack_endpoint_type => 'publicURL', # publicURL, adminURL, etc
})

Defaults to adminURL to maintain backwards compatibility.
