### PR TITLE
Fog::Compute::Ecloud::Servers create method returns 'invalidsshkey'

### DIFF
--- a/lib/fog/ecloud/requests/compute/virtual_machine_create_from_template.rb
+++ b/lib/fog/ecloud/requests/compute/virtual_machine_create_from_template.rb
@@ -90,8 +90,8 @@ module Fog
                     end
                   end
                 end
+                xml.SshKey(:href => options[:ssh_key_uri])
               end
-              xml.SshKey(:href => options[:ssh_key_uri])
             end
             xml.PoweredOn options[:powered_on]
             xml.Template(:href => options[:template_uri], :type => options[:template_type])


### PR DESCRIPTION
The error 'Error message="Ssh key id '0' is invalid." majorErrorCode="400" minorErrorCode="InvalidSshKey' is always returned from the Terremark ecloud server when attempting to create a VM from template using the ecloud module - this is due to incorrect formatting of the xml that is passed to the Terremark server. According to Terremark's eCloud API documentation, the SshKey element should be nested within the LinuxCustomization element, but it is created outside using this method.

This patch fixes the problem.
