### PR TITLE
enabled to select the net-id of quantum when you boot the instance.

### DIFF
--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -13,9 +13,19 @@ module Fog
           }
 
           vanilla_options = ['metadata', 'accessIPv4', 'accessIPv6',
-                             'availability_zone', 'user_data', 'key_name', 'adminPass']
+                             'availability_zone', 'user_data', 'key_name', 'adminPass',
+                             'net_id', 'v4_fixed_ip', 'port_id']
           vanilla_options.select{|o| options[o]}.each do |key|
             data['server'][key] = options[key]
+          end
+
+          if options['net_id']
+            data['server']['networks'] = []
+            data['server']['networks'] << {
+              'uuid' => options['net_id'],
+              'fixed_ip' => options['v4_fixed_ip'],
+              'port' => options['port_id']
+            }
           end
 
           if options['security_groups']
@@ -95,6 +105,9 @@ module Fog
             'created'    => '2012-09-27T00:04:18Z',
             'updated'    => '2012-09-27T00:04:27Z',
             'user_id'    => @openstack_username,
+            'net_id'     => '6e6863ce-d60a-4d7b-a8b0-18d790b44e3b',
+            'v4_fixed_ip'=> '172.24.17.30',
+            'port_id'    => '33f95161-845a-4956-ac63-1d39fdf91120'
           }
 
           response_data = {


### PR DESCRIPTION
I enabled to select the net-id of quantum when you boot instances.

http://docs.openstack.org/api/openstack-compute/2/content/CreateServers.html

This OpenStack API Guide does not contain about booting with net-id of quantum. 
So I checked API by executing the 'nova boot --nic' command. 

and This patch also enabled to select 'v4-fixed-ip' and 'port-id'.

I did test with mock and real openstack router of folsom (2012.2.1) release.

Best regards from Tokyo. :D 
