### PR TITLE
[openstack|compute] configurable :openstack_endpoint_type

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -10,7 +10,8 @@ module Fog
                  :persistent, :openstack_service_type, :openstack_service_name,
                  :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
-                 :current_user, :current_tenant, :openstack_region
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type
 
       ## MODELS
       #
@@ -294,6 +295,7 @@ module Fog
           @openstack_service_type = options[:openstack_service_type] || ['nova', 'compute']
           @openstack_service_name = options[:openstack_service_name]
           @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
+          @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
           @openstack_region      = options[:openstack_region]
 
           @connection_options = options[:connection_options] || {}
@@ -371,7 +373,8 @@ module Fog
               :openstack_tenant     => @openstack_tenant,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
-              :openstack_identity_service_type => @openstack_identity_service_type
+              :openstack_identity_service_type => @openstack_identity_service_type,
+              :openstack_endpoint_type => @openstack_endpoint_type
             }
 
             if @openstack_auth_uri.path =~ /\/v2.0\//


### PR DESCRIPTION
:openstack_endpoint_type is missing as a recognized parameter. This
patch fixes that, and allows the :openstack_endpoint_type to be
configurable instead of hardcoding the value to 'publicURL'

That is, you can create the connection to the service as follows:

require 'fog'

conn = Fog::Compute.new({
:provider => 'OpenStack',
:openstack_api_key => ENV['OS_PASSWORD'],
:openstack_username => ENV["OS_USERNAME"],
:openstack_auth_url => ENV["OS_AUTH_URL"]
:openstack_tenant => ENV["OS_TENANT_NAME"],
:openstack_endpoint_type => 'adminURL', # publicURL, adminURL, etc
})

Defaults to publicURL to maintain backwards compatibility.
