### PR TITLE
[openstack] Retrieve supported API version for Image & Network services

### DIFF
--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -3,6 +3,8 @@ require 'fog/openstack'
 module Fog
   module Image
     class OpenStack < Fog::Service
+      SUPPORTED_VERSIONS = /v1(\.(0|1))*/
+
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_type, :openstack_service_name, :openstack_tenant,
@@ -206,9 +208,11 @@ module Fog
           @host   = uri.host
           @path   = uri.path
           @path.sub!(/\/$/, '')
-          unless @path.match(/v1(\.1)*/)
-            raise Fog::OpenStack::Errors::ServiceUnavailable.new(
-                  "OpenStack binding only supports version 1.1 (a.k.a. 1)")
+          unless @path.match(SUPPORTED_VERSIONS)
+            @path = "/" + Fog::OpenStack.get_supported_version(SUPPORTED_VERSIONS,
+                                                               uri,
+                                                               @auth_token,
+                                                               @connection_options)
           end
           @port   = uri.port
           @scheme = uri.scheme

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -3,6 +3,7 @@ require 'fog/openstack'
 module Fog
   module Network
     class OpenStack < Fog::Service
+      SUPPORTED_VERSIONS = /v2(\.0)*/
 
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
@@ -225,33 +226,15 @@ module Fog
           @host   = uri.host
           @path   = uri.path
           @path.sub!(/\/$/, '')
-          unless @path.match(/^\/v(\d)+(\.)?(\d)*$/)
-            @path = "/" + retrieve_current_version(uri)
+          unless @path.match(SUPPORTED_VERSIONS)
+            @path = "/" + Fog::OpenStack.get_supported_version(SUPPORTED_VERSIONS,
+                                                               uri,
+                                                               @auth_token,
+                                                               @connection_options)
           end
           @port   = uri.port
           @scheme = uri.scheme
           true
-        end
-
-        def retrieve_current_version(uri)
-          response = Fog::Connection.new(
-            "#{uri.scheme}://#{uri.host}:#{uri.port}", false, @connection_options).request({
-              :expects => [200, 204],
-              :headers => {'Content-Type' => 'application/json',
-                           'Accept' => 'application/json',
-                           'X-Auth-Token' => @auth_token},
-              :host    => uri.host,
-              :method  => 'GET'
-          })
-
-          body = Fog::JSON.decode(response.body)
-          version = nil
-          unless body['versions'].empty?
-            current_version = body['versions'].detect { |x| x["status"] == "CURRENT" }
-            version = current_version["id"]
-          end
-          raise Errors::NotFound.new('No API versions found') if version.nil?
-          version
         end
 
       end

--- a/tests/openstack/version_tests.rb
+++ b/tests/openstack/version_tests.rb
@@ -1,0 +1,55 @@
+Shindo.tests('OpenStack | versions', ['openstack']) do
+  begin
+    @old_mock_value = Excon.defaults[:mock]
+    Excon.defaults[:mock] = true
+    Excon.stubs.clear
+
+    body = {
+        "versions" => [
+            { "status" => "CURRENT", "id" => "v2.0", "links" => [ {
+                                                                      "href" => "http://example:9292/v2/",
+                                                                      "rel" => "self" }
+                                                                ]
+            },
+            { "status" => "CURRENT", "id" => "v1.1", "links" => [ {
+                                                                      "href" => "http://exampple:9292/v1/",
+                                                                      "rel" => "self"
+                                                                  }
+                                                                ]
+            },
+            { "status" => "SUPPORTED", "id"=>"v1.0", "links" => [ {
+                                                                      "href" => "http://example:9292/v1/",
+                                                                      "rel" => "self"
+                                                                  }
+                                                                ]
+            }
+        ]
+    }
+
+    tests("supported") do
+      Excon.stub({ :method => 'GET' },
+                 { :status => 300, :body => Fog::JSON.encode(body) })
+
+      returns("v1.1") do
+        Fog::OpenStack.get_supported_version(/v1(\.(0|1))*/,
+                                             URI('http://example/'),
+                                             "authtoken")
+      end
+    end
+
+    tests("unsupported") do
+      Excon.stub({ :method => 'GET' },
+                 { :status => 300, :body => Fog::JSON.encode(body) })
+
+      raises(Fog::OpenStack::Errors::ServiceUnavailable) do
+        Fog::OpenStack.get_supported_version(/v3(\.(0|1))*/,
+                                             URI('http://example/'),
+                                             "authtoken")
+      end
+    end
+
+  ensure
+    Excon.stubs.clear
+    Excon.defaults[:mock] = @old_mock_value
+  end
+end


### PR DESCRIPTION
Some environments don't set the API version for endpoints in service catalog (as a default glance or quantum endpoint in a devstack env), so if you try to use Fog::Image of Fog::Network it'll fail with a 300 (Multiple Choices) error. Also, Fog doesn't support some latest API versions (i.e. glance v2).

Instead of failing, Fog will now check if the service catalog returns an API version and if it is supported by Fog. If not, it'll try to retrieve the supported API endpoint.
