### PR TITLE
[Vsphere] Assign service to clone_result before new instance of vm

### DIFF
--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -122,12 +122,13 @@ module Fog
           req_options['datacenter'] = "#{datacenter}"
           # Perform the actual clone
           clone_results = service.vm_clone(req_options)
+          # We need to assign the service, otherwise we can't reload the model
+          clone_results['new_vm'][:service] = self.service
           # Create the new VM model. TODO This only works when "wait=true"
           new_vm = self.class.new(clone_results['new_vm'])
-          # We need to assign the collection and the connection otherwise we
+          # We need to assign the collection otherwise we
           # cannot reload the model.
           new_vm.collection = self.collection
-          new_vm.service = service
           # Return the new VM model.
           new_vm
         end


### PR DESCRIPTION
The previous code had the following error when cloning a vm on Vsphere:

```
~/fog-1.10.1/lib/fog/vsphere/models/compute/server.rb:122:in `clone': undefin
ed method `service=' for #<Fog::Compute::Vsphere::Server> (NoMethodError)
```

I fixed it by assigning the service before creating the new instance of "new_vm".

Can anyone review it? Thanks!
