### PR TITLE
[rackspace|storage] Added ability to determine prefixes from Class Objects

### DIFF
--- a/lib/fog/rackspace/models/storage/files.rb
+++ b/lib/fog/rackspace/models/storage/files.rb
@@ -55,7 +55,7 @@ module Fog
         def get(key, &block)
           requires :directory
           data = service.get_object(directory.key, key, &block)
-          metadata = Metadata.from_headers(data.headers)  
+          metadata = Metadata.from_headers(self, data.headers)  
           file_data = data.headers.merge({
             :body => data.body,
             :key  => key,

--- a/lib/fog/rackspace/models/storage/metadata.rb
+++ b/lib/fog/rackspace/models/storage/metadata.rb
@@ -1,3 +1,8 @@
+require 'fog/rackspace/models/storage/directory'
+require 'fog/rackspace/models/storage/file'
+require 'fog/rackspace/models/storage/directories'
+require 'fog/rackspace/models/storage/files'
+
 module Fog
   module Storage
     class Rackspace
@@ -60,33 +65,45 @@ module Fog
         
         private
         
+        def directory?
+          [Fog::Storage::Rackspace::Directory, Fog::Storage::Rackspace::Directories].include? parent_class
+        end
+        
+        def file?
+          [Fog::Storage::Rackspace::File, Fog::Storage::Rackspace::Files].include? parent_class
+        end
+        
+        def parent_class
+          parent.is_a?(Class) ? parent : parent.class
+        end
+        
         def meta_prefix
-          if parent.is_a? Fog::Storage::Rackspace::Directory
+          if directory?
             CONTAINER_META_PREFIX
-          elsif parent.is_a? Fog::Storage::Rackspace::File
+          elsif file?
             OBJECT_META_PREFIX
           else
-            raise "Metadata prefix is unknown for #{parent.class}"
+            raise "Metadata prefix is unknown for #{parent_class}"
           end
         end
 
         def remove_meta_prefix
-          if parent.is_a? Fog::Storage::Rackspace::Directory
+          if directory?
             CONTAINER_REMOVE_META_PREFIX
-          elsif parent.is_a? Fog::Storage::Rackspace::File
+          elsif file?
             OBJECT_REMOVE_META_PREFIX
           else
-            raise "Remove Metadata prefix is unknown for #{parent.class}"
+            raise "Remove Metadata prefix is unknown for #{parent_class}"
           end
         end
 
         def meta_prefix_regex
-          if parent.is_a? Fog::Storage::Rackspace::Directory
+          if directory?
             CONTAINER_KEY_REGEX
-          elsif parent.is_a? Fog::Storage::Rackspace::File
+          elsif file?
             OBJECT_KEY_REGEX
           else
-            raise "Metadata prefix is unknown for #{parent.class}"
+            raise "Metadata prefix is unknown for #{parent_class}"
           end
         end
         

--- a/tests/rackspace/models/storage/metadata_tests.rb
+++ b/tests/rackspace/models/storage/metadata_tests.rb
@@ -2,7 +2,19 @@ require 'fog/rackspace/models/storage/metadata'
 require 'fog/rackspace/models/storage/directory'
 require 'fog/rackspace/models/storage/file'
 
+
 Shindo.tests('Fog::Rackspace::Storage | metadata', ['rackspace']) do
+  
+  def assert_directory(obj, assert_value)
+    metadata = Fog::Storage::Rackspace::Metadata.new obj
+    returns(assert_value) { metadata.send :directory? }
+  end
+  
+  def assert_file(obj, assert_value)
+    metadata = Fog::Storage::Rackspace::Metadata.new obj
+    returns(assert_value) { metadata.send :file? }
+  end
+  
   tests('Directory') do
     @directory = Fog::Storage::Rackspace::Directory.new
     tests('#to_key') do
@@ -123,5 +135,40 @@ Shindo.tests('Fog::Rackspace::Storage | metadata', ['rackspace']) do
      metadata = Fog::Storage::Rackspace::Metadata.new @file
       metadata[:test] = true
       metadata[:test]
+   end
+   
+   tests('#directory?') do
+     assert_directory Fog::Storage::Rackspace::Directories, true
+     assert_directory Fog::Storage::Rackspace::Directory, true       
+     assert_directory Fog::Storage::Rackspace::Directory.new, true
+
+     assert_directory nil, false
+     assert_directory Fog::Storage::Rackspace::Files, false
+     assert_directory Fog::Storage::Rackspace::File, false
+     assert_directory Fog::Storage::Rackspace::File.new, false
+     assert_directory "I am a string!", false      
+   end
+   
+   tests('#file?') do
+     assert_file Fog::Storage::Rackspace::Directories, false
+     assert_file Fog::Storage::Rackspace::Directory, false    
+     assert_file Fog::Storage::Rackspace::Directory.new, false
+
+     assert_file nil, false
+     assert_file Fog::Storage::Rackspace::Files, true
+     assert_file Fog::Storage::Rackspace::File, true
+     assert_file Fog::Storage::Rackspace::File.new, true
+     assert_file "I am a string!", false      
+   end
+   
+   tests('#parent_class') do
+     tests('Fog::Storage::Rackspace::Directory object') do
+       metadata = Fog::Storage::Rackspace::Metadata.new Fog::Storage::Rackspace::Directory.new
+       returns(Fog::Storage::Rackspace::Directory) { metadata.send :parent_class }       
+     end
+     tests('Fog::Storage::Rackspace::Directory class') do
+       metadata = Fog::Storage::Rackspace::Metadata.new Fog::Storage::Rackspace::Directory
+       returns(Fog::Storage::Rackspace::Directory) { metadata.send :parent_class }       
+     end
    end
 end


### PR DESCRIPTION
[rackspace|storage] added the ability to determine meta prefixes from Class objects as well as Fog object. This addresses issue in Files#get method.
