### PR TITLE
[rackspace|storage]  decoding strings in Metadata.from_headers.

### DIFF
--- a/lib/fog/rackspace/models/storage/metadata.rb
+++ b/lib/fog/rackspace/models/storage/metadata.rb
@@ -42,7 +42,7 @@ module Fog
           headers.each_pair do |k, v|
             key = Metadata.to_key(k)
             next unless key
-            metadata.data[key] = Fog::JSON.decode(v)
+            metadata.data[key] = Metadata.decode_value(v)
           end
           metadata
         end   
@@ -56,6 +56,12 @@ module Fog
         end                             
         
         private
+        
+        def self.decode_value(obj)
+          Fog::JSON.decode(obj)
+        rescue MultiJson::LoadError => e
+          obj
+        end
         
         def self.to_key(key)
            m = key.match KEY_REGEX

--- a/tests/rackspace/models/storage/metadata_tests.rb
+++ b/tests/rackspace/models/storage/metadata_tests.rb
@@ -35,7 +35,7 @@ Shindo.tests('Fog::Rackspace::Storage | metadata', ['rackspace']) do
     headers = {
       "X-Container-Meta-My-Integer"=> "42",
       "X-Container-Meta-My-Boolean"=> "true", 
-      "X-Container-Meta-My-String"=> "\"I am a string\"" 
+      "X-Container-Meta-My-String"=> "I am a string" 
     }
 
     metadata = Fog::Storage::Rackspace::Metadata.from_headers headers


### PR DESCRIPTION
Addressed issue where Fog::Rackspace::Metadata.from_headers throws a MultiJson::LoadError exception when encountering a string.
