### PR TITLE
Remove :url param from aws get_service request

### DIFF
--- a/lib/fog/aws/requests/storage/get_service.rb
+++ b/lib/fog/aws/requests/storage/get_service.rb
@@ -25,8 +25,7 @@ module Fog
             :host     => @host,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::Storage::AWS::GetService.new,
-            :url      => @host
+            :parser   => Fog::Parsers::Storage::AWS::GetService.new
           })
         end
 


### PR DESCRIPTION
As of geemus/excon@cb6b273 Excon validates params for `request` method.
However, array of valid params doesn’t include `url` param, which ends up with `ArgumentError: The following keys are invalid: :url` exception.
I removed that param from `get_service` method, and everything seems to be OK, however, I’m not sure if this is not excon’s bug, and I shouldn’t add `:url` to `VALID_CONNECTION_KEYS` array – if so, just let me know.
