### PR TITLE
Fix non-circular-require warnings

### DIFF
--- a/lib/fog/aws/elasticache.rb
+++ b/lib/fog/aws/elasticache.rb
@@ -132,8 +132,6 @@ module Fog
         def self.data
           @data ||= Hash.new do |hash, region|
             hash[region] = Hash.new do |region_hash, key|
-              owner_id = Fog::AWS::Mock.owner_id
-              security_group_id = Fog::AWS::Mock.security_group_id
               region_hash[key] = {
                 :clusters  => {}, # cache cluster data, indexed by cluster ID
               }

--- a/lib/fog/core/json.rb
+++ b/lib/fog/core/json.rb
@@ -41,7 +41,7 @@ module Fog
     begin
       require 'multi_json'
       include NewJSON
-    rescue Exception => e
+    rescue Exception
       Fog::Logger.deprecation "Defaulting to json library for json parsing. Please consider using multi_json library for the greatest performance/flexibility."
       require 'json'
       include LegacyJSON

--- a/lib/fog/core/service.rb
+++ b/lib/fog/core/service.rb
@@ -72,7 +72,7 @@ module Fog
       def fetch_credentials(options)
         # attempt to load credentials from config file
         begin
-          default_credentials = Fog.credentials.reject {|key, value| !(recognized | requirements).include?(key)}
+          Fog.credentials.reject {|key, value| !(recognized | requirements).include?(key)}
         rescue LoadError
           # if there are no configured credentials, do nothing
           {}

--- a/lib/fog/hp/storage.rb
+++ b/lib/fog/hp/storage.rb
@@ -177,7 +177,7 @@ module Fog
           signature = Fog::HP.escape(signature)
 
           # generate the temp url using the signature and expiry
-          temp_url = "#{scheme}://#{host}:#{port}#{encoded_path}?temp_url_sig=#{signature}&temp_url_expires=#{expires}"
+          "#{scheme}://#{host}:#{port}#{encoded_path}?temp_url_sig=#{signature}&temp_url_expires=#{expires}"
         end
 
       end

--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -63,7 +63,6 @@ module Fog
 
       class Mock
         attr_reader :auth_token
-        attr_reader :unscoped_token
         attr_reader :auth_token_expiration
         attr_reader :current_user
         attr_reader :current_tenant

--- a/lib/fog/rackspace/compute_v2.rb
+++ b/lib/fog/rackspace/compute_v2.rb
@@ -30,7 +30,7 @@ module Fog
          def to_s
            "Image should have transitioned to '#{desired_state}' not '#{current_state}'"
          end
-       end
+      end
 
       DFW_ENDPOINT = 'https://dfw.servers.api.rackspacecloud.com/v2'
       ORD_ENDPOINT = 'https://ord.servers.api.rackspacecloud.com/v2'
@@ -163,7 +163,7 @@ module Fog
           unless response.body.empty?
             begin
               response.body = Fog::JSON.decode(response.body)
-            rescue Fog::JSON::LoadError => e
+            rescue Fog::JSON::LoadError
               response.body = {}
             end
           end

--- a/lib/fog/rackspace/mock_data.rb
+++ b/lib/fog/rackspace/mock_data.rb
@@ -104,8 +104,7 @@ module Fog
               "extra_specs" => {},
             }
 
-            #Mock Data Hash
-            h = {
+            mock_data = {
               #Compute V2
               :flavors => Hash.new { |h,k| h[k] = flavor unless k == NOT_FOUND_ID},
               :images => Hash.new { |h,k| h[k] = image unless k == NOT_FOUND_ID },        
@@ -121,11 +120,11 @@ module Fog
             }
             
             # seed with initial data
-            h[:flavors][flavor_id] = flavor
-            h[:images][image_id] = image
-            h[:networks][network_id] = network
+            mock_data[:flavors][flavor_id] = flavor
+            mock_data[:images][image_id] = image
+            mock_data[:networks][network_id] = network
             
-            h            
+            mock_data
           end
         end[@rackspace_api_key]
       end

--- a/lib/fog/rackspace/service.rb
+++ b/lib/fog/rackspace/service.rb
@@ -28,7 +28,7 @@ module Fog
 
       def authenticate(options)
          self.send authentication_method, options
-       end
+      end
 
       private
 

--- a/lib/fog/riakcs.rb
+++ b/lib/fog/riakcs.rb
@@ -84,7 +84,7 @@ module Fog
             data[key_id][:status] = status
           end
 
-          if regrant = user[:new_key_secret]
+          if user[:new_key_secret]
             data[key_id][:key_secret] = rand(100).to_s
           end
 


### PR DESCRIPTION
This fixes miscellaneous warnings in fog including unused variables,
indentation mismatch and one warning for a duplicated attr_reader.
