### PR TITLE
Add block handlers for SCP

### DIFF
--- a/lib/fog/core/scp.rb
+++ b/lib/fog/core/scp.rb
@@ -66,11 +66,11 @@ module Fog
         @options  = { :paranoid => false }.merge(options)
       end
 
-      def upload(local_path, remote_path, upload_options = {})
+      def upload(local_path, remote_path, upload_options = {}, &block)
         begin
           Net::SCP.start(@address, @username, @options) do |scp|
             scp.upload!(local_path, remote_path, upload_options) do |ch, name, sent, total|
-              # TODO: handle progress display?
+              block.call(ch, name, sent, total) if block
             end
           end
         rescue Exception => error
@@ -82,7 +82,7 @@ module Fog
         begin
           Net::SCP.start(@address, @username, @options) do |scp|
             scp.download!(remote_path, local_path, download_options) do |ch, name, sent, total|
-              # TODO: handle progress display?
+              block.call(ch, name, sent, total) if block
             end
           end
         rescue Exception => error


### PR DESCRIPTION
This allows to use a block to handle scp data callbacks, so you can do something like this:

``` ruby
server.scp(local_path, remote_path) do |ch, name, sent, total|
   # use data here
end
```
