### PR TITLE
[openstack|image] Check for glance version (fog only supports v1)

### DIFF
--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -206,6 +206,10 @@ module Fog
           @host   = uri.host
           @path   = uri.path
           @path.sub!(/\/$/, '')
+          unless @path.match(/v1(\.1)*/)
+            raise Fog::OpenStack::Errors::ServiceUnavailable.new(
+                  "OpenStack binding only supports version 1.1 (a.k.a. 1)")
+          end
           @port   = uri.port
           @scheme = uri.scheme
           true


### PR DESCRIPTION
Check if version returned by service catalog is supported, as Fog only suports glance version v1 (or v1.1). I'm working on v2 support.

Same behaviour as [openstack compute](https://github.com/fog/fog/blob/master/lib/fog/openstack/compute.rb#L406)
