### PR TITLE
[rackspace|storage] fixed issue in ruby 1.8.7 where metadata was not being deleted

### DIFF
--- a/lib/fog/rackspace/models/storage/file.rb
+++ b/lib/fog/rackspace/models/storage/file.rb
@@ -120,21 +120,21 @@ module Fog
         def header_to_key(opt)
           opt.gsub(metadata_prefix, '').split('-').map {|k| k[0, 1].downcase + k[1..-1]}.join('_').to_sym
         end
-
+        
         def metadata_to_headers
-          header_map = header_mapping
-          Hash[metadata.map {|k, v| [header_map[k], v] }]
-        end
+          hash = {}
+          metadata.each_pair do |k,v|
+            key = metakey(k,v)
+            hash[key] = v
+          end     
+          hash
+        end     
 
-        def header_mapping
-          header_map = metadata.dup
-          header_map.each_pair {|k, v| header_map[k] = key_to_header(k)}
+        def metakey(key, value)
+          prefix = value.nil? ?  "X-Remove-Object-Meta-" : "X-Object-Meta-"
+          prefix + key.to_s.split(/[-_]/).map(&:capitalize).join('-')
         end
-
-        def key_to_header(key)
-          metadata_prefix + key.to_s.split(/[-_]/).map(&:capitalize).join('-')
-        end
-
+        
         def metadata_attributes
           if last_modified
             headers = service.head_object(directory.key, self.key).headers

--- a/tests/rackspace/models/storage/file_tests.rb
+++ b/tests/rackspace/models/storage/file_tests.rb
@@ -3,7 +3,7 @@ Shindo.tests('Fog::Rackspace::Storage | file', ['rackspace']) do
   pending if Fog.mocking?
 
   def object_meta_attributes
-    @instance.connection.head_object(@directory.key, @instance.key).headers.reject {|k, v| !(k =~ /X-Object-Meta-/)}
+    @instance.service.head_object(@directory.key, @instance.key).headers.reject {|k, v| !(k =~ /X-Object-Meta-/)}
   end
 
   def clear_metadata
@@ -64,8 +64,20 @@ Shindo.tests('Fog::Rackspace::Storage | file', ['rackspace']) do
           @instance.metadata[:foo] = nil
           @instance.save
           object_meta_attributes
-        end
+        end      
 
+        tests("removes one key while leaving the other") do
+          @instance.metadata[:color] = "green"
+          @instance.save
+          returns({"X-Object-Meta-Foo"=>"bar", "X-Object-Meta-Color"=>"green"}) { object_meta_attributes  }
+                    
+          tests("set metadata[:color] = nil").returns({"X-Object-Meta-Foo"=>"bar"}) do
+            @instance.metadata[:color] = nil
+            @instance.save
+            
+            object_meta_attributes
+          end
+        end
       end
     
       tests('#metadata keys') do
@@ -105,7 +117,6 @@ Shindo.tests('Fog::Rackspace::Storage | file', ['rackspace']) do
           @instance.save
           object_meta_attributes['X-Object-Meta-Foo-Bar']
         end
-
       end
 
     end


### PR DESCRIPTION
File metadata is not being removed when set to nil when using ruby 1.8.7. This bug was exposed by running the file_tests without using mocks.

After reviewing the specs we should have been setting the key names to X-Remove-Object-Meta-<keyname> when we are trying to delete keys.

http://docs.rackspace.com/files/api/v1/cf-devguide/content/Update_Object_Metadata-d1e2338.html
