### PR TITLE
[openstack|network] Add support for OpenStack Networking LBaaS extension

### DIFF
--- a/lib/fog/openstack/models/network/lb_health_monitor.rb
+++ b/lib/fog/openstack/models/network/lb_health_monitor.rb
@@ -1,0 +1,68 @@
+require 'fog/core/model'
+
+module Fog
+  module Network
+    class OpenStack
+      class LbHealthMonitor < Fog::Model
+        identity :id
+
+        attribute :type
+        attribute :delay
+        attribute :timeout
+        attribute :max_retries
+        attribute :http_method
+        attribute :url_path
+        attribute :expected_codes
+        attribute :status
+        attribute :admin_state_up
+        attribute :tenant_id
+
+        def initialize(attributes)
+          prepare_service_value(attributes)
+          super
+        end
+
+        def save
+          requires :type, :delay, :timeout, :max_retries
+          identity ? update : create
+        end
+
+        def create
+          requires :type, :delay, :timeout, :max_retries
+          merge_attributes(service.create_lb_health_monitor(self.type,
+                                                            self.delay,
+                                                            self.timeout,
+                                                            self.max_retries,
+                                                            self.attributes).body['health_monitor'])
+          self
+        end
+
+        def update
+          requires :id, :type, :delay, :timeout, :max_retries
+          merge_attributes(service.update_lb_health_monitor(self.id,
+                                                            self.attributes).body['health_monitor'])
+          self
+        end
+
+        def destroy
+          requires :id
+          service.delete_lb_health_monitor(self.id)
+          true
+        end
+
+        def associate_to_pool(pool_id)
+          requires :id
+          service.associate_lb_health_monitor(pool_id, self.id)
+          true
+        end
+
+        def disassociate_from_pool(pool_id)
+          requires :id
+          service.disassociate_lb_health_monitor(pool_id, self.id)
+          true
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/network/lb_health_monitors.rb
+++ b/lib/fog/openstack/models/network/lb_health_monitors.rb
@@ -1,0 +1,34 @@
+require 'fog/core/collection'
+require 'fog/openstack/models/network/lb_health_monitor'
+
+module Fog
+  module Network
+    class OpenStack
+      class LbHealthMonitors < Fog::Collection
+
+        attribute :filters
+
+        model Fog::Network::OpenStack::LbHealthMonitor
+
+        def initialize(attributes)
+          self.filters ||= {}
+          super
+        end
+
+        def all(filters = filters)
+          self.filters = filters
+          load(service.list_lb_health_monitors(filters).body['health_monitors'])
+        end
+
+        def get(health_monitor_id)
+          if health_monitor = service.get_lb_health_monitor(health_monitor_id).body['health_monitor']
+            new(health_monitor)
+          end
+        rescue Fog::Network::OpenStack::NotFound
+          nil
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/network/lb_member.rb
+++ b/lib/fog/openstack/models/network/lb_member.rb
@@ -1,0 +1,53 @@
+require 'fog/core/model'
+
+module Fog
+  module Network
+    class OpenStack
+      class LbMember < Fog::Model
+        identity :id
+
+        attribute :pool_id
+        attribute :address
+        attribute :protocol_port
+        attribute :weight
+        attribute :status
+        attribute :admin_state_up
+        attribute :tenant_id
+
+        def initialize(attributes)
+          prepare_service_value(attributes)
+          super
+        end
+
+        def save
+          requires :pool_id, :address, :protocol_port, :weight
+          identity ? update : create
+        end
+
+        def create
+          requires :pool_id, :address, :protocol_port, :weight
+          merge_attributes(service.create_lb_member(self.pool_id,
+                                                    self.address,
+                                                    self.protocol_port,
+                                                    self.weight,
+                                                    self.attributes).body['member'])
+          self
+        end
+
+        def update
+          requires :id, :pool_id, :address, :protocol_port, :weight
+          merge_attributes(service.update_lb_member(self.id,
+                                                    self.attributes).body['member'])
+          self
+        end
+
+        def destroy
+          requires :id
+          service.delete_lb_member(self.id)
+          true
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/network/lb_members.rb
+++ b/lib/fog/openstack/models/network/lb_members.rb
@@ -1,0 +1,34 @@
+require 'fog/core/collection'
+require 'fog/openstack/models/network/lb_member'
+
+module Fog
+  module Network
+    class OpenStack
+      class LbMembers < Fog::Collection
+
+        attribute :filters
+
+        model Fog::Network::OpenStack::LbMember
+
+        def initialize(attributes)
+          self.filters ||= {}
+          super
+        end
+
+        def all(filters = filters)
+          self.filters = filters
+          load(service.list_lb_members(filters).body['members'])
+        end
+
+        def get(member_id)
+          if member = service.get_lb_member(member_id).body['member']
+            new(member)
+          end
+        rescue Fog::Network::OpenStack::NotFound
+          nil
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/network/lb_pool.rb
+++ b/lib/fog/openstack/models/network/lb_pool.rb
@@ -1,0 +1,78 @@
+require 'fog/core/model'
+
+module Fog
+  module Network
+    class OpenStack
+      class LbPool < Fog::Model
+        identity :id
+
+        attribute :subnet_id
+        attribute :protocol
+        attribute :lb_method
+        attribute :name
+        attribute :description
+        attribute :health_monitors
+        attribute :members
+        attribute :status
+        attribute :admin_state_up
+        attribute :vip_id
+        attribute :tenant_id
+        attribute :active_connections
+        attribute :bytes_in
+        attribute :bytes_out
+        attribute :total_connections
+
+        def initialize(attributes)
+          prepare_service_value(attributes)
+          super
+        end
+
+        def save
+          requires :subnet_id, :protocol, :lb_method
+          identity ? update : create
+        end
+
+        def create
+          requires :subnet_id, :protocol, :lb_method
+          merge_attributes(service.create_lb_pool(self.subnet_id,
+                                                  self.protocol,
+                                                  self.lb_method,
+                                                  self.attributes).body['pool'])
+          self
+        end
+
+        def update
+          requires :id, :subnet_id, :protocol, :lb_method
+          merge_attributes(service.update_lb_pool(self.id,
+                                                  self.attributes).body['pool'])
+          self
+        end
+
+        def destroy
+          requires :id
+          service.delete_lb_pool(self.id)
+          true
+        end
+
+        def stats
+          requires :id
+          merge_attributes(service.get_lb_pool_stats(self.id).body['stats'])
+          self
+        end
+
+        def associate_health_monitor(health_monitor_id)
+          requires :id
+          service.associate_lb_health_monitor(self.id, health_monitor_id)
+          true
+        end
+
+        def disassociate_health_monitor(health_monitor_id)
+          requires :id
+          service.disassociate_lb_health_monitor(self.id, health_monitor_id)
+          true
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/network/lb_pools.rb
+++ b/lib/fog/openstack/models/network/lb_pools.rb
@@ -1,0 +1,34 @@
+require 'fog/core/collection'
+require 'fog/openstack/models/network/lb_pool'
+
+module Fog
+  module Network
+    class OpenStack
+      class LbPools < Fog::Collection
+
+        attribute :filters
+
+        model Fog::Network::OpenStack::LbPool
+
+        def initialize(attributes)
+          self.filters ||= {}
+          super
+        end
+
+        def all(filters = filters)
+          self.filters = filters
+          load(service.list_lb_pools(filters).body['pools'])
+        end
+
+        def get(pool_id)
+          if pool = service.get_lb_pool(pool_id).body['pool']
+            new(pool)
+          end
+        rescue Fog::Network::OpenStack::NotFound
+          nil
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/network/lb_vip.rb
+++ b/lib/fog/openstack/models/network/lb_vip.rb
@@ -1,0 +1,59 @@
+require 'fog/core/model'
+
+module Fog
+  module Network
+    class OpenStack
+      class LbVip < Fog::Model
+        identity :id
+
+        attribute :subnet_id
+        attribute :pool_id
+        attribute :protocol
+        attribute :protocol_port
+        attribute :name
+        attribute :description
+        attribute :address
+        attribute :port_id
+        attribute :session_persistence
+        attribute :connection_limit
+        attribute :status
+        attribute :admin_state_up
+        attribute :tenant_id
+
+        def initialize(attributes)
+          prepare_service_value(attributes)
+          super
+        end
+
+        def save
+          requires :subnet_id, :pool_id, :protocol, :protocol_port
+          identity ? update : create
+        end
+
+        def create
+          requires :subnet_id, :pool_id, :protocol, :protocol_port
+          merge_attributes(service.create_lb_vip(self.subnet_id,
+                                                 self.pool_id,
+                                                 self.protocol,
+                                                 self.protocol_port,
+                                                 self.attributes).body['vip'])
+          self
+        end
+
+        def update
+          requires :id, :subnet_id, :pool_id, :protocol, :protocol_port
+          merge_attributes(service.update_lb_vip(self.id,
+                                                 self.attributes).body['vip'])
+          self
+        end
+
+        def destroy
+          requires :id
+          service.delete_lb_vip(self.id)
+          true
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/network/lb_vips.rb
+++ b/lib/fog/openstack/models/network/lb_vips.rb
@@ -1,0 +1,34 @@
+require 'fog/core/collection'
+require 'fog/openstack/models/network/lb_vip'
+
+module Fog
+  module Network
+    class OpenStack
+      class LbVips < Fog::Collection
+
+        attribute :filters
+
+        model Fog::Network::OpenStack::LbVip
+
+        def initialize(attributes)
+          self.filters ||= {}
+          super
+        end
+
+        def all(filters = filters)
+          self.filters = filters
+          load(service.list_lb_vips(filters).body['vips'])
+        end
+
+        def get(vip_id)
+          if vip = service.get_lb_vip(vip_id).body['vip']
+            new(vip)
+          end
+        rescue Fog::Network::OpenStack::NotFound
+          nil
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -24,6 +24,14 @@ module Fog
       collection  :floating_ips
       model       :router
       collection  :routers
