### PR TITLE
Chdir in a block to dry up all method

### DIFF
--- a/lib/fog/local/models/storage/files.rb
+++ b/lib/fog/local/models/storage/files.rb
@@ -14,19 +14,19 @@ module Fog
         def all
           requires :directory
           if directory.collection.get(directory.key)
-            pwd = Dir.pwd
-            Dir.chdir(service.path_to(directory.key))
-            data = Dir.glob('**/*').reject do |file|
-              ::File.directory?(file)
-            end.map do |key|
-              path = file_path(key)
-              {
-                :content_length => ::File.size(path),
-                :key            => key,
-                :last_modified  => ::File.mtime(path)
-              }
-            end
-            Dir.chdir(pwd)
+            data = []
+            Dir.chdir(service.path_to(directory.key)) {
+              data = Dir.glob('**/*').reject do |file|
+                ::File.directory?(file)
+              end.map do |key|
+                path = file_path(key)
+                {
+                  :content_length => ::File.size(path),
+                  :key            => key,
+                  :last_modified  => ::File.mtime(path)
+                }
+              end
+            }
             load(data)
           else
             nil


### PR DESCRIPTION
Whilst testing out Fog with the `:local` provider, I kept having a problem with FakeFS. This change fixes compatibility with it but more importantly the exception raised when multiple threads access the same block is most likely the desired behaviour. Thoughts?
