### PR TITLE
Upgraded the net-scp dep from ~>1.0.4 to ~>1.1 because 1.0.6 was yanked from RubyGems.org

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency('formatador', '~>0.2.0')
   s.add_dependency('multi_json', '~>1.0')
   s.add_dependency('mime-types')
-  s.add_dependency('net-scp', '~>1.0.4')
+  s.add_dependency('net-scp', '~>1.1')
   s.add_dependency('net-ssh', '>=2.1.3')
   s.add_dependency('nokogiri', '~>1.5.0')
   s.add_dependency('ruby-hmac')


### PR DESCRIPTION
RubyGems.org yanked v1.0.6 causing problems
with installing the gem.
