### PR TITLE
[rackspace|lb] Fixed issue with paths having two slashes

### DIFF
--- a/lib/fog/rackspace/load_balancers.rb
+++ b/lib/fog/rackspace/load_balancers.rb
@@ -137,7 +137,6 @@ module Fog
           rescue Excon::Errors::InternalServerError => error
             raise InternalServerError.slurp error
           rescue Excon::Errors::HTTPStatusError => error
-            puts error.inspect
             raise ServiceError.slurp error
           end
           unless response.body.empty?


### PR DESCRIPTION
This was causing the API to return 401's.
