### PR TITLE
[openstack|compute] fix get_metadata call

### DIFF
--- a/lib/fog/openstack/models/compute/metadata.rb
+++ b/lib/fog/openstack/models/compute/metadata.rb
@@ -24,7 +24,7 @@ module Fog
 
         def get(key)
           requires :parent
-          data = service.get_meta(collection_name, @parent.id, key).body["meta"]
+          data = service.get_metadata(collection_name, @parent.id, key).body["meta"]
           metas = []
           data.each_pair {|k,v| metas << {"key" => k, "value" => v} }
           new(metas[0])


### PR DESCRIPTION
`get_meta` isn't a method. `get_metadata` is :)
