### PR TITLE
Fixed typo

### DIFF
--- a/lib/fog/rackspace/docs/storage.md
+++ b/lib/fog/rackspace/docs/storage.md
@@ -278,7 +278,7 @@ This returns a `Fog::Storage::Rackspace::Directory` instance:
     cdn_cname=nil
     > 
 
-## Create Drectory
+## Create Directory
 
 To create a directory:
 


### PR DESCRIPTION
Added a missing 'i' to change "Create Drectory" to "Create Directory".
