### PR TITLE
[digitalocean] Check to see if digitalocean_api_key exists before running exit code

### DIFF
--- a/tests/digitalocean/helper.rb
+++ b/tests/digitalocean/helper.rb
@@ -32,7 +32,7 @@ def fog_test_server_destroy
 end
 
 at_exit do
-  unless Fog.mocking?
+  unless Fog.mocking? || Fog.credentials[:digitalocean_api_key].nil?
     server = service.servers.find { |s| s.name == 'fog-test-server' }
     if server
       server.wait_for(120) do


### PR DESCRIPTION
When running a tests without mocking I get the following exception:

/Users/kyle.rames/Projects/fog/lib/fog/core/service.rb:208:in `validate_options': Missing required arguments: digitalocean_api_key, digitalocean_client_id (ArgumentError)
    from /Users/kyle.rames/Projects/fog/lib/fog/core/service.rb:58:in`new'
    from /Users/kyle.rames/Projects/fog/lib/fog/compute.rb:44:in `new'
    from /Users/kyle.rames/Projects/fog/lib/fog/compute.rb:5:in`[]'
    from tests/digitalocean/helper.rb:4:in `service'
    from tests/digitalocean/helper.rb:36:in`block in <top (required)>'

This pull request checks to see if we are mocking and if a digitalocean_api_key before attempting to delete servers.
