### PR TITLE
Extended Fog::Storage::AWS::Files files method

### DIFF
--- a/lib/fog/aws/models/storage/directory.rb
+++ b/lib/fog/aws/models/storage/directory.rb
@@ -47,8 +47,13 @@ module Fog
           end
         end
 
-        def files
-          @files ||= Fog::Storage::AWS::Files.new(:directory => self, :service => service)
+        def files(options={})
+          arguments = {
+            :directory => self,
+            :service => service
+          }
+          arguments.merge!(options) if options.is_a? Hash
+          @files ||= Fog::Storage::AWS::Files.new(arguments)
         end
 
         def payer


### PR DESCRIPTION
This method now accepts an hash of options that is fed to the Fog::Storage::AWS::Files constructor.

It's useful to filter the files that are returned prior to actually getting all the files.

Example:

``` ruby
Fog::Storage::AWS::Directory.files(
  :directory => some_bucket, 
  :service => some_bucket.service, 
  :prefix => 'this/is/some/key/prefix'
)
```
