### PR TITLE
[vsphere] Use find_raw_datacenter instead of get_raw_datacenter

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_resource_pool.rb
+++ b/lib/fog/vsphere/requests/compute/get_resource_pool.rb
@@ -11,7 +11,7 @@ module Fog
         protected
 
         def get_raw_resource_pool(name, cluster_name, datacenter_name)
-          dc      = get_raw_datacenter(datacenter_name)
+          dc      = find_raw_datacenter(datacenter_name)
           cluster = dc.find_compute_resource(cluster_name)
           cluster.resourcePool.find name
         end

--- a/lib/fog/vsphere/requests/compute/list_datacenters.rb
+++ b/lib/fog/vsphere/requests/compute/list_datacenters.rb
@@ -20,7 +20,7 @@ module Fog
         end
 
         def find_datacenters name=nil
-          name ? [get_raw_datacenter(name)] : raw_datacenters
+          name ? [find_raw_datacenter(name)] : raw_datacenters
         end
       end
 


### PR DESCRIPTION
find_raw_datacenter uses the cache of datacenters in list_datacenters, speeding it up. Calls get_raw_datacenter if not cached
