### PR TITLE
Wait for volume to be available before attaching

### DIFF
--- a/lib/fog/aws/models/compute/volume.rb
+++ b/lib/fog/aws/models/compute/volume.rb
@@ -108,6 +108,7 @@ module Fog
             self.availability_zone = new_server.availability_zone
           elsif new_server
             requires :device
+            wait_for { ready? }
             @server = nil
             self.server_id = new_server.id
             service.attach_volume(server_id, id, device)


### PR DESCRIPTION
We ran into a case in one of our AWS availability zones where new volumes are not ready to be attached for a few seconds after creation.  Attempting to attach the volumes while they are in "creating" state fails.
