### PR TITLE
Remove the OpenStack API cache busting.

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -338,7 +338,7 @@ module Fog
               }.merge!(params[:headers] || {}),
               :host     => @host,
               :path     => "#{@path}/#{@tenant_id}/#{params[:path]}",
-              :query    => params[:query] || ('ignore_awful_caching' << Time.now.to_i.to_s)
+              :query    => params[:query]
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration

--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -230,8 +230,6 @@ module Fog
               }.merge!(params[:headers] || {}),
               :host     => @host,
               :path     => "#{@path}/#{params[:path]}"#,
-              # Causes errors for some requests like tenants?limit=1
-              # :query    => ('ignore_awful_caching' << Time.now.to_i.to_s)
             }))
           rescue Excon::Errors::Unauthorized => error
             raise if retried

--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -148,8 +148,6 @@ module Fog
               }.merge!(params[:headers] || {}),
               :host     => @host,
               :path     => "#{@path}/#{params[:path]}"#,
-              # Causes errors for some requests like tenants?limit=1
-              # :query    => ('ignore_awful_caching' << Time.now.to_i.to_s)
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -168,8 +168,6 @@ module Fog
               }.merge!(params[:headers] || {}),
               :host     => @host,
               :path     => "#{@path}/#{params[:path]}"#,
-              # Causes errors for some requests like tenants?limit=1
-              # :query    => ('ignore_awful_caching' << Time.now.to_i.to_s)
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -150,8 +150,6 @@ module Fog
               }.merge!(params[:headers] || {}),
               :host     => @host,
               :path     => "#{@path}/#{params[:path]}"#,
-              # Causes errors for some requests like tenants?limit=1
-              # :query    => ('ignore_awful_caching' << Time.now.to_i.to_s)
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration

--- a/lib/fog/rackspace/compute.rb
+++ b/lib/fog/rackspace/compute.rb
@@ -210,7 +210,6 @@ module Fog
               }.merge!(params[:headers] || {}),
               :host     => endpoint_uri.host,
               :path     => "#{endpoint_uri.path}/#{params[:path]}",
-              :query    => ('ignore_awful_caching' << Time.now.to_i.to_s)
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration


### PR DESCRIPTION
Not sure why this was ever here, and I cannot find a reason to continuously bust
the Nova request caching in the wsgi request handler. It does not help
performance, and makes attempts at ANY caching of responses of a Fog request
annoying.
