### PR TITLE
Fog::Compute::Vsphere get_vm_by_ref method is misspelled in vm_reconfig_hardware

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_reconfig_hardware.rb
+++ b/lib/fog/vsphere/requests/compute/vm_reconfig_hardware.rb
@@ -5,7 +5,7 @@ module Fog
         def vm_reconfig_hardware(options = {})
           raise ArgumentError, "hardware_spec is a required parameter" unless options.has_key? 'hardware_spec'
           raise ArgumentError, "instance_uuid is a required parameter" unless options.has_key? 'instance_uuid'
-          vm_mob_ref = get_vm_by_ref(options['instance_uuid'])
+          vm_mob_ref = get_vm_ref(options['instance_uuid'])
           task = vm_mob_ref.ReconfigVM_Task(:spec => RbVmomi::VIM.VirtualMachineConfigSpec(options['hardware_spec']))
           task.wait_for_completion
            { 'task_state' => task.info.state }


### PR DESCRIPTION
Method 'get_vm_by_ref' should be 'get_vm_ref' in vm_reconfig_hardware.rb, when run by default it returns 'NoMethodError' for 'get_vm_by_ref' because it doesn't exist anywhere.