+      model       :lb_pool
+      collection  :lb_pools
+      model       :lb_member
+      collection  :lb_members
+      model       :lb_health_monitor
+      collection  :lb_health_monitors
+      model       :lb_vip
+      collection  :lb_vips
 
       ## REQUESTS
       #
@@ -67,6 +75,37 @@ module Fog
       request :add_router_interface
       request :remove_router_interface
 
+      # LBaaS Pool CRUD
+      request :list_lb_pools
+      request :create_lb_pool
+      request :delete_lb_pool
+      request :get_lb_pool
+      request :get_lb_pool_stats
+      request :update_lb_pool
+
+      # LBaaS Member CRUD
+      request :list_lb_members
+      request :create_lb_member
+      request :delete_lb_member
+      request :get_lb_member
+      request :update_lb_member
+
+      # LBaaS Health Monitor CRUD
+      request :list_lb_health_monitors
+      request :create_lb_health_monitor
+      request :delete_lb_health_monitor
+      request :get_lb_health_monitor
+      request :update_lb_health_monitor
+      request :associate_lb_health_monitor
+      request :disassociate_lb_health_monitor
+
+      # LBaaS VIP CRUD
+      request :list_lb_vips
+      request :create_lb_vip
+      request :delete_lb_vip
+      request :get_lb_vip
+      request :update_lb_vip
+
       # Tenant
       request :set_tenant
 
@@ -79,6 +118,10 @@ module Fog
               :subnets => {},
               :floating_ips => {},
               :routers => {},
+              :lb_pools => {},
+              :lb_members => {},
+              :lb_health_monitors => {},
+              :lb_vips => {},
             }
           end
         end

