### PR TITLE
[openstack|image] Define get method for images

### DIFF
--- a/lib/fog/openstack/models/image/images.rb
+++ b/lib/fog/openstack/models/image/images.rb
@@ -18,6 +18,7 @@ module Fog
         def find_by_id(id)
           self.find {|image| image.id == id}
         end
+        alias_method :get, :find_by_id
 
         def public
           images = load(service.list_public_images_detailed.body['images'])

--- a/tests/openstack/models/image/images_tests.rb
+++ b/tests/openstack/models/image/images_tests.rb
@@ -7,6 +7,11 @@ Shindo.tests("Fog::Image[:openstack] | images", ['openstack']) do
       image.id == @instance['image']['id']
     end
 
+    tests('#get').succeeds do
+      image = Fog::Image[:openstack].images.get(@instance['image']['id'])
+      image.id == @instance['image']['id']
+    end
+    
     tests('#destroy').succeeds do
       Fog::Image[:openstack].images.destroy(@instance['image']['id'])
     end


### PR DESCRIPTION
Use common `get` method to get image information, This should fix the `reload` method that is not working right now (because there's no get method).

To not break existing clients, I defined the `get` method as an alias for `find_by_id`.
