### PR TITLE
Forcing good version of Excon

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
   s.add_dependency('builder')
-  s.add_dependency('excon', '~>0.14')
+  s.add_dependency('excon', '~>0.20')
   s.add_dependency('formatador', '~>0.2.0')
   s.add_dependency('multi_json', '~>1.0')
   s.add_dependency('mime-types')


### PR DESCRIPTION
The old gemspec allow a buggy version of Excon (0.19.2) and fog may not work properly.
