### PR TITLE
[core] Updated to make ssh timeout user configurable.

### DIFF
--- a/lib/fog/core/ssh.rb
+++ b/lib/fog/core/ssh.rb
@@ -46,7 +46,7 @@ module Fog
           raise ArgumentError.new(':key_data, :keys, :password or a loaded ssh-agent is required to initialize SSH')
         end
 
-        options[:timeout] = 30
+        options[:timeout] ||= 30
         if options[:key_data] || options[:keys]
           options[:keys_only] = true
           #Explicitly set these so net-ssh doesn't add the default keys


### PR DESCRIPTION
Updated to make ssh timeout user configurable. This should address issue https://github.com/fog/fog/issues/1681.

@geemus Can you take a look at this?
