### PR TITLE
[Rackspace|block storage] Support optional `snapshot_id` key when creating volumes

### DIFF
--- a/lib/fog/rackspace/requests/block_storage/create_volume.rb
+++ b/lib/fog/rackspace/requests/block_storage/create_volume.rb
@@ -13,6 +13,7 @@ module Fog
           data['volume']['display_description'] = options[:display_description] unless options[:display_description].nil?
           data['volume']['volume_type'] = options[:volume_type] unless options[:volume_type].nil?
           data['volume']['availability_zone'] = options[:availability_zone] unless options[:availability_zone].nil?
+          data['volume']['snapshot_id'] = options[:snapshot_id] unless options[:snapshot_id].nil?
 
           request(
             :body => Fog::JSON.encode(data),


### PR DESCRIPTION
Usage of snapshot_id is already present in mock, but not within real method.
