### PR TITLE
Openstack: fix bin/openstack.rb errors.

### DIFF
--- a/lib/fog/bin/openstack.rb
+++ b/lib/fog/bin/openstack.rb
@@ -7,6 +7,8 @@ class OpenStack < Fog::Bin
         Fog::Compute::OpenStack
       when :identity
         Fog::Identity::OpenStack
+      when :image
+        Fog::Image::OpenStack
       when :network
         Fog::Network::OpenStack
       when :storage
@@ -23,14 +25,17 @@ class OpenStack < Fog::Bin
           Fog::Logger.warning("OpenStack[:compute] is not recommended, use Compute[:openstack] for portability")
           Fog::Compute.new(:provider => 'OpenStack')
         when :identity
-          Fog::Logger.warning("OpenStack[:identity] is not recommended, use Compute[:openstack] for portability")
-          Fog::Compute.new(:provider => 'OpenStack')
+          Fog::Logger.warning("OpenStack[:identity] is not recommended, use Identity[:openstack] for portability")
+          Fog::Identity.new(:provider => 'OpenStack')
+        when :image
+          Fog::Logger.warning("OpenStack[:image] is not recommended, use Image[:openstack] for portability")
+          Fog::Image.new(:provider => 'OpenStack')
         when :network
           Fog::Logger.warning("OpenStack[:network] is not recommended, use Network[:openstack] for portability")
           Fog::Network.new(:provider => 'OpenStack')
         when :storage
           Fog::Logger.warning("OpenStack[:storage] is not recommended, use Storage[:openstack] for portability")
-          Fog::Network.new(:provider => 'OpenStack')
+          Fog::Storage.new(:provider => 'OpenStack')
         else
           raise ArgumentError, "Unrecognized service: #{key.inspect}"
         end


### PR DESCRIPTION
Updates Fog::Bin for OpenStack to support :image.

This patch also fixes a bunch of copy/paste errors in the
deprecated [] method.
