### PR TITLE
Support RSpec 2.x

### DIFF
--- a/tests/vcloud/requests/compute/disk_configure_tests.rb
+++ b/tests/vcloud/requests/compute/disk_configure_tests.rb
@@ -1,5 +1,10 @@
-require 'spec'
-require 'spec/mocks'
+begin
+  require 'rspec'
+  require 'rspec/mocks'
+rescue LoadError
+  require 'spec'
+  require 'spec/mocks'
+end
 
 Shindo.tests("Vcloud::Compute | disk_requests", ['vcloud']) do
 


### PR DESCRIPTION
Hi,

since running RSpec 2.x works just fine for the test suite, I am proposing to allow both 1.x and 2.x versions for running tests. This makes it much easier to automate test runs in the environments like Fedora, where the old RSpec is long time gone.

Please accept. Thanks.
