### PR TITLE
[Brightbox] Updates image selector for name format

### DIFF
--- a/lib/fog/brightbox/compute.rb
+++ b/lib/fog/brightbox/compute.rb
@@ -1,6 +1,7 @@
 require 'fog/brightbox'
 require 'fog/compute'
 require 'fog/brightbox/oauth2'
+require 'fog/brightbox/compute/image_selector'
 
 module Fog
   module Compute
@@ -268,13 +269,15 @@ module Fog
 
         # Returns an identifier for the default image for use
         #
-        # Currently tries to find the latest version Ubuntu LTS (i686) widening
-        # up to the latest, official version of Ubuntu available.
+        # Currently tries to find the latest version of Ubuntu (i686) from
+        # Brightbox.
         #
         # Highly recommended that you actually select the image you want to run
         # on your servers yourself!
         #
-        # @return [String, nil]
+        # @return [String] if image is found, returns the identifier
+        # @return [NilClass] if no image is found or an error occurs
+        #
         def default_image
           return @default_image_id unless @default_image_id.nil?
           @default_image_id = Fog.credentials[:brightbox_default_image] || select_default_image
@@ -458,30 +461,12 @@ module Fog
 
         # Queries the API and tries to select the most suitable official Image
         # to use if the user chooses not to select their own.
+        #
+        # @return [String] if image is found, the image's identifier
+        # @return [NilClass] if no image found or an error occured
+        #
         def select_default_image
-          return @default_image_id unless @default_image_id.nil?
-
-          all_images = list_images
-          official_images = all_images.select {|img| img["official"] == true}
-          ubuntu_lts_images = official_images.select {|img| img["name"] =~ /Ubuntu.*LTS/}
-          ubuntu_lts_i686_images = ubuntu_lts_images.select {|img| img["arch"] == "i686"}
-
-          if ubuntu_lts_i686_images.empty?
-            # Accept other architectures
-            if ubuntu_lts_images.empty?
-              # Accept non-LTS versions of Ubuntu
-              unsorted_images = official_images.select {|img| img["name"] =~ /Ubuntu/}
-            else
-              unsorted_images = ubuntu_lts_images
-            end
-          else
-            unsorted_images = ubuntu_lts_i686_images
-          end
-
-          # Get the latest and use it's ID for the default image
-          @default_image_id = unsorted_images.sort {|a,b| a["created_at"] <=> b["created_at"]}.first["id"]
-        rescue
-          nil
+          Fog::Brightbox::Compute::ImageSelector.new(list_images).latest_ubuntu
         end
       end
 

--- a/lib/fog/brightbox/compute/image_selector.rb
+++ b/lib/fog/brightbox/compute/image_selector.rb
@@ -1,0 +1,45 @@
+module Fog
+  module Brightbox
+    module Compute
+      #
+      # This selects the preferred image to use based on a number of
+      # conditions
+      #
+      class ImageSelector
+        # Prepares a selector with the API output
+        #
+        # @param [Array<Hash>] images hash matching API output for {Fog::Compute::Brightbox#list_images}
+        #
+        def initialize(images)
+          @images = images
+        end
+
+        # Returns current identifier of the latest version of Ubuntu
+        #
+        # The order of preference is:
+        # * Only Official Brightbox images
+        # * Only Ubuntu images
+        # * Latest by name (alphanumeric sort)
+        # * Latest by creation date
+        #
+        # @note This performs a live query against the API
+        #
+        # @return [String] if image matches containing the identifier
+        # @return [NilClass] if no image matches
+        #
+        def latest_ubuntu
+          @images.select do |img|
+            img["official"] == true &&
+              img["arch"] == "i686" &&
+              img["name"] =~ /ubuntu/i
+          end.sort do |a,b|
+            # Reverse sort so "raring" > "precise" and "13.10" > "13.04"
+            b["name"].downcase <=> a["name"].downcase
+          end.first["id"]
+        rescue
+          nil
+        end
+      end
+    end
+  end
+end

