### PR TITLE
[openstack|network] Add endpoint_type option

### DIFF
--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -7,7 +7,7 @@ module Fog
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_api_key, :openstack_username,
+                 :openstack_api_key, :openstack_username, :openstack_endpoint_type,
                  :current_user, :current_tenant
 
       ## MODELS
@@ -120,6 +120,7 @@ module Fog
           @openstack_must_reauthenticate  = false
           @openstack_service_type         = options[:openstack_service_type] || ['network']
           @openstack_service_name         = options[:openstack_service_name]
+          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
 
           @connection_options = options[:connection_options] || {}
 
@@ -192,7 +193,7 @@ module Fog
               :openstack_auth_token => @openstack_auth_token,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => 'adminURL'
+              :openstack_endpoint_type => @openstack_endpoint_type
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)


### PR DESCRIPTION
Let users set what endpoint type to use when connecting to OpenStack Network service. Default is "adminURL".
