### PR TITLE
restore ability to load fog from source without bundler

### DIFF
--- a/lib/fog.rb
+++ b/lib/fog.rb
@@ -1,3 +1,8 @@
+# necessary when requiring fog without rubygems while also
+# maintaining ruby 1.8.7 support (can't use require_relative)
+__LIB_DIR__ = File.expand_path(File.dirname(__FILE__))
+$LOAD_PATH.unshift __LIB_DIR__ unless $LOAD_PATH.include?(__LIB_DIR__)
+
 # any one of these can be required separately.
 # they all depend on fog/core for shared functionality.
 require 'fog/atmos'

--- a/lib/fog/core.rb
+++ b/lib/fog/core.rb
@@ -1,8 +1,3 @@
-__LIB_DIR__ = File.expand_path(File.join(File.dirname(__FILE__), '..'))
-
-$LOAD_PATH.unshift __LIB_DIR__ unless
-  $LOAD_PATH.include?(__LIB_DIR__)
-
 # external core dependencies
 require 'base64'
 require 'cgi'


### PR DESCRIPTION
from discussion on e5c438a20661d7d71b5e583edf7cbadabab6d43b (@krames @geemus)

This should restore the ability to load fog from source without bundler. It does not add support for requiring individual fog providers by source without bundler, since that would require adding this load path hack to each provider's file. Let me know if I should do that?