--- a/lib/fog/openstack/requests/network/associate_lb_health_monitor.rb
+++ b/lib/fog/openstack/requests/network/associate_lb_health_monitor.rb
@@ -1,0 +1,39 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def associate_lb_health_monitor(pool_id, health_monitor_id)
+          data = {
+            'health_monitor' => {
+              'id' => health_monitor_id,
+            }
+          }
+
+          request(
+            :body     => Fog::JSON.encode(data),
+            :expects  => [201],
+            :method   => 'POST',
+            :path     => "lb/pools/#{pool_id}/health_monitors"
+          )
+        end
+      end
+
+      class Mock
+        def associate_lb_health_monitor(pool_id, health_monitor_id)
+          response = Excon::Response.new
+          if pool = list_lb_pools.body['pools'].detect { |_| _['id'] == pool_id }
+            pool['health_monitors'] << health_monitor_id
+            self.data[:lb_pools][pool_id] = pool
+            response.body = { 'health_monitor' => {} }
+            response.status = 200
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/create_lb_health_monitor.rb
+++ b/lib/fog/openstack/requests/network/create_lb_health_monitor.rb
@@ -1,0 +1,56 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def create_lb_health_monitor(type, delay, timeout, max_retries, options = {})
+          data = {
+            'health_monitor' => {
+              'type'        => type,
+              'delay'       => delay,
+              'timeout'     => timeout,
+              'max_retries' => max_retries
+            }
+          }
+
+          vanilla_options = [:http_method, :url_path, :expected_codes, :admin_state_up, :tenant_id]
+          vanilla_options.reject{ |o| options[o].nil? }.each do |key|
+            data['health_monitor'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => [201],
+            :method  => 'POST',
+            :path    => 'lb/health_monitors'
+          )
+        end
+      end
+
+      class Mock
+        def create_lb_health_monitor(type, delay, timeout, max_retries, options = {})
+          response = Excon::Response.new
+          response.status = 201
+          data = {
+            'id'             => Fog::Mock.random_numbers(6).to_s,
+            'type'           => type,
+            'delay'          => delay,
+            'timeout'        => timeout,
+            'max_retries'    => max_retries,
+            'http_method'    => options[:http_method],
+            'url_path'       => options[:url_path],
+            'expected_codes' => options[:expected_codes],
+            'status'         => 'ACTIVE',
+            'admin_state_up' => options[:admin_state_up],
+            'tenant_id'      => options[:tenant_id],
+          }
+
+          self.data[:lb_health_monitors][data['id']] = data
+          response.body = { 'health_monitor' => data }
+          response
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/create_lb_member.rb
+++ b/lib/fog/openstack/requests/network/create_lb_member.rb
@@ -1,0 +1,53 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def create_lb_member(pool_id, address, protocol_port, weight, options = {})
+          data = {
+            'member' => {
+              'pool_id'       => pool_id,
+              'address'       => address,
+              'protocol_port' => protocol_port,
+              'weight'        => weight
+            }
+          }
+
+          vanilla_options = [:admin_state_up, :tenant_id]
+          vanilla_options.reject{ |o| options[o].nil? }.each do |key|
+            data['member'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => [201],
+            :method  => 'POST',
+            :path    => 'lb/members'
+          )
+        end
+      end
+
+      class Mock
+        def create_lb_member(pool_id, address, protocol_port, weight, options = {})
+          response = Excon::Response.new
+          response.status = 201
+          data = {
+            'id'              => Fog::Mock.random_numbers(6).to_s,
+            'pool_id'         => pool_id,
+            'address'         => address,
+            'protocol_port'   => protocol_port,
+            'weight'          => weight,
+            'status'          => 'ACTIVE',
+            'admin_state_up'  => options[:admin_state_up],
+            'tenant_id'       => options[:tenant_id],
+          }
+
+          self.data[:lb_members][data['id']] = data
+          response.body = { 'member' => data }
+          response
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/create_lb_pool.rb
+++ b/lib/fog/openstack/requests/network/create_lb_pool.rb
@@ -1,0 +1,60 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def create_lb_pool(subnet_id, protocol, lb_method, options = {})
+          data = {
+            'pool' => {
+              'subnet_id' => subnet_id,
+              'protocol'  => protocol,
+              'lb_method' => lb_method
+            }
+          }
+
+          vanilla_options = [:name, :description, :admin_state_up, :tenant_id]
+          vanilla_options.reject{ |o| options[o].nil? }.each do |key|
+            data['pool'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => [201],
+            :method  => 'POST',
+            :path    => 'lb/pools'
+          )
+        end
+      end
+
+      class Mock
+        def create_lb_pool(subnet_id, protocol, lb_method, options = {})
+          response = Excon::Response.new
+          response.status = 201
+          data = {
+            'id'                 => Fog::Mock.random_numbers(6).to_s,
+            'subnet_id'          => subnet_id,
+            'protocol'           => protocol,
+            'lb_method'          => lb_method,
+            'name'               => options[:name],
+            'description'        => options[:description],
+            'health_monitors'    => [],
+            'members'            => [],
+            'status'             => 'ACTIVE',
+            'admin_state_up'     => options[:admin_state_up],
+            'vip_id'             => nil,
+            'tenant_id'          => options[:tenant_id],
+            'active_connections' => nil,
+            'bytes_in'           => nil,
+            'bytes_out'          => nil,
+            'total_connections'  => nil
+          }
+
+          self.data[:lb_pools][data['id']] = data
+          response.body = { 'pool' => data }
+          response
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/create_lb_vip.rb
+++ b/lib/fog/openstack/requests/network/create_lb_vip.rb
@@ -1,0 +1,60 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def create_lb_vip(subnet_id, pool_id, protocol, protocol_port, options = {})
+          data = {
+            'vip' => {
+              'subnet_id'     => subnet_id,
+              'pool_id'       => pool_id,
+              'protocol'      => protocol,
+              'protocol_port' => protocol_port
+            }
+          }
+
+          vanilla_options = [:name, :description, :address, :session_persistence, :connection_limit,
+                             :admin_state_up, :tenant_id]
+          vanilla_options.reject{ |o| options[o].nil? }.each do |key|
+            data['vip'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => [201],
+            :method  => 'POST',
+            :path    => 'lb/vips'
+          )
+        end
+      end
+
+      class Mock
+        def create_lb_vip(subnet_id,  pool_id, protocol, protocol_port, options = {})
+          response = Excon::Response.new
+          response.status = 201
+          data = {
+            'id'                  => Fog::Mock.random_numbers(6).to_s,
+            'subnet_id'           => subnet_id,
+            'pool_id'             => pool_id,
+            'protocol'            => protocol,
+            'protocol_port'       => protocol_port,
+            'name'                => options[:name],
+            'description'         => options[:description],
+            'address'             => options[:address],
+            'port_id'             => Fog::Mock.random_numbers(6).to_s,
+            'session_persistence' => options[:session_persistence],
+            'connection_limit'    => options[:connection_limit],
+            'status'              => 'ACTIVE',
+            'admin_state_up'      => options[:admin_state_up],
+            'tenant_id'           => options[:tenant_id],
+          }
+
+          self.data[:lb_vips][data['id']] = data
+          response.body = { 'vip' => data }
+          response
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/delete_lb_health_monitor.rb
+++ b/lib/fog/openstack/requests/network/delete_lb_health_monitor.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def delete_lb_health_monitor(health_monitor_id)
+          request(
+            :expects => 204,
+            :method  => 'DELETE',
+            :path    => "lb/health_monitors/#{health_monitor_id}"
+          )
+        end
+      end
+
+      class Mock
+        def delete_lb_health_monitor(health_monitor_id)
+          response = Excon::Response.new
+          if list_lb_health_monitors.body['health_monitors'].map { |r| r['id'] }.include? health_monitor_id
+            self.data[:lb_health_monitors].delete(health_monitor_id)
+            response.status = 204
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/delete_lb_member.rb
+++ b/lib/fog/openstack/requests/network/delete_lb_member.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def delete_lb_member(member_id)
+          request(
+            :expects => 204,
+            :method  => 'DELETE',
+            :path    => "lb/members/#{member_id}"
+          )
+        end
+      end
+
+      class Mock
+        def delete_lb_member(member_id)
+          response = Excon::Response.new
+          if list_lb_members.body['members'].map { |r| r['id'] }.include? member_id
+            self.data[:lb_members].delete(member_id)
+            response.status = 204
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/delete_lb_pool.rb
+++ b/lib/fog/openstack/requests/network/delete_lb_pool.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def delete_lb_pool(pool_id)
+          request(
+            :expects => 204,
+            :method  => 'DELETE',
+            :path    => "lb/pools/#{pool_id}"
+          )
+        end
+      end
+
+      class Mock
+        def delete_lb_pool(pool_id)
+          response = Excon::Response.new
+          if list_lb_pools.body['pools'].map { |r| r['id'] }.include? pool_id
+            self.data[:lb_pools].delete(pool_id)
+            response.status = 204
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/delete_lb_vip.rb
+++ b/lib/fog/openstack/requests/network/delete_lb_vip.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def delete_lb_vip(vip_id)
+          request(
+            :expects => 204,
+            :method  => 'DELETE',
+            :path    => "lb/vips/#{vip_id}"
+          )
+        end
+      end
+
+      class Mock
+        def delete_lb_vip(vip_id)
+          response = Excon::Response.new
+          if list_lb_vips.body['vips'].map { |r| r['id'] }.include? vip_id
+            self.data[:lb_vips].delete(vip_id)
+            response.status = 204
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/disassociate_lb_health_monitor.rb
+++ b/lib/fog/openstack/requests/network/disassociate_lb_health_monitor.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def disassociate_lb_health_monitor(pool_id, health_monitor_id)
+          request(
+            :expects  => [204],
+            :method   => 'DELETE',
+            :path     => "lb/pools/#{pool_id}/health_monitors/#{health_monitor_id}"
+          )
+        end
+      end
+
+      class Mock
+        def disassociate_lb_health_monitor(pool_id, health_monitor_id)
+          response = Excon::Response.new
+          if pool = list_lb_pools.body['pools'].detect { |_| _['id'] == pool_id }
+            pool['health_monitors'].delete(health_monitor_id)
+            self.data[:lb_pools][pool_id] = pool
+            response.status = 204
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/get_lb_health_monitor.rb
+++ b/lib/fog/openstack/requests/network/get_lb_health_monitor.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def get_lb_health_monitor(health_monitor_id)
+          request(
+            :expects => [200],
+            :method  => 'GET',
+            :path    => "lb/health_monitors/#{health_monitor_id}"
+          )
+        end
+      end
+
+      class Mock
+        def get_lb_health_monitor(health_monitor_id)
+          response = Excon::Response.new
+          if data = self.data[:lb_health_monitors][health_monitor_id]
+            response.status = 200
+            response.body = { 'health_monitor' => data }
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/get_lb_member.rb
+++ b/lib/fog/openstack/requests/network/get_lb_member.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def get_lb_member(member_id)
+          request(
+            :expects => [200],
+            :method  => 'GET',
+            :path    => "lb/members/#{member_id}"
+          )
+        end
+      end
+
+      class Mock
+        def get_lb_member(member_id)
+          response = Excon::Response.new
+          if data = self.data[:lb_members][member_id]
+            response.status = 200
+            response.body = { 'member' => data }
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/get_lb_pool.rb
+++ b/lib/fog/openstack/requests/network/get_lb_pool.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def get_lb_pool(pool_id)
+          request(
+            :expects => [200],
+            :method  => 'GET',
+            :path    => "lb/pools/#{pool_id}"
+          )
+        end
+      end
+
+      class Mock
+        def get_lb_pool(pool_id)
+          response = Excon::Response.new
+          if data = self.data[:lb_pools][pool_id]
+            response.status = 200
+            response.body = { 'pool' => data }
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/get_lb_pool_stats.rb
+++ b/lib/fog/openstack/requests/network/get_lb_pool_stats.rb
@@ -1,0 +1,35 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def get_lb_pool_stats(pool_id)
+          request(
+            :expects => [200],
+            :method  => 'GET',
+            :path    => "lb/pools/#{pool_id}/stats"
+          )
+        end
+      end
+
+      class Mock
+        def get_lb_pool_stats(pool_id)
+          response = Excon::Response.new
+          if data = self.data[:lb_pools][pool_id]
+            stats = {}
+            stats["active_connections"] = 0
+            stats["bytes_in"] = 0
+            stats["bytes_out"] = 0
+            stats["total_connections"] = 0
+            response.status = 200
+            response.body = { 'stats' => stats }
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/get_lb_vip.rb
+++ b/lib/fog/openstack/requests/network/get_lb_vip.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def get_lb_vip(vip_id)
+          request(
+            :expects => [200],
+            :method  => 'GET',
+            :path    => "lb/vips/#{vip_id}"
+          )
+        end
+      end
+
+      class Mock
+        def get_lb_vip(vip_id)
+          response = Excon::Response.new
+          if data = self.data[:lb_vips][vip_id]
+            response.status = 200
+            response.body = { 'vip' => data }
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/list_lb_health_monitors.rb
+++ b/lib/fog/openstack/requests/network/list_lb_health_monitors.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def list_lb_health_monitors(filters = {})
+          request(
+            :expects => 200,
+            :method  => 'GET',
+            :path    => 'lb/health_monitors',
+            :query   => filters
+          )
+        end
+      end
+
+      class Mock
+        def list_lb_health_monitors(filters = {})
+          Excon::Response.new(
+            :body   => { 'health_monitors' => self.data[:lb_health_monitors].values },
+            :status => 200
+          )
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/list_lb_members.rb
+++ b/lib/fog/openstack/requests/network/list_lb_members.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def list_lb_members(filters = {})
+          request(
+            :expects => 200,
+            :method  => 'GET',
+            :path    => 'lb/members',
+            :query   => filters
+          )
+        end
+      end
+
+      class Mock
+        def list_lb_members(filters = {})
+          Excon::Response.new(
+            :body   => { 'members' => self.data[:lb_members].values },
+            :status => 200
+          )
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/list_lb_pools.rb
+++ b/lib/fog/openstack/requests/network/list_lb_pools.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def list_lb_pools(filters = {})
+          request(
+            :expects => 200,
+            :method  => 'GET',
+            :path    => 'lb/pools',
+            :query   => filters
+          )
+        end
+      end
+
+      class Mock
+        def list_lb_pools(filters = {})
+          Excon::Response.new(
+            :body   => { 'pools' => self.data[:lb_pools].values },
+            :status => 200
+          )
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/list_lb_vips.rb
+++ b/lib/fog/openstack/requests/network/list_lb_vips.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def list_lb_vips(filters = {})
+          request(
+            :expects => 200,
+            :method  => 'GET',
+            :path    => 'lb/vips',
+            :query   => filters
+          )
+        end
+      end
+
+      class Mock
+        def list_lb_vips(filters = {})
+          Excon::Response.new(
+            :body   => { 'vips' => self.data[:lb_vips].values },
+            :status => 200
+          )
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/update_lb_health_monitor.rb
+++ b/lib/fog/openstack/requests/network/update_lb_health_monitor.rb
@@ -1,0 +1,45 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def update_lb_health_monitor(health_monitor_id, options = {})
+          data = { 'health_monitor' => {} }
+
+          vanilla_options = [:delay, :timeout, :max_retries, :http_method, :url_path, :expected_codes, :admin_state_up]
+          vanilla_options.select{ |o| options.has_key?(o) }.each do |key|
+            data['health_monitor'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => 200,
+            :method  => 'PUT',
+            :path    => "lb/health_monitors/#{health_monitor_id}"
+          )
+        end
+      end
+
+      class Mock
+        def update_lb_health_monitor(health_monitor_id, options = {})
+          response = Excon::Response.new
+          if health_monitor = list_lb_health_monitors.body['health_monitors'].detect { |_| _['id'] == health_monitor_id }
+            health_monitor['delay']          = options[:delay]
+            health_monitor['timeout']        = options[:timeout]
+            health_monitor['max_retries']    = options[:max_retries]
+            health_monitor['http_method']    = options[:http_method]
+            health_monitor['url_path']       = options[:url_path]
+            health_monitor['expected_codes'] = options[:expected_codes]
+            health_monitor['admin_state_up'] = options[:admin_state_up]
+            response.body = { 'health_monitor' => health_monitor }
+            response.status = 200
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/update_lb_member.rb
+++ b/lib/fog/openstack/requests/network/update_lb_member.rb
@@ -1,0 +1,41 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def update_lb_member(member_id, options = {})
+          data = { 'member' => {} }
+
+          vanilla_options = [:pool_id, :weight, :admin_state_up]
+          vanilla_options.select{ |o| options.has_key?(o) }.each do |key|
+            data['member'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => 200,
+            :method  => 'PUT',
+            :path    => "lb/members/#{member_id}"
+          )
+        end
+      end
+
+      class Mock
+        def update_lb_member(member_id, options = {})
+          response = Excon::Response.new
+          if member = list_lb_members.body['members'].detect { |_| _['id'] == member_id }
+            member['pool_id']        = options[:pool_id]
+            member['weight']         = options[:weight]
+            member['admin_state_up'] = options[:admin_state_up]
+            response.body = { 'member' => member }
+            response.status = 200
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/update_lb_pool.rb
+++ b/lib/fog/openstack/requests/network/update_lb_pool.rb
@@ -1,0 +1,42 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def update_lb_pool(pool_id, options = {})
+          data = { 'pool' => {} }
+
+          vanilla_options = [:name, :description, :lb_method, :admin_state_up]
+          vanilla_options.select{ |o| options.has_key?(o) }.each do |key|
+            data['pool'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => 200,
+            :method  => 'PUT',
+            :path    => "lb/pools/#{pool_id}"
+          )
+        end
+      end
+
+      class Mock
+        def update_lb_pool(pool_id, options = {})
+          response = Excon::Response.new
+          if pool = list_lb_pools.body['pools'].detect { |_| _['id'] == pool_id }
+            pool['name']            = options[:name]
+            pool['description']     = options[:description]
+            pool['lb_method']       = options[:lb_method]
+            pool['admin_state_up']  = options[:admin_state_up]
+            response.body = { 'pool' => pool }
+            response.status = 200
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/requests/network/update_lb_vip.rb
+++ b/lib/fog/openstack/requests/network/update_lb_vip.rb
@@ -1,0 +1,44 @@
+module Fog
+  module Network
+    class OpenStack
+
+      class Real
+        def update_lb_vip(vip_id, options = {})
+          data = { 'vip' => {} }
+
+          vanilla_options = [:pool_id, :name, :description, :session_persistence, :connection_limit, :admin_state_up]
+          vanilla_options.select{ |o| options.has_key?(o) }.each do |key|
+            data['vip'][key] = options[key]
+          end
+
+          request(
+            :body    => Fog::JSON.encode(data),
+            :expects => 200,
+            :method  => 'PUT',
+            :path    => "lb/vips/#{vip_id}"
+          )
+        end
+      end
+
+      class Mock
+        def update_lb_vip(vip_id, options = {})
+          response = Excon::Response.new
+          if vip = list_lb_vips.body['vips'].detect { |_| _['id'] == vip_id }
+            vip['pool_id']             = options[:pool_id]
+            vip['name']                = options[:name]
+            vip['description']         = options[:description]
+            vip['session_persistence'] = options[:session_persistence]
+            vip['connection_limit']    = options[:connection_limit]
+            vip['admin_state_up']      = options[:admin_state_up]
+            response.body = { 'vip' => vip }
+            response.status = 200
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
+        end
+      end
+
+    end
+  end
+end

