### PR TITLE
[vsphere] allow setting ram and num of cpu when cloning

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -186,7 +186,17 @@ module Fog
               :nicSettingMap => cust_adapter_mapping)
           end
           customization_spec ||= nil
-          
+
+          # FIXME: pad this out with the rest of the useful things in VirtualMachineConfigSpec
+          # http://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.ConfigSpec.html
+          #          
+          if options.has_key?('memoryMB') || options.has_key?('numCPUs')
+            virtual_machine_config_spec = {
+              :memoryMB => options['memoryMB'],
+              :numCPUs  => options['numCPUs']
+            }
+          end
+
           relocation_spec=nil
           if ( options['linked_clone'] )
             # cribbed heavily from the rbvmomi clone_vm.rb

--- a/tests/vsphere/requests/compute/vm_clone_tests.rb
+++ b/tests/vsphere/requests/compute/vm_clone_tests.rb
@@ -16,6 +16,16 @@ Shindo.tests("Fog::Compute[:vsphere] | vm_clone request", 'vsphere') do
 
   template = "folder/rhel64"
   datacenter = "Solutions"
+  tests("Standard Clone setting ram and cpu | The return value should") do
+    response = compute.vm_clone('datacenter' => datacenter, 'template_path' => template, 'name' => 'cloning_vm', 'memoryMB' => '8192', 'numCPUs' => '8', 'wait' => true)
+    test("be a kind of Hash") { response.kind_of? Hash }
+    %w{ vm_ref task_ref }.each do |key|
+      test("have a #{key} key") { response.has_key? key }
+    end
+  end
+
+  template = "folder/rhel64"
+  datacenter = "Solutions"
   tests("Linked Clone | The return value should") do
     response = compute.vm_clone('datacenter' => datacenter, 'template_path' => template, 'name' => 'cloning_vm_linked', 'wait' => 1, 'linked_clone' => true)
     test("be a kind of Hash") { response.kind_of? Hash }


### PR DESCRIPTION
builds a `virtual_machine_config_spec` with memoryMB + numCPUs when cloning if they are passed in as options.

eg:

``` ruby
#!/usr/bin/env ruby

require 'fog'
require 'pp'

connection = Fog::Compute[:vsphere]

options = { 
  'datacenter'          => 'syd07',
  'dest_folder'         => 'foo',
  'template_path'       => 'templates/ubuntu-precise-amd64',
  'name'                => 'bar-web-11',
  'resource_pool'       => ['cluster1','resource pool 2'],
  'memoryMB'            => '8192',
  'numCPUs'             => 4,
  'power_on'            => true,
  'wait'                => true
}

new_vm=connection.vm_clone(req_options)
pp new_vm

```
