### PR TITLE
[openstack|compute] rename meta_hash to to_hash; make it public

### DIFF
--- a/lib/fog/openstack/models/compute/metadata.rb
+++ b/lib/fog/openstack/models/compute/metadata.rb
@@ -34,12 +34,12 @@ module Fog
 
         def update(data=nil)
           requires :parent
-          service.update_metadata(collection_name, @parent.id, meta_hash(data))
+          service.update_metadata(collection_name, @parent.id, to_hash(data))
         end
 
         def set(data=nil)
           requires :parent
-          service.set_metadata(collection_name, @parent.id, meta_hash(data))
+          service.set_metadata(collection_name, @parent.id, to_hash(data))
         end
 
         def new(attributes = {})
@@ -47,8 +47,7 @@ module Fog
           super({ :parent => @parent }.merge!(attributes))
         end
 
-        private
-        def meta_hash(data=nil)
+        def to_hash(data=nil)
           if data.nil?
             data={}
             self.each do |meta|


### PR DESCRIPTION
OpenStack's metadata class has a private `meta_hash` method. OpenStack metadata can be represented by a hash, and it'd be super rad to be able to do so.

This commit changes that method to be called `to_hash` and makes it a public method.
