### PR TITLE
Add Vcloud support back to Fog::Compute

### DIFF
--- a/lib/fog/compute.rb
+++ b/lib/fog/compute.rb
@@ -35,6 +35,9 @@ module Fog
       when :stormondemand
         require 'fog/storm_on_demand/compute'
         Fog::Compute::StormOnDemand.new(attributes)
+      when :vcloud
+        require 'fog/vcloud/compute'
+        Fog::Vcloud::Compute.new(attributes)
       else
         if self.providers.include?(provider)
           require "fog/#{provider}/compute"


### PR DESCRIPTION
Vcloud does not work with the new cleanup code for generic provider compute support from commit eb0545b7241c61248428c1cda96f7143a83ceaa3.
Would return:
`NameError: uninitialized constant Fog::Compute::Vcloud
    from /usr/local/ruby/lib/ruby/gems/1.9.1/gems/fog-1.10.0/lib/fog/compute.rb:41:in `const_get'
    from /usr/local/ruby/lib/ruby/gems/1.9.1/gems/fog-1.10.0/lib/fog/compute.rb:41:in `new'`
