### PR TITLE
Follow 307 redirection from response even if response is a Hash

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -400,7 +400,7 @@ DATA
           begin
             response = @connection.request(params, &block)
           rescue Excon::Errors::TemporaryRedirect => error
-            uri = URI.parse(error.response.headers['Location'])
+            uri = URI.parse(error.response.is_a?(Hash) ? error.response[:headers]['Location'] : error.response.headers['Location'])
             Fog::Logger.warning("fog: followed redirect to #{uri.host}, connecting to the matching region will be more performant")
             response = Fog::Connection.new("#{@scheme}://#{uri.host}:#{@port}", false, @connection_options).request(original_params, &block)
           end


### PR DESCRIPTION
Hello,

This commit fixes a regression on #27.

From what I understand it seems that at some point the logic catching the 307 was moved to `Excon::Errors::TemporaryRedirect`. This is good, but it seems that since then `error.response` is not behaving as expected.

If we go `error.response.headers['Location']` it breaks with:

```
NoMethodError: undefined method `headers' for #<Hash:0x007fac3ba55c28>
```

Inspecting the `error.response` object:

``` ruby
response => 
{:body=>"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n
<Error>
  <Code>TemporaryRedirect</Code>
  <Message>Please re-send this request to the specified temporary endpoint. Continue to use the original request endpoint for future requests.</Message>
  <RequestId>659**********5D8</RequestId>
  <Bucket>**********-dev</Bucket>
  <HostId>RRfN**********RWE</HostId>
  <Endpoint>**********-dev.s3-external-3.amazonaws.com</Endpoint>
</Error>",
:headers=> {
  "x-amz-request-id"=>"659**********45D8",
  "x-amz-id-2"=>"RRfN**********bwRWE",
  "Location"=>"https://**********-dev.s3-external-3.amazonaws.com/?prefix=assets",
  "Content-Type"=>"application/xml", 
  "Transfer-Encoding"=>"chunked", 
  "Date"=>"Mon, 25 Feb 2013 09:31:32 GMT", "Server"=>"AmazonS3"
}, :status=>307, :remote_ip=>"**********"}>
```

My fix makes sure that it will handle correctly the response if it's a hash while still working if we have an Excon response object instead to avoid problems for users with various versions of Excon.

This fixes my issue and I doubt it'll break any logic.

Let me know if you need more information in order to merge this.

Thanks for the gem!
marc- 
