### PR TITLE
[libvirt|compute] handle missing <system> tag in libvirt node info

### DIFF
--- a/lib/fog/libvirt/requests/compute/get_node_info.rb
+++ b/lib/fog/libvirt/requests/compute/get_node_info.rb
@@ -14,7 +14,7 @@ module Fog
           node_hash[:uri] = client.uri
           xml = client.sys_info rescue nil
           [:uuid, :manufacturer, :product, :serial].each do |attr|
-            node_hash[attr] = node_attr(attr, xml)
+            node_hash[attr] = node_attr(attr, xml) rescue nil
           end if xml
 
           node_hash[:hostname] = client.hostname


### PR DESCRIPTION
Fixes #1652: libvirt provider requires a field that libvirt specifies as
optional
