### PR TITLE
AWS S3 Invalid signature when using response-content-disposition=attachment with filename

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -449,7 +449,7 @@ DATA
               if VALID_QUERY_KEYS.include?(key)
                 value = params[:query][key]
                 if value
-                  query_args << "#{key}=#{Fog::AWS.escape(value.to_s)}"
+                  query_args << "#{key}=#{value}"
                 else
                   query_args << key
                 end


### PR DESCRIPTION
Hi.  To request an S3 object as an attachment with a specific name (different from the object name), you'd use

```
file.url(expiry, query: {'response-content-disposition' => 'attachment; filename=foo.txt'})
```

This worked in 1.10 but in 1.11.1 it gets a SignatureDoesNotMatch error.  

The problem is that in 1.11.1, the signature() method is CGI encoding the query parameter values into the signature string, but AWS seems to expect the signature string to match the non-encoded values.  

This pull request is a quick edit to remove the encoding from the signature string.
