### PR TITLE
[vsphere|compute] fix incorrect filters.merge in networks model

### DIFF
--- a/lib/fog/vsphere/models/compute/networks.rb
+++ b/lib/fog/vsphere/models/compute/networks.rb
@@ -11,14 +11,14 @@ module Fog
         attr_accessor :datacenter
 
         def all(filters = {})
-          load service.list_networks(filters.merge(:datacenter => datacenter))
+          f = { :datacenter => datacenter }.merge(filters)
+          load service.list_networks(f)
         end
 
         def get(id)
           requires :datacenter
           new service.get_network(id, datacenter)
         end
-
       end
     end
   end


### PR DESCRIPTION
when requesting a list of networks options { :datacenter } was being ignored due to filters{} being merged in the wrong direction.

@jeffmccune thanks for your help with these.
