### PR TITLE
Fix warning

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new do |s|
   ## If your rubyforge_project name is different, then edit it and comment out
   ## the sub! line in the Rakefile
   s.name              = 'fog'
-  s.version           = '1.9.0.4c523be349'
+  s.version           = '1.9.0'
   s.date              = '2013-01-19'
   s.rubyforge_project = 'fog'
 


### PR DESCRIPTION
Fix for warning:

Excon#ssl_verify_peer is deprecated, use Excon.defaults[:ssl_verify_peer] instead (xxx/bundle/ruby/1.9.1/gems/fog-1.9.0/lib/fog/rackspace/storage.rb:97:in `initialize')
