### PR TITLE
OS: Fix revert_resize_server method name.

### DIFF
--- a/lib/fog/openstack/requests/compute/revert_resize_server.rb
+++ b/lib/fog/openstack/requests/compute/revert_resize_server.rb
@@ -3,7 +3,7 @@ module Fog
     class OpenStack
       class Real
 
-        def revert_resized_server(server_id)
+        def revert_resize_server(server_id)
           body = { 'revertResize' => nil }
           server_action(server_id, body)
         end
@@ -12,7 +12,7 @@ module Fog
 
       class Mock
 
-        def revert_resized_server(server_id)
+        def revert_resize_server(server_id)
           response = Excon::Response.new
           response.status = 202
 


### PR DESCRIPTION
Fixes an issue where calling revert_resize on the OpenStack Server
object would fail with a method name error.

---

Updates the revert_resize_server request methods to match the filename.
This also makes it match the method name we call in the
compute/server.rb module (revert_resize_server instead of
revert_resized_server).

Adds a test case which should guard against the above issue.
