### PR TITLE
[openstack|network] Added missing Network model attributes

### DIFF
--- a/lib/fog/openstack/models/network/network.rb
+++ b/lib/fog/openstack/models/network/network.rb
@@ -12,6 +12,14 @@ module Fog
         attribute :status
         attribute :admin_state_up
         attribute :tenant_id
+        attribute :provider_network_type,       
+                  :aliases =>  'provider:network_type'
+        attribute :provider_physical_network,
+                  :aliases => 'provider:physical_network'
+        attribute :provider_segmentation_id,
+                  :aliases => 'provider:segmentation_id'
+        attribute :router_external,
+                  :aliases => 'router:external'
 
         def initialize(attributes)
           # Old 'connection' is renamed as service and should be used instead

--- a/tests/openstack/models/network/network_tests.rb
+++ b/tests/openstack/models/network/network_tests.rb
@@ -1,13 +1,33 @@
 Shindo.tests("Fog::Network[:openstack] | network", ['openstack']) do
 
   tests('success') do
-
+    
     tests('#create').succeeds do
       @instance = Fog::Network[:openstack].networks.create(:name => 'net_name',
                                                            :shared => false,
                                                            :admin_state_up => true,
                                                            :tenant_id => 'tenant_id')
       !@instance.id.nil?
+    end
+    
+    tests('have attributes') do
+      attributes = [ 
+        :name,
+        :subnets,
+        :shared,
+        :status,
+        :admin_state_up,
+        :tenant_id,
+        :provider_network_type,
+        :provider_physical_network,
+        :provider_segmentation_id,
+        :router_external
+      ]
+      tests("The network model should respond to") do
+        attributes.each do |attribute|
+          test("#{attribute}") { @instance.respond_to? attribute }
+        end
+      end
     end
 
     tests('#update').succeeds do


### PR DESCRIPTION
The following patch adds the following missing attributes:

```
+---------------------------+--------------------------------------+
| Field                     | Value                                |
+---------------------------+--------------------------------------+
| provider:network_type     | gre                                  |
| provider:physical_network |                                      |
| provider:segmentation_id  | 1                                    |
| router:external           | False                                |
+---------------------------+--------------------------------------+
```

Not sure if the code style I've used for the attributes is OK though,
I did it so I don't break the 80 col. barrier.

Added also a small test for the new and existing attributes.
