### PR TITLE
Add :id attribute to libvirt nic model

### DIFF
--- a/lib/fog/libvirt/models/compute/nic.rb
+++ b/lib/fog/libvirt/models/compute/nic.rb
@@ -7,6 +7,7 @@ module Fog
       class Nic < Fog::Model
 
         identity :mac
+        attribute :id
         attribute :type
         attribute :network
         attribute :bridge


### PR DESCRIPTION
My cutting edge version of libvirt (1.0.4 Archlinux) seems to reply with  :id for NICs, causing the nic model to break.
