### PR TITLE
Avoids Fog::Compute::Joyent::Real#decode_time_attrs raising an exception...

### DIFF
--- a/lib/fog/joyent/compute.rb
+++ b/lib/fog/joyent/compute.rb
@@ -201,8 +201,8 @@ module Fog
 
         def decode_time_attrs(obj)
           if obj.kind_of?(Hash)
-            obj["created"] = Time.parse(obj["created"]) if obj["created"]
-            obj["updated"] = Time.parse(obj["updated"]) if obj["updated"]
+            obj["created"] = Time.parse(obj["created"]) unless obj["created"].nil? or obj["created"] == ''
+            obj["updated"] = Time.parse(obj["updated"]) unless obj["updated"].nil? or obj["updated"] == ''
           elsif obj.kind_of?(Array)
             obj.map do |o|
               decode_time_attrs(o)


### PR DESCRIPTION
... when an empty string is returned as created or updated property

I tried creating a machine with fog v1.11.1 and an exception ocurred:

<pre>
cloud_server = fog.create_machine(:name => 'joyent-test', :package => "Small 1GB", :dataset => "71101322-43a5-11e1-8f01-cf2a3031a7f4")
ArgumentError: no time information in ""
    from /Users/pbanos/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/time.rb:267:in `parse'
    from /Users/pbanos/.rvm/gems/ruby-1.9.3-p327/gems/fog-1.11.1/lib/fog/joyent/compute.rb:202:in `decode_time_attrs'
    from /Users/pbanos/.rvm/gems/ruby-1.9.3-p327/gems/fog-1.11.1/lib/fog/joyent/compute.rb:171:in `json_decode'
    from /Users/pbanos/.rvm/gems/ruby-1.9.3-p327/gems/fog-1.11.1/lib/fog/joyent/compute.rb:159:in `request'
    from /Users/pbanos/.rvm/gems/ruby-1.9.3-p327/gems/fog-1.11.1/lib/fog/joyent/requests/compute/create_machine.rb:10:in `create_machine'
</pre>


It seems Joyent API may now return these fields set to an empty string instead of nil, so that Time.parse will raise the observed ArgumentError.

I modified Fog::Compute::Joyent::Real#decode_time_attrs so that it does not try to parse times on empty strings
