### PR TITLE
[vSphere] Refactor and extend network interface methods (similar to the ovirt Implementation)

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -55,6 +55,7 @@ module Fog
       request :list_folders
       request :create_vm
       request :list_vm_interfaces
+      request :modify_vm_interface
       request :list_vm_volumes
       request :get_virtual_machine
       request :vm_reconfig_hardware

--- a/lib/fog/vsphere/models/compute/interface.rb
+++ b/lib/fog/vsphere/models/compute/interface.rb
@@ -5,12 +5,14 @@ module Fog
       class Interface < Fog::Model
 
         identity :mac
+        alias :id :mac
 
         attribute :network
         attribute :name
         attribute :status
         attribute :summary
         attribute :type
+        attribute :key
 
         def initialize(attributes={} )
           super defaults.merge(attributes)

--- a/lib/fog/vsphere/models/compute/interfaces.rb
+++ b/lib/fog/vsphere/models/compute/interfaces.rb
@@ -24,9 +24,21 @@ module Fog
         end
 
         def get(id)
-          new service.get_interface(id)
+          requires :vm
+          case vm
+            when Fog::Compute::Vsphere::Server
+              interface=service.get_vm_interface(vm.id, :key => id, :mac=> id, :name => id)
+            when Fog::Compute::Vsphere::Template
+              interface=service.get_template_interfaces(vm.id, :key => id, :mac=> id, :name => id)
+            else
+            raise 'interfaces should have vm or template'
+          end
+          if interface 
+            Fog::Compute::Vsphere::Interface.new(interface) 
+          else
+            nil         
+          end
         end
-
      end
     end
   end

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -72,8 +72,8 @@ module Fog
           service.vm_reconfig_cpus('instance_uuid' => instance_uuid, 'cpus' => cpus)
         end
 
-        def vm_reconfig_hardware(options = {})
-          requires :instance_uuid, :hardware_spec
+        def vm_reconfig_hardware(hardware_spec, options = {})
+          requires :instance_uuid
           service.vm_reconfig_hardware('instance_uuid' => instance_uuid, 'hardware_spec' => hardware_spec)
         end
 
@@ -162,6 +162,25 @@ module Fog
 
         def interfaces
           attributes[:interfaces] ||= id.nil? ? [] : service.interfaces( :vm => self )
+        end
+        
+        def interface_ready? attrs
+          (attrs.is_a? Hash and attrs[:blocking]) or attrs.is_a? Fog::Compute::Vsphere::Interface
+        end
+
+        def add_interface attrs
+          wait_for { not ready? } if interface_ready? attrs
+          service.add_vm_interface(id, attrs)
+        end
+
+        def update_interface attrs
+          wait_for { not ready? } if interface_ready? attrs
+          service.update_vm_interface(id, attrs)
+        end
+
+        def destroy_interface attrs
+          wait_for { not ready? } if interface_ready? attrs
+          service.destroy_vm_interface(id, attrs)
         end
 
         def volumes

--- a/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
@@ -37,9 +37,22 @@ module Fog
               :status  => nic.connectable.status,
               :summary => nic.deviceInfo.summary,
               :type    => nic.class,
+              :key     => nic.key,
             }
           end
 
+        end
+        
+        def get_vm_interface(vm_id, options={})
+          raise ArgumentError, "instance id is a required parameter" unless vm_id
+          if options.is_a? Fog::Compute::Vsphere::Interface
+            options
+          else
+            raise ArgumentError, "Either key or name is a required parameter. options: #{options}" unless options.has_key? :key or options.has_key? :mac or options.has_key? :name
+            list_vm_interfaces(vm_id).find do | nic |
+              (options.has_key? :key and nic[:key]==options[:key].to_i) or (options.has_key? :mac and nic[:mac]==options[:mac]) or (options.has_key? :name and nic[:name]==options[:name])
+            end
+          end
         end
 
       end

--- a/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
+++ b/lib/fog/vsphere/requests/compute/modify_vm_interface.rb
@@ -1,0 +1,58 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+
+        def add_vm_interface(vmid, options = {})
+          raise ArgumentError, "instance id is a required parameter" unless vmid
+
+          interface=get_interface_from_options(vmid, options)
+          vm_reconfig_hardware('instance_uuid' => vmid, 'hardware_spec' => {'deviceChange'=>[create_interface(interface)]})
+        end
+
+        def destroy_vm_interface(vmid, options = {})
+          raise ArgumentError, "instance id is a required parameter" unless vmid
+
+          interface=get_vm_interface(vmid, options)
+          vm_reconfig_hardware('instance_uuid' => vmid, 'hardware_spec' => {'deviceChange'=>[create_interface(interface, interface.key, :remove)]})
+        end
+        
+        def update_vm_interface(vmid, options = {})
+          raise ArgumentError, "instance id is a required parameter" unless vmid
+
+          interface=get_vm_interface(vmid, options)
+          vm_reconfig_hardware('instance_uuid' => vmid, 'hardware_spec' => {'deviceChange'=>[create_interface(interface, interface.key, :edit)]})          
+        end
+
+        private
+        def get_interface_from_options(vmid, options)
+          if options and options[:interface]
+            options[:interface]
+          elsif options[:key] and options[:key]>0
+            oldattributes=get_vm_interface(vmid, options)
+            Fog::Compute::Vsphere::Interface.new oldattributes.merge options
+          elsif options[:type] and options[:network]
+            Fog::Compute::Vsphere::Interface.new options
+          else
+            raise ArgumentError, "interface is a required parameter or pass options with type and network"
+          end
+        end
+
+      end
+
+      class Mock
+        def add_vm_interface(vmid, options = {})
+          raise ArgumentError, "instance id is a required parameter" unless vmid
+          raise ArgumentError, "interface is a required parameter" unless options and options[:interface]
+          true
+        end
+
+        def destroy_vm_interface(vmid, options = {})
+          raise ArgumentError, "instance id is a required parameter" unless vmid
+          raise ArgumentError, "interface is a required parameter" unless options and options[:interface]
+          true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is the changes discussed with Ohad the other day.
The extend the functionality of vSphere to add/destroy/update the interfaces.
Also a better way to retrieve interfaces was added (interfaces.get).

Changes:
- added methods to add, remove and update interfaces for vSphere
- added missing method to retrieve the interface
- added existing attribute key to interface (required for modifying, deleting interfaces)
- alias interface's mac to id
