### PR TITLE
[vsphere|compute] cleanup merge conflicts with clone method

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -146,6 +146,8 @@ module Fog
           # Options['numCPUs'] or Options['memoryMB']
           # Build up the specification for Hardware, for more details see ____________
           # https://github.com/rlane/rbvmomi/blob/master/test/test_serialization.rb
+          # http://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.ConfigSpec.html
+          # FIXME: pad this out with the rest of the useful things in VirtualMachineConfigSpec
           virtual_machine_config_spec.numCPUs = options['numCPUs'] if  ( options.has_key?('numCPUs') )
           virtual_machine_config_spec.memoryMB = options['memoryMB'] if ( options.has_key?('memoryMB') )
 
@@ -194,15 +196,6 @@ module Fog
               :nicSettingMap => cust_adapter_mapping)
           end
           customization_spec ||= nil
-
-          # FIXME: pad this out with the rest of the useful things in VirtualMachineConfigSpec
-          # http://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.vm.ConfigSpec.html
-          if options.has_key?('memoryMB') || options.has_key?('numCPUs')
-            virtual_machine_config_spec = {
-              :memoryMB => options['memoryMB'],
-              :numCPUs  => options['numCPUs']
-            }
-          end
 
           relocation_spec=nil
           if ( options['linked_clone'] )


### PR DESCRIPTION
@mingjin's PR and my PR clashed and we ended up with `virtual_machine_config_spec` being set twice.
@jeffmccune  this just cleans it up.

I missed his waiting PR before sending my own. I will try better to not duplicate effort next time.
