### PR TITLE
Pass the management URL also

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -405,7 +405,7 @@ module Fog
           @scheme = uri.scheme
            
           # Not all implementations have identity service in the catalog
-          if @openstack_identity_public_endpoint
+          if @openstack_identity_public_endpoint || @openstack_management_url
             @identity_connection = Fog::Connection.new(
               @openstack_identity_public_endpoint || @openstack_management_url,
               false, @connection_options)


### PR DESCRIPTION
When an implementation of Openstack does not have a public endpoint, the management URL needs to be passed.