--- a/tests/openstack/models/network/lb_health_monitor_tests.rb
+++ b/tests/openstack/models/network/lb_health_monitor_tests.rb
@@ -1,0 +1,52 @@
+Shindo.tests("Fog::Network[:openstack] | lb_health_monitor", ['openstack']) do
+
+  tests('success') do
+    before do
+      @lb_pool = Fog::Network[:openstack].lb_pools.create(:subnet_id => 'subnet_id',
+                                                          :protocol => 'HTTP',
+                                                          :lb_method => 'ROUND_ROBIN')
+    end
+
+    after do
+      @lb_pool.destroy
+    end
+
+    tests('#create').succeeds do
+      @instance = Fog::Network[:openstack].lb_health_monitors.create(:type => 'PING',
+                                                                     :delay => 1,
+                                                                     :timeout => 5,
+                                                                     :max_retries => 10,
+                                                                     :http_method => 'GET',
+                                                                     :url_path => '/',
+                                                                     :expected_codes => '200, 201',
+                                                                     :admin_state_up => true,
+                                                                     :tenant_id => 'tenant_id')
+      !@instance.id.nil?
+    end
+
+    tests('#update').succeeds do
+      @instance.delay = 5
+      @instance.timeout = 10
+      @instance.max_retries = 20
+      @instance.http_method = 'POST'
+      @instance.url_path = '/varz'
+      @instance.expected_codes = '200'
+      @instance.admin_state_up = false
+      @instance.update
+    end
+
+    tests('#associate_to_pool').succeeds do
+      @instance.associate_to_pool(@lb_pool.id)
+    end
+
+    tests('#disassociate_from_pool').succeeds do
+      @instance.disassociate_from_pool(@lb_pool.id)
+    end
+
+    tests('#destroy').succeeds do
+      @instance.destroy == true
+    end
+
+  end
+
+end

