### PR TITLE
[vsphere] fix bug where servers.all was ignoring filters due to hash merging in the wrong direction

### DIFF
--- a/lib/fog/vsphere/models/compute/servers.rb
+++ b/lib/fog/vsphere/models/compute/servers.rb
@@ -17,13 +17,15 @@ module Fog
         # 'folder' => '/Datacenters/vm/Jeff/Templates' will be MUCH faster.
         # than simply listing everything.
         def all(filters = { })
-          load service.list_virtual_machines(filters.merge(
-                                                  :datacenter    => datacenter,
-                                                  :cluster       => cluster,
-                                                  :network       => network,
-                                                  :resource_pool => resource_pool,
-                                                  :folder        => folder
-                                                ))
+          f = {
+            :datacenter    => datacenter,
+            :cluster       => cluster,
+            :network       => network,
+            :resource_pool => resource_pool,
+            :folder        => folder
+          }.merge(filters)
+
+          load service.list_virtual_machines(f)
         end
 
         def get(id, datacenter = nil)
@@ -31,9 +33,7 @@ module Fog
         rescue Fog::Compute::Vsphere::NotFound
           nil
         end
-
       end
-
     end
   end
 end


### PR DESCRIPTION
passing a filters hash to connection.servers.all was being ignored due to the hash merge happening in the wrong direction.
After the merge :folders, :datacenters etc was empty.

This swaps the merge around and is now working as I would expect.
Thanks @ohadlevy confirming my thoughts on this.
