### PR TITLE
OpenStack: update used limits tests.

### DIFF
--- a/lib/fog/openstack/requests/compute/get_limits.rb
+++ b/lib/fog/openstack/requests/compute/get_limits.rb
@@ -73,7 +73,7 @@ module Fog
             'totalRAMUsed'             => -2048,
             'totalInstancesUsed'       => -1,
             'totalSecurityGroupsUsed'  => 0,
-            'totalKeyPairsUsed'        => 0
+            'totalFloatingIpsUsed'     => 0
           }
 
 

--- a/tests/openstack/requests/compute/limit_tests.rb
+++ b/tests/openstack/requests/compute/limit_tests.rb
@@ -29,7 +29,7 @@ Shindo.tests('Fog::Compute[:openstack] | limits requests', ['openstack']) do
     'totalRAMUsed'              => Fixnum,
     'totalInstancesUsed'        => Fixnum,
     'totalSecurityGroupsUsed'   => Fixnum,
-    'totalKeyPairsUsed'         => Fixnum
+    'totalFloatingIpsUsed'      => Fixnum
   }
 
   @limits_format = {


### PR DESCRIPTION
Updates the get_limits request Mock and test so that it includes the
new totalFloatingIpsUsed limit.

Also, drops the totalKeyPairsUsed limit since it is no longer used
since https://bugs.launchpad.net/nova/+bug/1089877.
