### PR TITLE
Rackspace Provide networks attribute to allow create via collection to enable networks

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'fog/compute/models/server'
 require 'fog/rackspace/models/compute_v2/metadata'
 
@@ -121,6 +122,11 @@ module Fog
         #    "private"=> [{"version"=>4, "addr"=>"10.177.18.209"}]
         #  }
         attribute :addresses
+
+        # @!attribute [r] networks
+        # @return [Array] Network IDs to attach to server on create
+        # @see http://docs.rackspace.com/servers/api/v2/cs-devguide/content/CreateServers.html
+        attribute :networks
         
         # @!attribute [r] flavor_id
         # @return [String] The flavor Id. 
@@ -197,11 +203,12 @@ module Fog
           options[:disk_config] = disk_config unless disk_config.nil?
           options[:metadata] = metadata.to_hash unless @metadata.nil?
           options[:personality] = personality unless personality.nil?
+          options[:networks] = networks.dup unless networks.nil?
 
           if options[:networks]
-            options[:networks].map! { |id| { :uuid => id } }
+            options[:networks].map!{ |id| { :uuid => id } }
           end
-
+          
           data = service.create_server(name, image_id, flavor_id, 1, 1, options)
           merge_attributes(data.body['server'])
           true


### PR DESCRIPTION
This allows for usage like:

``` ruby
server = connection.servers.create(
  :name => _name,
  :image_id => _image_id,
  :flavor_id => _flavor_id,
  :metadata => _metadata,
  :networks => _networks
)
```
