### PR TITLE
fixed bug, floatingip methods to Fog::OpenStack::Network

### DIFF
--- a/lib/fog/openstack/models/network/floating_ip.rb
+++ b/lib/fog/openstack/models/network/floating_ip.rb
@@ -32,7 +32,7 @@ module Fog
           merge_attributes(connection.create_floating_ip(self.floating_network_id,
 
 
-                                                    self.attributes).body['floating_ip'])
+                                                    self.attributes).body['floatingip'])
           self
         end
 

--- a/lib/fog/openstack/models/network/floating_ips.rb
+++ b/lib/fog/openstack/models/network/floating_ips.rb
@@ -17,11 +17,11 @@ module Fog
 
         def all(filters = filters)
           self.filters = filters
-          load(connection.list_floating_ips(filters).body['floating_ips'])
+          load(connection.list_floating_ips(filters).body['floatingips'])
         end
 
         def get(floating_network_id)
-          if floating_ip = connection.get_floating_ip(floating_network_id).body['floating_ip']
+          if floating_ip = connection.get_floating_ip(floating_network_id).body['floatingip']
             new(floating_ip)
           end
         rescue Fog::Network::OpenStack::NotFound

--- a/lib/fog/openstack/requests/network/associate_floating_ip.rb
+++ b/lib/fog/openstack/requests/network/associate_floating_ip.rb
@@ -5,14 +5,14 @@ module Fog
       class Real
         def associate_floating_ip(floating_ip_id, port_id, options = {})
           data = {
-            'floating_ip' => {
+            'floatingip' => {
               'port_id'    => port_id,
             }
           }
 
           vanilla_options = [:fixed_ip_address]
           vanilla_options.reject{ |o| options[o].nil? }.each do |key|
-            data['floating_ip'][key] = options[key]
+            data['floatingip'][key] = options[key]
           end
 
           request(
@@ -39,7 +39,7 @@ module Fog
           }
 
           self.data[:floating_ips][data['floating_ip_id']] = data
-          response.body = { 'floating_ip' => data }
+          response.body = { 'floatingip' => data }
           response
         end
       end

--- a/lib/fog/openstack/requests/network/create_floating_ip.rb
+++ b/lib/fog/openstack/requests/network/create_floating_ip.rb
@@ -5,7 +5,7 @@ module Fog
       class Real
         def create_floating_ip(floating_network_id, options = {})
           data = {
-            'floating_ip' => {
+            'floatingip' => {
               'floating_network_id' => floating_network_id,
               'port_id' => options[:port_id],
               'tenant_id' => options[:tenant_id],
@@ -15,7 +15,7 @@ module Fog
 
           vanilla_options = [:port_id, :tenant_id, :fixed_ip_address ]
           vanilla_options.reject{ |o| options[o].nil? }.each do |key|
-            data['floating_ip'][key] = options[key]
+            data['floatingip'][key] = options[key]
           end
 
           request(
@@ -40,7 +40,7 @@ module Fog
             'router_id'           => nil,
           }
           self.data[:floating_ips][data['id']] = data
-          response.body = { 'floating_ip' => data }
+          response.body = { 'floatingip' => data }
           response
         end
       end

--- a/lib/fog/openstack/requests/network/delete_floating_ip.rb
+++ b/lib/fog/openstack/requests/network/delete_floating_ip.rb
@@ -15,7 +15,7 @@ module Fog
       class Mock
         def delete_floating_ip(floating_ip_id)
           response = Excon::Response.new
-          if list_floating_ips.body['floating_ips'].map { |r| r['id'] }.include? floating_ip_id
+          if list_floating_ips.body['floatingips'].map { |r| r['id'] }.include? floating_ip_id
             self.data[:floating_ips].delete(floating_ip_id)
             response.status = 204
             response

--- a/lib/fog/openstack/requests/network/disassociate_floating_ip.rb
+++ b/lib/fog/openstack/requests/network/disassociate_floating_ip.rb
@@ -5,14 +5,14 @@ module Fog
       class Real
         def disassociate_floating_ip(floating_ip_id, options = {})
           data = {
-            'floating_ip' => {
+            'floatingip' => {
               'port_id'    => nil,
             }
           }
 
           vanilla_options = [:fixed_ip_address]
           vanilla_options.reject{ |o| options[o].nil? }.each do |key|
-            data['floating_ip'][key] = options[key]
+            data['floatingip'][key] = options[key]
           end
 
           request(
@@ -39,7 +39,7 @@ module Fog
           }
 
           self.data[:floating_ips][data['floating_ip_id']] = data
-          response.body = { 'floating_ip' => data }
+          response.body = { 'floatingip' => data }
           response
         end
       end

--- a/lib/fog/openstack/requests/network/get_floating_ip.rb
+++ b/lib/fog/openstack/requests/network/get_floating_ip.rb
@@ -18,7 +18,7 @@ module Fog
           if data = self.data[:floating_ips][floating_ip_id]
             response.status = 200
             response.body = {
-              "floating_ip" => {
+              "floatingip" => {
                 "id"                  => "00000000-0000-0000-0000-000000000000",
                 # changed
                 # "floating_ip_id" => floating_ip_id,

--- a/lib/fog/openstack/requests/network/list_floating_ips.rb
+++ b/lib/fog/openstack/requests/network/list_floating_ips.rb
@@ -16,7 +16,7 @@ module Fog
       class Mock
         def list_floating_ips(filters = {})
           Excon::Response.new(
-            :body   => { 'floating_ips' => self.data[:floating_ips].values },
+            :body   => { 'floatingips' => self.data[:floating_ips].values },
             :status => 200
           )
         end


### PR DESCRIPTION
Hi.

quantum api need no underscore valiable name, on no mock mode. (ex floatingips

updated for ruby naming conventions. · 9ebd161 · kanetann/fog https://github.com/kanetann/fog/commit/9ebd161e03e3931a3322776b6bc156a9bb071069
