### PR TITLE
[glesys] Attributes were overwritten when getting server details

### DIFF
--- a/lib/fog/glesys/models/compute/server.rb
+++ b/lib/fog/glesys/models/compute/server.rb
@@ -14,11 +14,8 @@ module Fog
         attribute :cpucores
         attribute :memorysize
         attribute :disksize
-        attribute :cpu
-        attribute :memory
-        attribute :disk
-        attribute :uptime
         attribute :transfer
+        attribute :uptime
         attribute :templatename
         attribute :managedhosting
         attribute :platform
@@ -27,6 +24,7 @@ module Fog
         attribute :state
         attribute :iplist
         attribute :description
+        attribute :usage
         attribute :glera_enabled, :aliases => "gleraenabled"
         attribute :supported_features, :aliases => "supportedfeatures"
 

--- a/lib/fog/glesys/models/compute/servers.rb
+++ b/lib/fog/glesys/models/compute/servers.rb
@@ -24,8 +24,14 @@ module Fog
             if details.empty? || status.empty?
               nil
             else
-              status['server'].merge!({ :serverid => identifier})
+              details['server']['usage'] = Hash.new
+
+              %w|cpu memory disk transfer|.each do |attr|
+                details['server']['usage'][attr] = status['server'].delete(attr)
+              end
+
               details['server'].merge!(status['server'])
+
               new(details['server'])
             end
           rescue


### PR DESCRIPTION
Attributes were overwritten when requesting full information about a
server. Essential the problem is that both the server details and the
server status were requested from Glesys then merged together to create
a Fog Glesys server model object. I moved some of the status attributes
into a usage attribute on the server instead.
