### PR TITLE
CloudStack: fails when there are no VMs in default view for user

### DIFF
--- a/lib/fog/cloudstack/models/compute/servers.rb
+++ b/lib/fog/cloudstack/models/compute/servers.rb
@@ -23,7 +23,7 @@ module Fog
 
         def get(server_id)
           servers = service.list_virtual_machines('id' => server_id)["listvirtualmachinesresponse"]["virtualmachine"]
-          unless servers.empty?
+          unless servers.nil?
             new(servers.first)
           end
         rescue Fog::Compute::Cloudstack::BadRequest


### PR DESCRIPTION
The following code will fail if there are no VMs in the user's cloudstack default view (.first of a nil object)

``` ruby
require 'rubygems'
require 'fog'

service = Fog::Compute[:cloudstack]
puts service.list_virtual_machines["listvirtualmachinesresponse"]["virtualmachine"].first
```