--- a/tests/openstack/models/network/lb_health_monitors_tests.rb
+++ b/tests/openstack/models/network/lb_health_monitors_tests.rb
@@ -1,0 +1,21 @@
+Shindo.tests("Fog::Network[:openstack] | lb_health_monitors", ['openstack']) do
+  @lb_health_monitor = Fog::Network[:openstack].lb_health_monitors.create(:type => 'PING',
+                                                                          :delay => 1,
+                                                                          :timeout => 5,
+                                                                          :max_retries => 10)
+  @lb_health_monitors = Fog::Network[:openstack].lb_health_monitors
+
+  tests('success') do
+
+    tests('#all').succeeds do
+      @lb_health_monitors.all
+    end
+
+    tests('#get').succeeds do
+      @lb_health_monitors.get @lb_health_monitor.id
+    end
+
+  end
+
+  @lb_health_monitor.destroy
+end

--- a/tests/openstack/models/network/lb_member_tests.rb
+++ b/tests/openstack/models/network/lb_member_tests.rb
@@ -1,0 +1,28 @@
+Shindo.tests("Fog::Network[:openstack] | lb_member", ['openstack']) do
+
+  tests('success') do
+
+    tests('#create').succeeds do
+      @instance = Fog::Network[:openstack].lb_members.create(:pool_id => 'pool_id',
+                                                             :address => '10.0.0.1',
+                                                             :protocol_port => '80',
+                                                             :weight => 100,
+                                                             :admin_state_up => true,
+                                                             :tenant_id => 'tenant_id')
+      !@instance.id.nil?
+    end
+
+    tests('#update').succeeds do
+      @instance.pool_id = 'new_pool_id'
+      @instance.weight = 50
+      @instance.admin_state_up = false
+      @instance.update
+    end
+
+    tests('#destroy').succeeds do
+      @instance.destroy == true
+    end
+
+  end
+
+end

