### PR TITLE
[glesys] Consistent naming of attributes

### DIFF
--- a/lib/fog/glesys/models/compute/template.rb
+++ b/lib/fog/glesys/models/compute/template.rb
@@ -11,7 +11,7 @@ module Fog
 
         attribute :platform
         attribute :operating_system, :aliases => "operatingsystem"
-        attribute :min_mem_size, :aliases => "minimummemorysize"
+        attribute :minimum_memory_size, :aliases => "minimummemorysize"
         attribute :minimum_disk_size, :aliases => "minimumdisksize"
         attribute :instance_cost, :aliases => "instancecost"
         attribute :license_cost, :aliases => "licensecost"


### PR DESCRIPTION
I saw that the attributes in glesys template weren't consistent. This update will fix the naming. And this won't break anything since fog isn't released since I added the attributes. :v:

Lucky me!
