### PR TITLE
[glesys] Ability to pass in options to server details

### DIFF
--- a/lib/fog/glesys/requests/compute/server_details.rb
+++ b/lib/fog/glesys/requests/compute/server_details.rb
@@ -3,8 +3,8 @@ module Fog
     class Glesys
       class Real
 
-        def server_details(serverid)
-          request("/server/details", { :serverid => serverid })
+        def server_details(serverid, options = {})
+          request("/server/details", { :serverid => serverid }.merge!(options) )
         end
       end
 


### PR DESCRIPTION
This gives us the option include the :includestate option in the
request. And when this option is set to true we will get the status of
the server.
