### PR TITLE
Stop hardcoding the server's ssh port.

### DIFF
--- a/lib/fog/compute/models/server.rb
+++ b/lib/fog/compute/models/server.rb
@@ -4,7 +4,7 @@ module Fog
   module Compute
     class Server < Fog::Model
 
-      attr_writer :username, :private_key, :private_key_path, :public_key, :public_key_path
+      attr_writer :username, :private_key, :private_key_path, :public_key, :public_key_path, :ssh_port
 
       def username
         @username ||= 'root'
@@ -28,6 +28,9 @@ module Fog
         @public_key ||= public_key_path && File.read(public_key_path)
       end
 
+      def ssh_port
+        @ssh_port ||= 22
+      end
 
       def scp(local_path, remote_path, upload_options = {})
         require 'net/scp'
@@ -56,10 +59,6 @@ module Fog
         options[:key_data] = [private_key] if private_key
         options[:port] ||= ssh_port
         Fog::SSH.new(public_ip_address, username, options).run(commands, &blk)
-      end
-
-      def ssh_port
-        22
       end
 
       def sshable?(options={})


### PR DESCRIPTION
Because people might want to run ssh in a different port.
