### PR TITLE
Fix circular requires in fog

### DIFF
--- a/lib/fog/atmos/storage.rb
+++ b/lib/fog/atmos/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/atmos'
 require 'fog/storage'
 
 module Fog

--- a/lib/fog/aws/auto_scaling.rb
+++ b/lib/fog/aws/auto_scaling.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class AutoScaling < Fog::Service

--- a/lib/fog/aws/beanstalk.rb
+++ b/lib/fog/aws/beanstalk.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class ElasticBeanstalk < Fog::Service

--- a/lib/fog/aws/cdn.rb
+++ b/lib/fog/aws/cdn.rb
@@ -1,4 +1,3 @@
-require 'fog/aws'
 require 'fog/cdn'
 
 module Fog

--- a/lib/fog/aws/cloud_formation.rb
+++ b/lib/fog/aws/cloud_formation.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class CloudFormation < Fog::Service

--- a/lib/fog/aws/cloud_watch.rb
+++ b/lib/fog/aws/cloud_watch.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class CloudWatch < Fog::Service

--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/aws'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/aws/data_pipeline.rb
+++ b/lib/fog/aws/data_pipeline.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class DataPipeline < Fog::Service

--- a/lib/fog/aws/dns.rb
+++ b/lib/fog/aws/dns.rb
@@ -1,4 +1,3 @@
-require 'fog/aws'
 require 'fog/dns'
 
 module Fog

--- a/lib/fog/aws/dynamodb.rb
+++ b/lib/fog/aws/dynamodb.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class DynamoDB < Fog::Service

--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class ELB < Fog::Service

--- a/lib/fog/aws/emr.rb
+++ b/lib/fog/aws/emr.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class EMR < Fog::Service

--- a/lib/fog/aws/glacier.rb
+++ b/lib/fog/aws/glacier.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class Glacier < Fog::Service

--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class IAM < Fog::Service

--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class RDS < Fog::Service

--- a/lib/fog/aws/ses.rb
+++ b/lib/fog/aws/ses.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class SES < Fog::Service

--- a/lib/fog/aws/simpledb.rb
+++ b/lib/fog/aws/simpledb.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class SimpleDB < Fog::Service

--- a/lib/fog/aws/sns.rb
+++ b/lib/fog/aws/sns.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class SNS < Fog::Service

--- a/lib/fog/aws/sqs.rb
+++ b/lib/fog/aws/sqs.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class SQS < Fog::Service

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/aws'
 require 'fog/storage'
 
 module Fog

--- a/lib/fog/aws/sts.rb
+++ b/lib/fog/aws/sts.rb
@@ -1,5 +1,3 @@
-require 'fog/aws'
-
 module Fog
   module AWS
     class STS < Fog::Service

--- a/lib/fog/bare_metal_cloud/compute.rb
+++ b/lib/fog/bare_metal_cloud/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/bare_metal_cloud'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/bluebox/blb.rb
+++ b/lib/fog/bluebox/blb.rb
@@ -1,5 +1,3 @@
-require 'fog/bluebox'
-
 module Fog
   module Bluebox
     class BLB < Fog::Service

--- a/lib/fog/bluebox/compute.rb
+++ b/lib/fog/bluebox/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/bluebox'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/bluebox/dns.rb
+++ b/lib/fog/bluebox/dns.rb
@@ -1,4 +1,3 @@
-require 'fog/bluebox'
 require 'fog/dns'
 
 module Fog

--- a/lib/fog/brightbox/compute.rb
+++ b/lib/fog/brightbox/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/brightbox'
 require 'fog/compute'
 require 'fog/brightbox/oauth2'
 

--- a/lib/fog/cloudstack/compute.rb
+++ b/lib/fog/cloudstack/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/cloudstack'
 require 'fog/compute'
 require 'digest/md5'
 

--- a/lib/fog/digitalocean/compute.rb
+++ b/lib/fog/digitalocean/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/digitalocean'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -1,4 +1,3 @@
-require 'fog/dnsimple'
 require 'fog/dns'
 
 module Fog

--- a/lib/fog/dnsmadeeasy/dns.rb
+++ b/lib/fog/dnsmadeeasy/dns.rb
@@ -1,4 +1,3 @@
-require 'fog/dnsmadeeasy'
 require 'fog/dns'
 
 module Fog

--- a/lib/fog/dreamhost/dns.rb
+++ b/lib/fog/dreamhost/dns.rb
@@ -1,4 +1,3 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'dreamhost'))
 require 'fog/dns'
 
 module Fog

--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -1,4 +1,3 @@
-require 'fog/dynect'
 require 'fog/dns'
 
 module Fog

--- a/lib/fog/go_grid/compute.rb
+++ b/lib/fog/go_grid/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/go_grid'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/google/storage.rb
+++ b/lib/fog/google/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/google'
 require 'fog/storage'
 
 module Fog

--- a/lib/fog/hp/block_storage.rb
+++ b/lib/fog/hp/block_storage.rb
@@ -1,5 +1,3 @@
-require 'fog/hp'
-
 module Fog
   module HP
     class BlockStorage < Fog::Service

--- a/lib/fog/hp/cdn.rb
+++ b/lib/fog/hp/cdn.rb
@@ -1,4 +1,3 @@
-require 'fog/hp'
 require 'fog/cdn'
 
 module Fog

--- a/lib/fog/hp/compute.rb
+++ b/lib/fog/hp/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/hp'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/hp/storage.rb
+++ b/lib/fog/hp/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/hp'
 require 'fog/storage'
 
 module Fog

--- a/lib/fog/ibm/compute.rb
+++ b/lib/fog/ibm/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/ibm'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/ibm/storage.rb
+++ b/lib/fog/ibm/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/ibm'
 require 'fog/storage'
 
 module Fog

