### PR TITLE
[openstack|compute] images collection should not return nil for #all

### DIFF
--- a/lib/fog/openstack/models/compute/images.rb
+++ b/lib/fog/openstack/models/compute/images.rb
@@ -13,10 +13,11 @@ module Fog
 
         def all
           data = service.list_images_detail.body['images']
-          load(data)
+          images = load(data)
           if server
             self.replace(self.select {|image| image.server_id == server.id})
           end
+          images
         end
 
         def get(image_id)

--- a/tests/openstack/models/compute/images_tests.rb
+++ b/tests/openstack/models/compute/images_tests.rb
@@ -1,0 +1,14 @@
+Shindo.tests("Fog::Compute[:openstack] | images collection", ['openstack']) do
+
+  tests('success') do
+
+    tests('#all').succeeds do
+      fog = Fog::Compute[:openstack]
+      test 'not nil' do
+        fog.images.all.is_a? Array
+      end
+    end
+
+  end
+end
+


### PR DESCRIPTION
Fog::Compute[:openstack].images.all returns nil without the patch.
The patch should bring the images collection behaviour in-line with
other collections I think.

The added test should expose the issue.
