### PR TITLE
[Rackspace|Compute_v2] Added note about bootstrap method and RackConnect

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/servers.rb
+++ b/lib/fog/rackspace/models/compute_v2/servers.rb
@@ -19,6 +19,8 @@ module Fog
         end
 
         # Creates a new server and populates ssh keys
+        # @note This method is incompatible with Cloud Servers utlizing RackConnect. RackConnect users 
+        #     should use server personalization to install keys.  Please see Server#personality for more information.
         # @example
         #   service = Fog::Compute.new(:provider => 'rackspace', 
         #                             :version => :v2, 


### PR DESCRIPTION
Added a note to indicate that customers utilizing RackConnect and Cloud Servers should opt to use the server personality functionality instead of the bootstrap method as the public ip address gets reassigned when the RackConnect automation scripts are run.

See issue https://github.com/fog/fog/issues/1507 for more information.

@brianseeders @bradgignac @brianhartsock Can you give me some feedback on this pull request?
