### PR TITLE
[VMWare] Fixed broken support for obj_ids with spaces.

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -152,7 +152,7 @@ module Fog
 
         # returns vmware managed obj id string
         def managed_obj_id obj
-          obj.to_s.match(/\("(\S+)"\)/)[1]
+          obj.to_s.match(/\("([^"]+)"\)/)[1]
         end
 
       end


### PR DESCRIPTION
Might cure the illness reported in issue https://github.com/fog/fog/issues/1671.
