### PR TITLE
Remove warning when using a period in an S3 bucket name.

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -201,8 +201,6 @@ module Fog
             if !path_style && COMPLIANT_BUCKET_NAMES !~ bucket_name
               Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
               path_style = true
-            elsif bucket_name.include?('.')
-              Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) might fail with https.")
             end
 
             if path_style


### PR DESCRIPTION
This removes a warning that is outputed by Fog when a S3 bucket name
contains a period. This resulted in excessive logging of a condition when
using Fog to push to a S3 bucket configured to serve a web site. See
fredjean/middleman-s3_sync#10 to see the issue that triggered this commit.
