### PR TITLE
Typo in instantiate_vapp_template.rb

### DIFF
--- a/lib/fog/vcloud/requests/compute/instantiate_vapp_template.rb
+++ b/lib/fog/vcloud/requests/compute/instantiate_vapp_template.rb
@@ -71,7 +71,7 @@ module Fog
         include Shared
 
         def instantiate_vapp_template options = {}
-          validate_instantiate_vapp_template_options optionsgi
+          validate_instantiate_vapp_template_options options
           request(
             :body     => generate_instantiate_vapp_template_request(options),
             :expects  => 201,


### PR DESCRIPTION
Remove typo in instantiate_vapp_template()