--- a/tests/brightbox/compute/image_selector_tests.rb
+++ b/tests/brightbox/compute/image_selector_tests.rb
@@ -1,0 +1,103 @@
+Shindo.tests("Fog::Brightbox::Compute::ImageSelector.new", ["brightbox"]) do
+
+  sample_images = [
+    {
+      "id" => "img-00000",
+      "name" => "Ubuntu Lucid 10.04 LTS",
+      "official" => true,
+      "arch" => "i686",
+      "created_at" => "2013-04-30T12:34:56"
+    },
+    {
+      "id" => "img-11111",
+      "name" => "ubuntu-precise-12.04-amd64-server",
+      "official" => false,
+      "arch" => "i686",
+      "created_at" => "2013-05-01T12:34:56"
+    },
+    {
+      "id" => "img-22222",
+      "name" => "ubuntu-quantal-12.10-i386-server",
+      "official" => true,
+      "arch" => "i686",
+      "created_at" => "2013-05-01T12:34:56"
+    },
+    {
+      "id" => "img-33333",
+      "name" => "ubuntu-raring-13.04-amd64-server",
+      "official" => true,
+      "arch" => "amd64",
+      "created_at" => "2013-05-01T12:34:56"
+    },
+    {
+      "id" => "img-44444",
+      "name" => "Fedora 17 server",
+      "official" => true,
+      "arch" => "i686",
+      "created_at" => "2013-05-01T12:34:56"
+    },
+    {
+      "id" => "img-ubuntu",
+      "name" => "ubuntu-raring-13.04-i386-server",
+      "official" => true,
+      "arch" => "i686",
+      "created_at" => "2013-05-01T12:34:56"
+    },
+  ]
+
+  @image_selector = Fog::Brightbox::Compute::ImageSelector.new(sample_images)
+
+  test("#respond_to?(:latest_ubuntu)") do
+    @image_selector.respond_to?(:latest_ubuntu)
+  end
+
+  tests("when there are sample of images") do
+    tests("#latest_ubuntu").returns("img-ubuntu") do
+      @image_selector.latest_ubuntu
+    end
+  end
+
+  tests("when only old format names are present") do
+    tests("#latest_ubuntu").returns("img-ubuntu") do
+      sample_images = [
+        {
+          "id" => "img-11111",
+          "name" => "Ubuntu Lucid 10.04 LTS server",
+          "official" => true,
+          "arch" => "i686",
+          "created_at" => "2013-05-01T12:34:56"
+        },
+        {
+          "id" => "img-22222",
+          "name" => "Ubuntu Quantal 12.10 server",
+          "official" => false,
+          "arch" => "x86_64",
+          "created_at" => "2013-05-01T12:34:56"
+        },
+        {
+          "id" => "img-ubuntu",
+          "name" => "Ubuntu Quantal 12.10 server",
+          "official" => true,
+          "arch" => "i686",
+          "created_at" => "2013-05-01T12:34:56"
+        },
+        {
+          "id" => "img-33333",
+          "name" => "Blank disk image",
+          "official" => true,
+          "arch" => "i686",
+          "created_at" => "2013-05-01T12:34:56"
+        }
+      ]
+      @image_selector = Fog::Brightbox::Compute::ImageSelector.new(sample_images)
+      @image_selector.latest_ubuntu
+
+    end
+  end
+
+  tests("when ") do
+    tests("#latest_ubuntu").returns(nil) do
+      Fog::Brightbox::Compute::ImageSelector.new([]).latest_ubuntu
+    end
+  end
+end


### PR DESCRIPTION
Brightbox is now moving to using the default Ubuntu Cloud Images
(http://cloud-images.ubuntu.com/) where we are also using the naming
convention used there.

So the image selector has been updated to select the latest version of
Ubuntu (i386, official Brightbox) image if no image is specified with
the new format.
