### PR TITLE
joyent resize smartmachine incorrect class type

### DIFF
--- a/lib/fog/joyent/models/compute/server.rb
+++ b/lib/fog/joyent/models/compute/server.rb
@@ -53,7 +53,7 @@ module Fog
 
         def resize(flavor)
           requires :id
-          service.resize_machine(id, flavor)
+          service.resize_machine(id, flavor.name)
           true
         end
 

--- a/lib/fog/joyent/requests/compute/resize_machine.rb
+++ b/lib/fog/joyent/requests/compute/resize_machine.rb
@@ -1,6 +1,7 @@
 module Fog
   module Compute
     class Joyent
+     class Real
       def resize_machine(id, package)
         request(
           :method => "POST",
@@ -8,6 +9,7 @@ module Fog
           :query => {"action" => "resize", "package" => package}
         )
       end
+     end
     end
   end
 end


### PR DESCRIPTION
When doing a resize on Fog master the following error message appears. . 

NoMethodError: undefined method `resize_machine' for #<Fog::Compute::Joyent::Real:0x000000015b86b8>
        from /home/angus/.rvm/gems/ruby-1.9.3-p194/gems/fog-1.9.0/lib/fog/joyent/models/compute/server.rb:56:in`resize'
        from (irb):6
        from /home/angus/.rvm/rubies/ruby-1.9.3-p194/bin/irb:16:in `<main>'

It appears that the service needs to be 'cast' as Real.  I've also ensured that there is consistancy by the library method resize that requires a 'flavor' passes the 'package' (string) to the request library.  