--- a/tests/openstack/models/network/lb_members_tests.rb
+++ b/tests/openstack/models/network/lb_members_tests.rb
@@ -1,0 +1,21 @@
+Shindo.tests("Fog::Network[:openstack] | lb_members", ['openstack']) do
+  @lb_member = Fog::Network[:openstack].lb_members.create(:pool_id => 'pool_id',
+                                                          :address => '10.0.0.1',
+                                                          :protocol_port => '80',
+                                                          :weight => 100)
+  @lb_members = Fog::Network[:openstack].lb_members
+
+  tests('success') do
+
+    tests('#all').succeeds do
+      @lb_members.all
+    end
+
+    tests('#get').succeeds do
+      @lb_members.get @lb_member.id
+    end
+
+  end
+
+  @lb_member.destroy
+end

--- a/tests/openstack/models/network/lb_pool_tests.rb
+++ b/tests/openstack/models/network/lb_pool_tests.rb
@@ -1,0 +1,53 @@
+Shindo.tests("Fog::Network[:openstack] | lb_pool", ['openstack']) do
+
+  tests('success') do
+    before do
+      @lb_health_monitor =  Fog::Network[:openstack].lb_health_monitors.create(:type => 'PING',
+                                                                               :delay => 1,
+                                                                               :timeout => 5,
+                                                                               :max_retries => 10)
+    end
+
+    after do
+      @lb_health_monitor.destroy
+    end
+
+    tests('#create').succeeds do
+      @instance = Fog::Network[:openstack].lb_pools.create(:subnet_id => 'subnet_id',
+                                                           :protocol => 'HTTP',
+                                                           :lb_method => 'ROUND_ROBIN',
+                                                           :name => 'test-pool',
+                                                           :description => 'Test Pool',
+                                                           :admin_state_up => true,
+                                                           :tenant_id => 'tenant_id')
+      !@instance.id.nil?
+    end
+
+    tests('#update').succeeds do
+      @instance.name = 'new-test-pool'
+      @instance.description = 'New Test Pool'
+      @instance.lb_method = 'LEAST_CONNECTIONS'
+      @instance.admin_state_up = false
+      @instance.update
+    end
+
+    tests('#stats').succeeds do
+      @instance.stats
+      !@instance.active_connections.nil?
+    end
+
+    tests('#associate_health_monitor').succeeds do
+      @instance.associate_health_monitor(@lb_health_monitor.id)
+    end
+
+    tests('#disassociate_health_monitor').succeeds do
+      @instance.disassociate_health_monitor(@lb_health_monitor.id)
+    end
+
+    tests('#destroy').succeeds do
+      @instance.destroy == true
+    end
+
+  end
+
+end

--- a/tests/openstack/models/network/lb_pools_tests.rb
+++ b/tests/openstack/models/network/lb_pools_tests.rb
@@ -1,0 +1,20 @@
+Shindo.tests("Fog::Network[:openstack] | lb_pools", ['openstack']) do
+  @lb_pool = Fog::Network[:openstack].lb_pools.create(:subnet_id => 'subnet_id',
+                                                      :protocol => 'HTTP',
+                                                      :lb_method => 'ROUND_ROBIN')
+  @lb_pools = Fog::Network[:openstack].lb_pools
+
+  tests('success') do
+
+    tests('#all').succeeds do
+      @lb_pools.all
+    end
+
+    tests('#get').succeeds do
+      @lb_pools.get @lb_pool.id
+    end
+
+  end
+
+  @lb_pool.destroy
+end

--- a/tests/openstack/models/network/lb_vip_tests.rb
+++ b/tests/openstack/models/network/lb_vip_tests.rb
@@ -1,0 +1,39 @@
+Shindo.tests("Fog::Network[:openstack] | lb_vip", ['openstack']) do
+
+  tests('success') do
+
+    tests('#create').succeeds do
+      @instance = Fog::Network[:openstack].lb_vips.create(:subnet_id => 'subnet_id',
+                                                          :pool_id => 'pool_id',
+                                                          :protocol => 'HTTP',
+                                                          :protocol_port => 80,
+                                                          :name => 'test-vip',
+                                                          :description => 'Test VIP',
+                                                          :address => '10.0.0.1',
+                                                          :session_persistence => {
+                                                            "cookie_name" => "COOKIE_NAME",
+                                                            "type" => "APP_COOKIE"
+                                                          },
+                                                          :connection_limit => 10,
+                                                          :admin_state_up => true,
+                                                          :tenant_id => 'tenant_id')
+      !@instance.id.nil?
+    end
+
+    tests('#update').succeeds do
+      @instance.pool_id = 'new_pool_id',
+      @instance.name = 'new-test-vip'
+      @instance.description = 'New Test VIP'
+      @instance.session_persistence = { "type" => "HTTP_COOKIE" }
+      @instance.connection_limit = 5
+      @instance.admin_state_up = false
+      @instance.update
+    end
+
+    tests('#destroy').succeeds do
+      @instance.destroy == true
+    end
+
+  end
+
+end

