### PR TITLE
Rackspace Node Model - variable collection does not contain instance of load balancer

### DIFF
--- a/lib/fog/rackspace/models/load_balancers/node.rb
+++ b/lib/fog/rackspace/models/load_balancers/node.rb
@@ -30,8 +30,9 @@ module Fog
 
         private
         def load_balancer
-          collection.load_balancer
+          @attributes[:load_balancer]
         end
+        
         def create
           requires :load_balancer, :address, :condition, :port
           options = {}


### PR DESCRIPTION
The following error is observed while trying to create a new node:

<pre>
/gems/fog-1.10.0/lib/fog/rackspace/models/load_balancers/node.rb:41:in `create': undefined method `id' for nil:NilClass (NoMethodError)
/gems/fog-1.10.0/lib/fog/rackspace/models/load_balancers/node.rb:26:in `save'
</pre>


I've attached code that replaces collection.load_balancer with @attribute[:load_balancer] which seems to fix the problem, but I'm not sure if this is the best method.
