### PR TITLE
Fix for AWS error message regex not matching `Code` correctly

### DIFF
--- a/lib/fog/aws/auto_scaling.rb
+++ b/lib/fog/aws/auto_scaling.rb
@@ -151,7 +151,7 @@ module Fog
               :parser     => parser
             })
           rescue Excon::Errors::HTTPStatusError => error
-            if match = error.message.match(/<Code>(.*)<\/Code>.*<Message>(.*)<\/Message>/)
+            if match = error.message.match(/(?:.*<Code>(.*)<\/Code>)(?:.*<Message>(.*)<\/Message>)/m)
               case match[1]
               when 'AlreadyExists'
                 #raise Fog::AWS::AutoScaling::IdentifierTaken.new(match[2])

--- a/lib/fog/aws/beanstalk.rb
+++ b/lib/fog/aws/beanstalk.rb
@@ -131,7 +131,7 @@ module Fog
                 :parser     => parser
             })
           rescue Excon::Errors::HTTPStatusError => error
-            if match = error.response.body.match(/<Code>(.*)<\/Code>[ \t\n]*<Message>(.*)<\/Message>/)
+            if match = error.message.match(/(?:.*<Code>(.*)<\/Code>)(?:.*<Message>(.*)<\/Message>)/m)
               raise case match[1].split('.').last
                       when 'InvalidParameterValue'
                         Fog::AWS::ElasticBeanstalk::InvalidParameterError.slurp(error, match[2])

--- a/lib/fog/aws/cloud_formation.rb
+++ b/lib/fog/aws/cloud_formation.rb
@@ -106,7 +106,7 @@ module Fog
               :parser     => parser
             })
           rescue Excon::Errors::HTTPStatusError => error
-            if match = error.message.match(/<Code>(.*)<\/Code><Message>(.*)<\/Message>/)
+            if match = error.message.match(/(?:.*<Code>(.*)<\/Code>)(?:.*<Message>(.*)<\/Message>)/m)
               raise case match[1].split('.').last
               when 'NotFound'
                 Fog::AWS::Compute::NotFound.slurp(error, match[2])

--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -391,7 +391,7 @@ module Fog
               :parser     => parser
             })
         rescue Excon::Errors::HTTPStatusError => error
-          if match = error.message.match(/<Code>(.*)<\/Code><Message>(.*)<\/Message>/)
+          if match = error.message.match(/(?:.*<Code>(.*)<\/Code>)(?:.*<Message>(.*)<\/Message>)/m)
             raise case match[1].split('.').last
                   when 'NotFound', 'Unknown'
                     Fog::Compute::AWS::NotFound.slurp(error, match[2])

--- a/lib/fog/aws/elasticache.rb
+++ b/lib/fog/aws/elasticache.rb
@@ -104,7 +104,7 @@ module Fog
               :parser     => parser
             })
           rescue Excon::Errors::HTTPStatusError => error
-            if match = error.message.match(/<Code>(.*)<\/Code>/m)
+            if match = error.message.match(/(?:.*<Code>(.*)<\/Code>?)/m)
               case match[1]
               when 'CacheSecurityGroupNotFound', 'CacheParameterGroupNotFound',
                 'CacheClusterNotFound'

--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -191,7 +191,7 @@ module Fog
             :parser     => parser
           })
         rescue Excon::Errors::HTTPStatusError => error
-          if match = error.message.match(/<Code>(.*)<\/Code>(?:.*<Message>(.*)<\/Message>)?/m)
+          if match = error.message.match(/(?:.*<Code>(.*)<\/Code>)(?:.*<Message>(.*)<\/Message>)/m)
             case match[1]
             when 'CertificateNotFound'
               raise Fog::AWS::IAM::NotFound.slurp(error, match[2])

--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -205,7 +205,7 @@ module Fog
             :parser     => parser
           })
         rescue Excon::Errors::HTTPStatusError => error
-          if match = error.message.match(/<Code>(.*)<\/Code>(?:.*<Message>(.*)<\/Message>)?/m)
+          if match = error.message.match(/(?:.*<Code>(.*)<\/Code>)(?:.*<Message>(.*)<\/Message>)/m)
             case match[1]
             when 'CertificateNotFound', 'NoSuchEntity'
               raise Fog::AWS::IAM::NotFound.slurp(error, match[2])

--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -206,7 +206,7 @@ module Fog
               :parser     => parser
             })
           rescue Excon::Errors::HTTPStatusError => error
-            if match = error.message.match(/<Code>(.*)<\/Code>[\s\\\w]+<Message>(.*)<\/Message>/m)
+            if match = error.message.match(/(?:.*<Code>(.*)<\/Code>)(?:.*<Message>(.*)<\/Message>)/m)
               case match[1].split('.').last
               when 'DBInstanceNotFound', 'DBParameterGroupNotFound', 'DBSnapshotNotFound', 'DBSecurityGroupNotFound'
                 raise Fog::AWS::RDS::NotFound.slurp(error, match[2])

--- a/lib/fog/aws/sts.rb
+++ b/lib/fog/aws/sts.rb
@@ -114,7 +114,7 @@ module Fog
 
             response
           rescue Excon::Errors::HTTPStatusError => error
-            if match = error.message.match(/<Code>(.*)<\/Code>(?:.*<Message>(.*)<\/Message>)?/m)
+            if match = error.message.match(/(?:.*<Code>(.*)<\/Code>)(?:.*<Message>(.*)<\/Message>)/m)
               case match[1]
               when 'EntityAlreadyExists', 'KeyPairMismatch', 'LimitExceeded', 'MalformedCertificate', 'ValidationError'
                 raise Fog::AWS::STS.const_get(match[1]).slurp(error, match[2])


### PR DESCRIPTION
The regular expression `<Code>(.*)<\/Code>(?:.*<Message>(.*)<\/Message>)` isn't matching the `Code` portion correctly in the error handling of `_request` methods of the various AWS classes.

As a consequence, the incorrect exception is raised from these methods. For example, the `get` method for users should return `nil` for a non-existent user, but instead `Fog::AWS::IAM::Error` is raised.

``` ruby
iam = Fog::AWS::IAM.new({:provider => 'AWS', :aws_access_key_id => ACCESS_KEY_ID, :aws_secret_access_key => SECRET_ACCESS_KEY})
user = iam.users.get('non_existent_user')
user.should be_nil
```

I've looked at what has changed in Fog, excon and the AWS SDK to see why the regex used to work, but am unable to figure it out.

However, by changing to regex to match `(?:.*<Code>(.*)<\/Code>)(?:.*<Message>(.*)<\/Message>)` the error handling logic in [Fog::AWS:IAM::Real#_request](https://github.com/fog/fog/blob/master/lib/fog/aws/iam.rb#L197) works as expected.
