### PR TITLE
Force UTC last_modified time on rackspace cloudfiles get_container

### DIFF
--- a/lib/fog/rackspace/requests/storage/get_container.rb
+++ b/lib/fog/rackspace/requests/storage/get_container.rb
@@ -34,12 +34,17 @@ module Fog
         # @raise [Fog::Storage::Rackspace::ServiceError]
         def get_container(container, options = {})
           options = options.reject {|key, value| value.nil?}
-          request(
+          response = request(
             :expects  => 200,
             :method   => 'GET',
             :path     => Fog::Rackspace.escape(container),
             :query    => {'format' => 'json'}.merge!(options)
           )
+          response.data[:body].each do |item|
+            item['last_modified'] += 'Z' if item['last_modified'][-1] != 'Z'
+          end
+
+          response
         end
 
       end


### PR DESCRIPTION
Re: issue #1809

This is probably not the ideal fix but it will at least show the problem:

From the Rackspace cloudfiles API, get_container returns last_modified values like this:

`2013-05-09T22:20:59.287990`

When doing a `Time.parse` on this value, it is returning the wrong value because it is adding an offset equal to your local time zone. However, the rackspace time is UTC. 

I 'fixed' this by force adding a 'Z' at the end of the last_modified time, which correctly parses the time as UTC.
