### PR TITLE
[openstack|volume] Added quota requests for Cinder

### DIFF
--- a/lib/fog/openstack/requests/volume/get_quota.rb
+++ b/lib/fog/openstack/requests/volume/get_quota.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Volume
+    class OpenStack
+      class Real
+
+        def get_quota(tenant_id)
+          request(
+            :expects  => 200,
+            :method   => 'GET',
+            :path     => "/os-quota-sets/#{tenant_id}"
+          )
+        end
+
+      end
+
+      class Mock
+
+        def get_quota(tenant_id)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            'quota_set' => (self.data[:quota_updated] or self.data[:quota]).merge({'id' => tenant_id})
+          }
+          response
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/volume/get_quota_defaults.rb
+++ b/lib/fog/openstack/requests/volume/get_quota_defaults.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Volume
+    class OpenStack
+      class Real
+
+        def get_quota_defaults(tenant_id)
+          request(
+            :expects  => 200,
+            :method   => 'GET',
+            :path     => "/os-quota-sets/#{tenant_id}/defaults"
+          )
+        end
+
+      end
+
+      class Mock
+
+        def get_quota_defaults(tenant_id)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            'quota_set' => self.data[:quota].merge({'id' => tenant_id})
+          }
+          response
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/volume/update_quota.rb
+++ b/lib/fog/openstack/requests/volume/update_quota.rb
@@ -1,0 +1,32 @@
+module Fog
+  module Volume
+    class OpenStack
+      class Real
+
+        def update_quota(tenant_id, options = {})
+          options['tenant_id'] = tenant_id
+          request(
+            :body => Fog::JSON.encode({ 'quota_set' => options }),
+            :expects => 200,
+            :method => 'PUT',
+            :path => "/os-quota-sets/#{tenant_id}"
+          )
+        end
+
+      end
+
+      class Mock
+
+        def update_quota(tenant_id, options = {})
+          self.data[:quota_updated] = self.data[:quota].merge options
+
+          response = Excon::Response.new
+          response.status = 200
+          response.body = { 'quota_set' => self.data[:quota_updated] }
+          response
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -29,6 +29,10 @@ module Fog
       request :list_snapshots
       request :get_snapshot_details
       request :delete_snapshot
+ 
+      request :update_quota
+      request :get_quota
+      request :get_quota_defaults
 
       request :set_tenant
 
@@ -37,7 +41,12 @@ module Fog
           @data ||= Hash.new do |hash, key|
             hash[key] = {
               :users => {},
-              :tenants => {}
+              :tenants => {},
+              :quota => {
+                'gigabytes' => 1000,
+                'volumes'   => 10,
+                'snapshots' => 10
+              }
             }
           end
         end

--- a/tests/openstack/requests/volume/quota_tests.rb
+++ b/tests/openstack/requests/volume/quota_tests.rb
@@ -1,0 +1,51 @@
+Shindo.tests('Fog::Volume[:openstack] | quota requests', ['openstack']) do
+
+  @tenant_id = Fog::Compute[:openstack].list_tenants.body['tenants'].first['id']
+  @quota_set_format = {
+    'volumes'   => Fog::Nullable::Integer,
+    'gigabytes' => Fog::Nullable::Integer,
+    'snapshots' => Fog::Nullable::Integer,
+    'id'        => String
+  }
+
+  tests('success') do
+
+    tests('#get_quota_defaults').formats({ 'quota_set' => @quota_set_format }) do
+      Fog::Volume[:openstack].get_quota_defaults(@tenant_id).body
+    end
+
+    tests('#get_quota').formats(@quota_set_format) do
+      @quota = Fog::Volume[:openstack].get_quota(@tenant_id).body['quota_set']
+      @quota
+    end
+
+    tests('#update_quota') do
+
+      new_values = @quota.merge({
+        'volumes'   => @quota['volumes']/2,
+        'snapshots' => @quota['snapshots']/2
+      })
+
+      succeeds do
+        Fog::Volume[:openstack].update_quota(@tenant_id, new_values.clone)
+      end
+
+      returns(new_values, 'returns new values') do
+        Fog::Volume[:openstack].get_quota(@tenant_id).body['quota_set']
+      end
+
+      # set quota back to old values
+      succeeds do
+        Fog::Volume[:openstack].update_quota(@tenant_id, @quota.clone)
+      end
+
+      # ensure old values are restored
+      returns(@quota, 'old values restored') do
+        Fog::Volume[:openstack].get_quota(@tenant_id).body['quota_set']
+      end
+
+    end
+
+  end
+end
+


### PR DESCRIPTION
When using Cinder, updating quotas related to volumes are now done through Cinder and not Nova. Updating volumes and gigabytes quotas through nova would result in this error:

{"badRequest": {"message": "Bad key(s) gigabytes,volumes in quota_set", "code": 400}}
