### PR TITLE
OpenStack: base64 encode personality in rebuild

### DIFF
--- a/lib/fog/openstack/requests/compute/rebuild_server.rb
+++ b/lib/fog/openstack/requests/compute/rebuild_server.rb
@@ -11,7 +11,15 @@ module Fog
           }}
           body['rebuild']['adminPass'] = admin_pass if admin_pass
           body['rebuild']['metadata'] = metadata if metadata
-          body['rebuild']['personality'] = personality if personality
+          if personality
+            body['rebuild']['personality'] = []
+            for file in personality
+              body['rebuild']['personality'] << {
+                'contents'  => Base64.encode64(file['contents']),
+                'path'      => file['path']
+              }
+            end
+          end
           server_action(server_id, body, 202)
         end
 


### PR DESCRIPTION
Updates the rebuild_server action so that it base64's the personality
just like we do in create_server.
