### PR TITLE
First attempt at an S3 path_style flag

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -7,7 +7,7 @@ module Fog
       extend Fog::AWS::CredentialFetcher::ServiceMethods
 
       requires :aws_access_key_id, :aws_secret_access_key
-      recognizes :endpoint, :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at
+      recognizes :endpoint, :region, :host, :path, :port, :scheme, :persistent, :use_iam_profile, :aws_session_token, :aws_credentials_expire_at, :path_style
 
       secrets    :aws_secret_access_key, :hmac
 
@@ -294,6 +294,7 @@ module Fog
             @persistent = options.fetch(:persistent, false)
             @port       = options[:port]        || 443
             @scheme     = options[:scheme]      || 'https'
+            @path_style = options[:path_style]  || false
           end
           @connection = Fog::Connection.new("#{@scheme}://#{@host}:#{@port}#{@path}", @persistent, @connection_options)
         end
@@ -324,11 +325,12 @@ DATA
           string_to_sign << canonical_amz_headers
 
           subdomain = params[:host].split(".#{@host}").first
-          unless subdomain =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
-            Fog::Logger.warning("fog: the specified s3 bucket name(#{subdomain}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
+          valid_dns = !!(subdomain =~ /^(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/)
+          if !valid_dns || @path_style
+            Fog::Logger.warning("fog: the specified s3 bucket name(#{subdomain}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html") unless valid_dns
             params[:host] = params[:host].split("#{subdomain}.")[-1]
             if params[:path]
-              params[:path] = "#{subdomain}/#{params[:path]}"
+              params[:path] = "#{subdomain}/#{params[:path]}" unless subdomain == @host
             else
               params[:path] = subdomain
             end


### PR DESCRIPTION
As discussed: https://github.com/fog/fog/issues/1631

The good news: This patch solves my issue.
The bad news: The fix completely depends on the - previously existing - side effects of Storage#signature on the params hash. So it fails during testing, since the method is then mocked. A 'proper' fix would probably involve removing all side-effects on the params[:path], injecting the setting during file/directory model creation and depending on their #url methods completely. Let me know what you think.