--- a/lib/fog/internet_archive/storage.rb
+++ b/lib/fog/internet_archive/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/internet_archive'
 require 'fog/storage'
 
 module Fog

--- a/lib/fog/joyent/compute.rb
+++ b/lib/fog/joyent/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/joyent'
 require 'fog/joyent/errors'
 require 'fog/compute'
 

--- a/lib/fog/libvirt/compute.rb
+++ b/lib/fog/libvirt/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/libvirt'
 require 'fog/compute'
 require 'fog/libvirt/models/compute/util/util'
 require 'fog/libvirt/models/compute/util/uri'

--- a/lib/fog/linode/compute.rb
+++ b/lib/fog/linode/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/linode'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/linode/dns.rb
+++ b/lib/fog/linode/dns.rb
@@ -1,4 +1,3 @@
-require 'fog/linode'
 require 'fog/dns'
 
 module Fog

--- a/lib/fog/local/storage.rb
+++ b/lib/fog/local/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/local/storage'
 require 'fog/storage'
 
 module Fog

--- a/lib/fog/ninefold/compute.rb
+++ b/lib/fog/ninefold/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/ninefold'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/ninefold/storage.rb
+++ b/lib/fog/ninefold/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/ninefold'
 require 'fog/storage'
 require 'fog/atmos'
 

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -1,5 +1,4 @@
 require 'fog/compute'
-require 'fog/openstack'
 
 module Fog
   module Compute

--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -1,5 +1,3 @@
-require 'fog/openstack'
-
 module Fog
   module Identity
     class OpenStack < Fog::Service

--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -1,5 +1,3 @@
-require 'fog/openstack'
-
 module Fog
   module Image
     class OpenStack < Fog::Service

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -1,5 +1,3 @@
-require 'fog/openstack'
-
 module Fog
   module Network
     class OpenStack < Fog::Service

--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/openstack'
 require 'fog/storage'
 
 module Fog

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -1,5 +1,3 @@
-require 'fog/openstack'
-
 module Fog
   module Volume
     class OpenStack < Fog::Service

--- a/lib/fog/rackspace/block_storage.rb
+++ b/lib/fog/rackspace/block_storage.rb
@@ -1,5 +1,3 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rackspace'))
-
 module Fog
   module Rackspace
     class BlockStorage < Fog::Service

--- a/lib/fog/rackspace/cdn.rb
+++ b/lib/fog/rackspace/cdn.rb
@@ -1,4 +1,3 @@
-require 'fog/rackspace'
 require 'fog/cdn'
 
 module Fog

--- a/lib/fog/rackspace/compute.rb
+++ b/lib/fog/rackspace/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/rackspace'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/rackspace/databases.rb
+++ b/lib/fog/rackspace/databases.rb
@@ -1,5 +1,3 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'rackspace'))
-
 module Fog
   module Rackspace
     class Databases < Fog::Service

--- a/lib/fog/rackspace/dns.rb
+++ b/lib/fog/rackspace/dns.rb
@@ -1,4 +1,3 @@
-require 'fog/rackspace'
 require 'fog/dns'
 
 module Fog

--- a/lib/fog/rackspace/identity.rb
+++ b/lib/fog/rackspace/identity.rb
@@ -1,5 +1,3 @@
-require 'fog/rackspace'
-
 module Fog
   module Rackspace
     class Identity < Fog::Service

--- a/lib/fog/rackspace/load_balancers.rb
+++ b/lib/fog/rackspace/load_balancers.rb
@@ -1,5 +1,3 @@
-require 'fog/rackspace'
-
 module Fog
   module Rackspace
     class LoadBalancers < Fog::Service

--- a/lib/fog/rackspace/storage.rb
+++ b/lib/fog/rackspace/storage.rb
@@ -1,4 +1,3 @@
-require 'fog/rackspace'
 require 'fog/storage'
 
 module Fog

--- a/lib/fog/riakcs/provisioning.rb
+++ b/lib/fog/riakcs/provisioning.rb
@@ -1,5 +1,3 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'riakcs'))
-
 module Fog
   module RiakCS
     class Provisioning < Fog::Service

--- a/lib/fog/riakcs/usage.rb
+++ b/lib/fog/riakcs/usage.rb
@@ -1,4 +1,3 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'riakcs'))
 require 'time'
 
 module Fog

--- a/lib/fog/storm_on_demand/compute.rb
+++ b/lib/fog/storm_on_demand/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/storm_on_demand'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/vcloud/compute.rb
+++ b/lib/fog/vcloud/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/vcloud'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/vmfusion/compute.rb
+++ b/lib/fog/vmfusion/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/vmfusion'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/voxel/compute.rb
+++ b/lib/fog/voxel/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/voxel'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/xenserver/compute.rb
+++ b/lib/fog/xenserver/compute.rb
@@ -1,4 +1,3 @@
-require 'fog/xenserver'
 require 'fog/compute'
 
 module Fog

--- a/lib/fog/zerigo/dns.rb
+++ b/lib/fog/zerigo/dns.rb
@@ -1,4 +1,3 @@
-require 'fog/zerigo'
 require 'fog/dns'
 
 module Fog


### PR DESCRIPTION
When run with -w fog prints out 1763 lines of warnings, most of which
are:

```
warning: loading in progress, circular require considered harmful - [file]
```

followed by a backtrace showing the circular require path.

Each of these circular requires are pulling in the fog provider
namespace, but due to the explicit namespacing in fog this is not
necessary.

The require may be necessary to have the service properly registered
with the provider.  Without this require this patch may break a user who
requires "fog/openstack/compute", but I am unsure if this is a supported
use of fog, please advise.