--- a/tests/openstack/models/network/lb_vips_tests.rb
+++ b/tests/openstack/models/network/lb_vips_tests.rb
@@ -1,0 +1,21 @@
+Shindo.tests("Fog::Network[:openstack] | lb_vips", ['openstack']) do
+  @lb_vip = Fog::Network[:openstack].lb_vips.create(:subnet_id => 'subnet_id',
+                                                    :pool_id => 'pool_id',
+                                                    :protocol => 'HTTP',
+                                                    :protocol_port => 80)
+  @lb_vips = Fog::Network[:openstack].lb_vips
+
+  tests('success') do
+
+    tests('#all').succeeds do
+      @lb_vips.all
+    end
+
+    tests('#get').succeeds do
+      @lb_vips.get @lb_vip.id
+    end
+
+  end
+
+  @lb_vip.destroy
+end

--- a/tests/openstack/requests/network/lb_health_monitor_tests.rb
+++ b/tests/openstack/requests/network/lb_health_monitor_tests.rb
@@ -1,0 +1,93 @@
+Shindo.tests('Fog::Network[:openstack] | lb_health_monitor requests', ['openstack']) do
+
+  @lb_health_monitor_format = {
+    'id'             => String,
+    'type'           => String,
+    'delay'          => Integer,
+    'timeout'        => Integer,
+    'max_retries'    => Integer,
+    'http_method'    => String,
+    'url_path'       => String,
+    'expected_codes' => String,
+    'status'         => String,
+    'admin_state_up' => Fog::Boolean,
+    'tenant_id'      => String,
+  }
+
+  tests('success') do
+    before do
+      @lb_pool = Fog::Network[:openstack].lb_pools.create(:subnet_id => 'subnet_id',
+                                                          :protocol => 'HTTP',
+                                                          :lb_method => 'ROUND_ROBIN')
+    end
+
+    after do
+      @lb_pool.destroy
+    end
+
+    tests('#create_lb_health_monitor').formats({'health_monitor' => @lb_health_monitor_format}) do
+      type = 'PING'
+      delay = 1
+      timeout = 5
+      max_retries = 10
+      attributes = {:http_method => 'GET', :url_path => '/', :expected_codes => '200, 201',
+                    :admin_state_up => true, :tenant_id => 'tenant_id'}
+      Fog::Network[:openstack].create_lb_health_monitor(type, delay, timeout, max_retries, attributes).body
+    end
+
+    tests('#list_lb_health_monitors').formats({'health_monitors' => [@lb_health_monitor_format]}) do
+      Fog::Network[:openstack].list_lb_health_monitors.body
+    end
+
+    tests('#get_lb_health_monitor').formats({'health_monitor' => @lb_health_monitor_format}) do
+      lb_health_monitor_id = Fog::Network[:openstack].lb_health_monitors.all.first.id
+      Fog::Network[:openstack].get_lb_health_monitor(lb_health_monitor_id).body
+    end
+
+    tests('#update_lb_health_monitor').formats({'health_monitor' => @lb_health_monitor_format}) do
+      lb_health_monitor_id = Fog::Network[:openstack].lb_health_monitors.all.first.id
+      attributes = {:delay => 5, :timeout => 10, :max_retries => 20,
+                    :http_method => 'POST', :url_path => '/varz', :expected_codes => '200',
+                    :admin_state_up => false}
+      Fog::Network[:openstack].update_lb_health_monitor(lb_health_monitor_id, attributes).body
+    end
+
+    tests('#associate_lb_health_monitor').succeeds do
+      lb_health_monitor_id = Fog::Network[:openstack].lb_health_monitors.all.first.id
+      Fog::Network[:openstack].associate_lb_health_monitor(@lb_pool.id, lb_health_monitor_id)
+    end
+
+    tests('#disassociate_lb_health_monitor').succeeds do
+      lb_health_monitor_id = Fog::Network[:openstack].lb_health_monitors.all.first.id
+      Fog::Network[:openstack].disassociate_lb_health_monitor(@lb_pool.id, lb_health_monitor_id)
+    end
+
+    tests('#delete_lb_health_monitor').succeeds do
+      lb_health_monitor_id = Fog::Network[:openstack].lb_health_monitors.all.first.id
+      Fog::Network[:openstack].delete_lb_health_monitor(lb_health_monitor_id)
+    end
+  end
+
+  tests('failure') do
+    tests('#get_lb_health_monitor').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].get_lb_health_monitor(0)
+    end
+
+    tests('#update_lb_health_monitor').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].update_lb_health_monitor(0, {})
+    end
+
+    tests('#associate_lb_health_monitor').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].associate_lb_health_monitor(0, 0)
+    end
+
+    tests('#disassociate_lb_health_monitor').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].disassociate_lb_health_monitor(0, 0)
+    end
+
+    tests('#delete_lb_health_monitor').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].delete_lb_health_monitor(0)
+    end
+  end
+
+end

--- a/tests/openstack/requests/network/lb_member_tests.rb
+++ b/tests/openstack/requests/network/lb_member_tests.rb
@@ -1,0 +1,60 @@
+Shindo.tests('Fog::Network[:openstack] | lb_member requests', ['openstack']) do
+
+  @lb_member_format = {
+    'id'             => String,
+    'pool_id'        => String,
+    'address'        => String,
+    'protocol_port'  => Integer,
+    'weight'         => Integer,
+    'status'         => String,
+    'admin_state_up' => Fog::Boolean,
+    'tenant_id'      => String,
+  }
+
+  tests('success') do
+    tests('#create_lb_member').formats({'member' => @lb_member_format}) do
+      pool_id = 'pool_id'
+      address = '10.0.0.1'
+      protocol_port = 80
+      weight = 100
+      attributes = {:admin_state_up => true, :tenant_id => 'tenant_id'}
+      Fog::Network[:openstack].create_lb_member(pool_id, address, protocol_port, weight, attributes).body
+    end
+
+    tests('#list_lb_members').formats({'members' => [@lb_member_format]}) do
+      Fog::Network[:openstack].list_lb_members.body
+    end
+
+    tests('#get_lb_member').formats({'member' => @lb_member_format}) do
+      lb_member_id = Fog::Network[:openstack].lb_members.all.first.id
+      Fog::Network[:openstack].get_lb_member(lb_member_id).body
+    end
+
+    tests('#update_lb_member').formats({'member' => @lb_member_format}) do
+      lb_member_id = Fog::Network[:openstack].lb_members.all.first.id
+      attributes = {:pool_id => 'new_pool_id', :weight => 50,
+                    :admin_state_up => false}
+      Fog::Network[:openstack].update_lb_member(lb_member_id, attributes).body
+    end
+
+    tests('#delete_lb_member').succeeds do
+      lb_member_id = Fog::Network[:openstack].lb_members.all.first.id
+      Fog::Network[:openstack].delete_lb_member(lb_member_id)
+    end
+  end
+
+  tests('failure') do
+    tests('#get_lb_member').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].get_lb_member(0)
+    end
+
+    tests('#update_lb_member').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].update_lb_member(0, {})
+    end
+
+    tests('#delete_lb_member').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].delete_lb_member(0)
+    end
+  end
+
+end

