### PR TITLE
enabled to select the net-id of quantum when you boot the instance.

### DIFF
--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -13,8 +13,7 @@ module Fog
           }
 
           vanilla_options = ['metadata', 'accessIPv4', 'accessIPv6',
-                             'availability_zone', 'user_data', 'key_name', 'adminPass',
-                             'net_id', 'v4_fixed_ip', 'port_id']
+                             'availability_zone', 'user_data', 'key_name', 'adminPass']
           vanilla_options.select{|o| options[o]}.each do |key|
             data['server'][key] = options[key]
           end


### PR DESCRIPTION
I enabled to select the net-id of quantum when you boot instances.

http://docs.openstack.org/api/openstack-compute/2/content/CreateServers.html

This OpenStack API Guide does not contain about booting with net-id of quantum. 
So I checked API by executing the 'nova boot --nic' command. 

and This patch also enabled to select 'v4-fixed-ip' and 'port-id'.

I did test with mock and real OpenStack router of folsom (2012.2.1) release.

If you boot with fog like this, you can select the net-id.

```
@compute.create_server('fogtest05', image_id, flavor_id, {'net_id' => uuid, 'v4_fixed_ip' => ip, 'port_id' => port})
```

or

```
@compute.create_server('fogtest05', image_id, flavor_id, {'net_id' => uuid})
```

Best Regards from Tokyo. :D 
