### PR TITLE
[rackspace|compute] updated mocking framework to support any flavor or image

### DIFF
--- a/lib/fog/rackspace/mock_data.rb
+++ b/lib/fog/rackspace/mock_data.rb
@@ -1,6 +1,9 @@
 module Fog
   module Rackspace
     module MockData
+      
+      NOT_FOUND_ID = "NOT-FOUND"
+      
       def data
         @@data ||= Hash.new do |hash, key|
           hash[key] = begin
@@ -101,12 +104,13 @@ module Fog
             }
 
             #Mock Data Hash
-            {
+            h = {
               #Compute V2
-              :flavors => {flavor_id => flavor},
-              :images  => {image_id => image},
+              :flavors => Hash.new { |h,k| h[k] = flavor unless k == NOT_FOUND_ID},
+              :images => Hash.new { |h,k| h[k] = image unless k == NOT_FOUND_ID },        
+              :networks => Hash.new { |h,k| h[k] = network unless k == NOT_FOUND_ID },
+
               :servers => {},
-              :networks => { network_id => network },
 
               #Block Storage
               :volumes            => {},
@@ -114,6 +118,13 @@ module Fog
               :volume_attachments => [],
               :volume_types       => {volume_type1_id => volume_type1, volume_type2_id => volume_type2},
             }
+            
+            # seed with initial data
+            h[:flavors][flavor_id] = flavor
+            h[:images][image_id] = image
+            h[:networks][network_id] = network
+            
+            h            
           end
         end[@rackspace_api_key]
       end

--- a/tests/rackspace/models/compute_v2/flavors_tests.rb
+++ b/tests/rackspace/models/compute_v2/flavors_tests.rb
@@ -12,6 +12,6 @@ Shindo.tests('Fog::Compute::RackspaceV2 | flavors', ['rackspace']) do
   end
 
   tests("failure").returns(nil) do
-    service.flavors.get('some_random_identity')
+    service.flavors.get(Fog::Rackspace::MockData::NOT_FOUND_ID)
   end
 end

--- a/tests/rackspace/models/compute_v2/images_tests.rb
+++ b/tests/rackspace/models/compute_v2/images_tests.rb
@@ -15,6 +15,6 @@ Shindo.tests('Fog::Compute::RackspaceV2 | images', ['rackspace']) do
   end
 
   tests("failure").returns(nil) do
-    service.images.get('some_random_identity')
+    service.images.get(Fog::Rackspace::MockData::NOT_FOUND_ID)
   end
 end

--- a/tests/rackspace/requests/compute/image_tests.rb
+++ b/tests/rackspace/requests/compute/image_tests.rb
@@ -57,12 +57,12 @@ Shindo.tests('Fog::Compute[:rackspace] | image requests', ['rackspace']) do
   tests('failure') do
 
     tests('#delete_image(0)').raises(Excon::Errors::BadRequest) do
-       @service.delete_image(0)
+       @service.delete_image(Fog::Rackspace::MockData::NOT_FOUND_ID)
     end
 
     tests('#get_image_details(0)').raises(Fog::Compute::Rackspace::NotFound) do
       pending if Fog.mocking?
-       @service.get_image_details(0)
+       @service.get_image_details(Fog::Rackspace::MockData::NOT_FOUND_ID)
     end
 
   end

--- a/tests/rackspace/requests/compute_v2/image_tests.rb
+++ b/tests/rackspace/requests/compute_v2/image_tests.rb
@@ -59,11 +59,11 @@ Shindo.tests('Fog::Compute::RackspaceV2 | image_tests', ['rackspace']) do
 
     tests('failure') do
       tests('#delete_image').raises(Excon::Errors::BadRequest) do
-        Fog::Compute[:rackspace].delete_image(0)
+        Fog::Compute[:rackspace].delete_image(Fog::Rackspace::MockData::NOT_FOUND_ID)
       end
 
       tests('#get_image').raises(Fog::Compute::RackspaceV2::NotFound) do
-        service.get_image(0)
+        service.get_image(Fog::Rackspace::MockData::NOT_FOUND_ID)
       end
     end
   ensure 


### PR DESCRIPTION
I updated MockData to create additional images/flavors if they are unknown. Hopefully, this should allow developers to utilize mocks without having to change their code.

This should address issue https://github.com/fog/fog/issues/1573. 

Users wanting should use contain Fog::Rackspace::MockData::NOT_FOUND_ID for situations where it is desirable not to find an image or flavor.