--- a/tests/openstack/requests/network/lb_pool_tests.rb
+++ b/tests/openstack/requests/network/lb_pool_tests.rb
@@ -1,0 +1,80 @@
+Shindo.tests('Fog::Network[:openstack] | lb_pool requests', ['openstack']) do
+
+  @lb_pool_format = {
+    'id'                 => String,
+    'subnet_id'          => String,
+    'protocol'           => String,
+    'lb_method'          => String,
+    'name'               => String,
+    'description'        => String,
+    'health_monitors'    => Array,
+    'members'            => Array,
+    'status'             => String,
+    'admin_state_up'     => Fog::Boolean,
+    'vip_id'             => Fog::Nullable::String,
+    'tenant_id'          => String,
+    'active_connections' => Fog::Nullable::Integer,
+    'bytes_in'           => Fog::Nullable::Integer,
+    'bytes_out'          => Fog::Nullable::Integer,
+    'total_connections'  => Fog::Nullable::Integer
+  }
+
+  @lb_pool_stats_format = {
+    'active_connections' => Integer,
+    'bytes_in'           => Integer,
+    'bytes_out'          => Integer,
+    'total_connections'  => Integer
+  }
+
+  tests('success') do
+    tests('#create_lb_pool').formats({'pool' => @lb_pool_format}) do
+      subnet_id = 'subnet_id'
+      protocol = 'HTTP'
+      lb_method = 'ROUND_ROBIN'
+      attributes = {:name => 'test-pool', :description => 'Test Pool',
+                    :admin_state_up => true, :tenant_id => 'tenant_id'}
+      Fog::Network[:openstack].create_lb_pool(subnet_id, protocol, lb_method, attributes).body
+    end
+
+    tests('#list_lb_pools').formats({'pools' => [@lb_pool_format]}) do
+      Fog::Network[:openstack].list_lb_pools.body
+    end
+
+    tests('#get_lb_pool').formats({'pool' => @lb_pool_format}) do
+      lb_pool_id = Fog::Network[:openstack].lb_pools.all.first.id
+      Fog::Network[:openstack].get_lb_pool(lb_pool_id).body
+    end
+
+    tests('#get_lb_pool_stats').formats({'stats' => @lb_pool_stats_format}) do
+      lb_pool_id = Fog::Network[:openstack].lb_pools.all.first.id
+      Fog::Network[:openstack].get_lb_pool_stats(lb_pool_id).body
+    end
+
+    tests('#update_lb_pool').formats({'pool' => @lb_pool_format}) do
+      lb_pool_id = Fog::Network[:openstack].lb_pools.all.first.id
+      attributes = {:name => 'new-test-pool', :description => 'New Test Pool',
+                    :lb_method => 'LEAST_CONNECTIONS', :admin_state_up => false}
+      Fog::Network[:openstack].update_lb_pool(lb_pool_id, attributes).body
+    end
+
+    tests('#delete_lb_pool').succeeds do
+      lb_pool_id = Fog::Network[:openstack].lb_pools.all.first.id
+      Fog::Network[:openstack].delete_lb_pool(lb_pool_id)
+    end
+  end
+
+  tests('failure') do
+    tests('#get_lb_pool').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].get_lb_pool(0)
+    end
+
+    tests('#update_lb_pool').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].update_lb_pool(0, {})
+    end
+
+    tests('#delete_lb_pool').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].delete_lb_pool(0)
+    end
+  end
+
+end

--- a/tests/openstack/requests/network/lb_vip_tests.rb
+++ b/tests/openstack/requests/network/lb_vip_tests.rb
@@ -1,0 +1,71 @@
+Shindo.tests('Fog::Network[:openstack] | lb_vip requests', ['openstack']) do
+
+  @lb_vip_format = {
+    'id'                  => String,
+    'subnet_id'           => String,
+    'pool_id'             => String,
+    'protocol'            => String,
+    'protocol_port'       => Integer,
+    'name'                => String,
+    'description'         => String,
+    'address'             => String,
+    'port_id'             => String,
+    'session_persistence' => Hash,
+    'connection_limit'    => Integer,
+    'status'              => String,
+    'admin_state_up'      => Fog::Boolean,
+    'tenant_id'           => String,
+  }
+
+  tests('success') do
+    tests('#create_lb_vip').formats({'vip' => @lb_vip_format}) do
+      subnet_id = 'subnet_id'
+      pool_id = 'pool_id'
+      protocol = 'HTTP'
+      protocol_port = 80
+      attributes = {:name => 'test-vip', :description => 'Test VIP',
+                    :address => '10.0.0.1', :connection_limit => 10,
+                    :session_persistence => { "cookie_name" => "COOKIE_NAME", "type" => "APP_COOKIE" },
+                    :admin_state_up => true, :tenant_id => 'tenant_id'}
+      Fog::Network[:openstack].create_lb_vip(subnet_id, pool_id, protocol, protocol_port, attributes).body
+    end
+
+    tests('#list_lb_vips').formats({'vips' => [@lb_vip_format]}) do
+      Fog::Network[:openstack].list_lb_vips.body
+    end
+
+    tests('#get_lb_vip').formats({'vip' => @lb_vip_format}) do
+      lb_vip_id = Fog::Network[:openstack].lb_vips.all.first.id
+      Fog::Network[:openstack].get_lb_vip(lb_vip_id).body
+    end
+
+    tests('#update_lb_vip').formats({'vip' => @lb_vip_format}) do
+      lb_vip_id = Fog::Network[:openstack].lb_vips.all.first.id
+      attributes = {:pool_id => 'new_pool_id', :name => 'new-test-vip',
+                    :description => 'New Test VIP', :connection_limit => 5,
+                    :session_persistence => { "type" => "HTTP_COOKIE" },
+                    :admin_state_up => false}
+      Fog::Network[:openstack].update_lb_vip(lb_vip_id, attributes).body
+    end
+
+    tests('#delete_lb_vip').succeeds do
+      lb_vip_id = Fog::Network[:openstack].lb_vips.all.first.id
+      Fog::Network[:openstack].delete_lb_vip(lb_vip_id)
+    end
+  end
+
+  tests('failure') do
+    tests('#get_lb_vip').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].get_lb_vip(0)
+    end
+
+    tests('#update_lb_vip').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].update_lb_vip(0, {})
+    end
+
+    tests('#delete_lb_vip').raises(Fog::Network::OpenStack::NotFound) do
+      Fog::Network[:openstack].delete_lb_vip(0)
+    end
+  end
+
+end


### PR DESCRIPTION
Add support for OpenStack Networking [Load Balancer as a Service (LBaaS)](http://docs.openstack.org/api/openstack-network/2.0/content/lbaas_ext.html) extension:
- Load balancing pools
- Load balancing members
- Load balancing health monitors
- Load balancing VIPs
