### PR TITLE
[aws|compute] VPC support related to addresses (elastic IPs)

### DIFF
--- a/lib/fog/aws/models/compute/address.rb
+++ b/lib/fog/aws/models/compute/address.rb
@@ -11,6 +11,7 @@ module Fog
         attribute :allocation_id,        :aliases => 'allocationId'
         attribute :server_id,            :aliases => 'instanceId'
         attribute :network_interface_id, :aliases => 'networkInterfaceId'
+        attribute :association_id,       :aliases => 'associationId'
         attribute :domain
 
         def initialize(attributes = {})

--- a/lib/fog/aws/requests/compute/associate_address.rb
+++ b/lib/fog/aws/requests/compute/associate_address.rb
@@ -51,6 +51,7 @@ module Fog
               allocation_ip = describe_addresses( 'allocation-id'  => "#{allocation_id}").body['addressesSet'].first
               if !allocation_ip.nil?
                 public_ip = allocation_ip['publicIp']
+                address = allocation_ip
               end
             end
             if !address.nil?

--- a/lib/fog/aws/requests/compute/associate_address.rb
+++ b/lib/fog/aws/requests/compute/associate_address.rb
@@ -51,6 +51,7 @@ module Fog
               allocation_ip = describe_addresses( 'allocation-id'  => "#{allocation_id}").body['addressesSet'].first
               if !allocation_ip.nil?
                 public_ip = allocation_ip['publicIp']
+                allocation_ip['associationId'] = "eipassoc-#{Fog::Mock.random_hex(8)}"
                 address = allocation_ip
               end
             end
@@ -78,7 +79,7 @@ module Fog
               response.body = {
                 'requestId'     => Fog::AWS::Mock.request_id,
                 'return'        => true,
-                'associationId' => Fog::AWS::Mock.request_id
+                'associationId' => address['associationId']
               }
             end
             response

--- a/lib/fog/aws/requests/compute/describe_addresses.rb
+++ b/lib/fog/aws/requests/compute/describe_addresses.rb
@@ -46,7 +46,7 @@ module Fog
 
           addresses_set = self.data[:addresses].values
 
-          aliases = {'public-ip' => 'publicIp', 'instance-id' => 'instanceId'}
+          aliases = {'public-ip' => 'publicIp', 'instance-id' => 'instanceId', 'allocation-id' => 'allocationId'}
           for filter_key, filter_value in filters
             aliased_key = aliases[filter_key]
             addresses_set = addresses_set.reject{|address| ![*filter_value].include?(address[aliased_key])}

--- a/lib/fog/aws/requests/compute/disassociate_address.rb
+++ b/lib/fog/aws/requests/compute/disassociate_address.rb
@@ -32,10 +32,17 @@ module Fog
 
       class Mock
 
-        def disassociate_address(public_ip)
+        def disassociate_address(public_ip=nil, association_id=nil)
           response = Excon::Response.new
           response.status = 200
-          if address = self.data[:addresses][public_ip]
+
+          if association_id
+            address = self.data[:addresses].detect { |public_ip, addr| addr['associationId'] == association_id }[1]
+          else
+            address = self.data[:addresses][public_ip]
+          end
+          
+          if address
             instance_id = address['instanceId']
             instance = self.data[:instances][instance_id]
             instance['ipAddress']         = instance['originalIpAddress']


### PR DESCRIPTION
i found a few bugs when writing tests against mocks related to allocating, associating, and disassociating elastic IPs in VPC.