### PR TITLE
Add support for AWS bucket website redirects

### DIFF
--- a/lib/fog/aws/parsers/storage/get_bucket_website.rb
+++ b/lib/fog/aws/parsers/storage/get_bucket_website.rb
@@ -2,9 +2,11 @@ module Fog
   module Parsers
     module Storage
       module AWS
+
+        # http://docs.aws.amazon.com/AmazonS3/latest/API/RESTBucketGETwebsite.html
         class GetBucketWebsite < Fog::Parsers::Base
           def reset
-            @response = { 'ErrorDocument' => {}, 'IndexDocument' => {} }
+            @response = { 'ErrorDocument' => {}, 'IndexDocument' => {}, 'RedirectAllRequestsTo' => {} }
           end
 
           def end_element(name)
@@ -13,6 +15,8 @@ module Fog
               @response['ErrorDocument'][name] = value
             when 'Suffix'
               @response['IndexDocument'][name] = value
+            when 'HostName'
+              @response['RedirectAllRequestsTo'][name] = value
             end
           end
         end

--- a/lib/fog/aws/requests/storage/put_bucket_website.rb
+++ b/lib/fog/aws/requests/storage/put_bucket_website.rb
@@ -5,28 +5,56 @@ module Fog
         # Change website configuration for an S3 bucket
         #
         # @param bucket_name [String] name of bucket to modify
-        # @param suffix [String] suffix to append to requests for the bucket
         # @param options [Hash]
-        # @option options key [String] key to use for 4XX class errors
+        # @option options RedirectAllRequestsTo [String] Host name to redirect all requests to - if this is set, other options are ignored
+        # @option options IndexDocument [String] suffix to append to requests for the bucket
+        # @option options ErrorDocument [String] key to use for 4XX class errors
         #
         # @see http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTBucketPUTwebsite.html
 
-        def put_bucket_website(bucket_name, suffix, options = {})
-          data =
-<<-DATA
-<WebsiteConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
-    <IndexDocument>
-        <Suffix>#{suffix}</Suffix>
-    </IndexDocument>
-DATA
+        def put_bucket_website(bucket_name, options, options_to_be_deprecated = {})
+          options ||= {}
 
-          if options[:key]
-            data <<
-<<-DATA
-<ErrorDocument>
-    <Key>#{options[:key]}</Key>
-</ErrorDocument>
-DATA
+          # Method used to be called with the suffix as the second parameter. Warn user that this is not the case any more and move on
+          if options.is_a?(String)
+            Fog::Logger.deprecation("put_bucket_website with #{options.class} param is deprecated, use put_bucket_website('#{bucket_name}', :IndexDocument => '#{options}') instead [light_black](#{caller.first})[/]")
+            options = { :IndexDocument => options }
+          end
+
+          # Parameter renamed from "key" to "ErrorDocument"
+          if options_to_be_deprecated[:key]
+            Fog::Logger.deprecation("put_bucket_website with three parameters is deprecated, use put_bucket_website('#{bucket_name}', :ErrorDocument => '#{options_to_be_deprecated[:key]}') instead [light_black](#{caller.first})[/]")
+            options[:ErrorDocument] = options_to_be_deprecated[:key]
+          end
+
+          options.merge!(options_to_be_deprecated) { |key, o1, o2| o1 }
+
+          data = "<WebsiteConfiguration xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
+
+          if options[:RedirectAllRequestsTo]
+            # Redirect precludes all other options
+            data << <<-DATA
+                      <RedirectAllRequestsTo>
+                        <HostName>#{options[:RedirectAllRequestsTo]}</HostName>
+                      </RedirectAllRequestsTo>
+                    DATA
+          else
+
+            if options[:IndexDocument]
+            data << <<-DATA
+                      <IndexDocument>
+                        <Suffix>#{options[:IndexDocument]}</Suffix>
+                      </IndexDocument>
+                    DATA
+            end
+
+            if options[:ErrorDocument]
+              data << <<-DATA
+                        <ErrorDocument>
+                          <Key>#{options[:ErrorDocument]}</Key>
+                        </ErrorDocument>
+                      DATA
+            end
           end
 
           data << '</WebsiteConfiguration>'

--- a/tests/aws/requests/storage/bucket_tests.rb
+++ b/tests/aws/requests/storage/bucket_tests.rb
@@ -68,7 +68,7 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
 
     tests("#head_bucket('#{@aws_bucket_name}')").succeeds do
       Fog::Storage[:aws].head_bucket(@aws_bucket_name)
-    end 
+    end
 
     file.destroy
 
@@ -137,8 +137,17 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
       Fog::Storage[:aws].put_request_payment(@aws_bucket_name, 'Requester')
     end
 
+    # This should show a warning, but work (second parameter is options hash for now)
     tests("#put_bucket_website('#{@aws_bucket_name}', 'index.html')").succeeds do
       Fog::Storage[:aws].put_bucket_website(@aws_bucket_name, 'index.html')
+    end
+
+    tests("#put_bucket_website('#{@aws_bucket_name}', :IndexDocument => 'index.html')").succeeds do
+      Fog::Storage[:aws].put_bucket_website(@aws_bucket_name, :IndexDocument => 'index.html')
+    end
+
+    tests("#put_bucket_website('#{@aws_bucket_name}', :RedirectAllRequestsTo => 'redirect.example..com')").succeeds do
+      Fog::Storage[:aws].put_bucket_website(@aws_bucket_name, :RedirectAllRequestsTo => 'redirect.example.com')
     end
 
     tests("#put_bucket_acl('#{@aws_bucket_name}', 'private')").succeeds do
@@ -358,6 +367,11 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
         storage_eu_endpoint.put_bucket(@aws_bucket_name)
       end
     end
+
+    tests("#put_bucket_website('fognonbucket', :RedirectAllRequestsTo => 'redirect.example.com')").raises(Excon::Errors::NotFound) do
+      Fog::Storage[:aws].put_bucket_website('fognonbucket', :RedirectAllRequestsTo => 'redirect.example.com')
+    end
+
   end
 
   # don't keep the bucket around


### PR DESCRIPTION
S3 buckets can redirect all requests to another host name (useful for static website hosting).
Since I could not find support for this in Fog, I added it.

To use, add :redirect_to => REDIRECT_TARGET to options hash for
put_bucket_website, e.g.: `connection.put_bucket_website("www.example.com", nil, :redirect_to => "example.com")`

To my eternal shame I have to confess that I have no idea how to write a spec for this, and looking at the existing put_bucket_website didn't help me any.
