### PR TITLE
[glesys] add platform to templates

### DIFF
--- a/lib/fog/glesys/models/compute/template.rb
+++ b/lib/fog/glesys/models/compute/template.rb
@@ -4,21 +4,13 @@ module Fog
   module Compute
     class Glesys
       class Template < Fog::Model
-        extend Fog::Deprecation
-
         identity :name
-
         attribute :platform
         attribute :operating_system, :aliases => "operatingsystem"
         attribute :minimum_memory_size, :aliases => "minimummemorysize"
         attribute :minimum_disk_size, :aliases => "minimumdisksize"
         attribute :instance_cost, :aliases => "instancecost"
         attribute :license_cost, :aliases => "licensecost"
-
-        def list
-          service.template_list
-        end
-
       end
     end
   end

--- a/lib/fog/glesys/models/compute/templates.rb
+++ b/lib/fog/glesys/models/compute/templates.rb
@@ -4,7 +4,6 @@ require 'fog/glesys/models/compute/template'
 module Fog
   module Compute
     class Glesys
-
       class Templates < Fog::Collection
 
         model Fog::Compute::Glesys::Template


### PR DESCRIPTION
Fix a bug and add a new feature to templates.

``` ruby
Fog::Compute[:glesys].templates # Show both OpenVZ and Xen templates
Fog::Compute[:glesys].templates.openvz # Show OpenVZ templates
Fog::Compute[:glesys].templates.xen # Show Xen templates
```
