### PR TITLE
[hp/openstack|compute] remove erroneous block argument to get_object; fi...

### DIFF
--- a/lib/fog/hp/requests/storage/get_object.rb
+++ b/lib/fog/hp/requests/storage/get_object.rb
@@ -19,7 +19,6 @@ module Fog
             )
           else
             response = request({
-              :block  => block,
               :expects  => 200,
               :method   => 'GET',
               :path     => "#{Fog::HP.escape(container)}/#{Fog::HP.escape(object)}"

--- a/lib/fog/hp/requests/storage/get_shared_object.rb
+++ b/lib/fog/hp/requests/storage/get_shared_object.rb
@@ -22,7 +22,6 @@ module Fog
             )
           else
             response = shared_request({
-              :block  => block,
               :expects  => 200,
               :method   => 'GET',
               :path     => path

--- a/lib/fog/openstack/requests/storage/get_object.rb
+++ b/lib/fog/openstack/requests/storage/get_object.rb
@@ -17,7 +17,6 @@ module Fog
           end
 
           request(params.merge!({
-            :block    => block,
             :expects  => 200,
             :method   => 'GET',
             :path     => "#{Fog::OpenStack.escape(container)}/#{Fog::OpenStack.escape(object)}"


### PR DESCRIPTION
Fixes https://github.com/fog/fog/issues/1588 for HP and OpenStack.
