### PR TITLE
Add API calls to manage flavor access across tenants

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -93,6 +93,11 @@ module Fog
       request :create_flavor
       request :delete_flavor
 
+      # Flavor Access
+      request :add_flavor_access
+      request :remove_flavor_access
+      request :list_tenants_with_flavor_access
+
       # Metadata
       request :list_metadata
       request :get_metadata

--- a/lib/fog/openstack/requests/compute/add_flavor_access.rb
+++ b/lib/fog/openstack/requests/compute/add_flavor_access.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        def add_flavor_access(flavor_ref, tenant_id)
+          request(
+            :body => MultiJson.encode({
+              "addTenantAccess" => {
+                "tenant" => tenant_id
+              }
+            }),
+            :expects  => [200, 203],
+            :method   => 'POST',
+            :path     => "flavors/#{flavor_ref}/action.json"
+          )
+        end
+      end
+
+      class Mock
+        def add_flavor_access(flavor_ref, tenant_id)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            "flavor_access" => [{ "tenant_id" => tenant_id, "flavor_id" => flavor_ref }]
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/compute/list_tenants_with_flavor_access.rb
+++ b/lib/fog/openstack/requests/compute/list_tenants_with_flavor_access.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        def list_tenants_with_flavor_access(flavor_ref)
+          request(
+            :expects  => [200, 203],
+            :method   => 'GET',
+            :path     => "flavors/#{flavor_ref}/os-flavor-access.json"
+          )
+        end
+      end
+
+      class Mock
+        def list_tenants_with_flavor_access(flavor_ref)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            "flavor_access" => [{ "tenant_id" => @tenant_id, "flavor_id" => flavor_ref }]
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/compute/remove_flavor_access.rb
+++ b/lib/fog/openstack/requests/compute/remove_flavor_access.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        def remove_flavor_access(flavor_ref, tenant_id)
+          request(
+            :body => MultiJson.encode({
+              "removeTenantAccess" => {
+                "tenant" => tenant_id
+              }
+            }),
+            :expects  => [200, 203],
+            :method   => 'POST',
+            :path     => "flavors/#{flavor_ref}/action.json"
+          )
+        end
+      end
+
+      class Mock
+        def remove_flavor_access(flavor_ref, tenant_id)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            "flavor_access" => []
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/tests/openstack/requests/compute/flavor_tests.rb
+++ b/tests/openstack/requests/compute/flavor_tests.rb
@@ -37,6 +37,18 @@ Shindo.tests('Fog::Compute[:openstack] | flavor requests', ['openstack']) do
       Fog::Compute[:openstack].delete_flavor('100')
     end
 
+    tests('add_flavor_access(flavor_ref, tenant_id)').formats({'flavor_access' => [{'tenant_id' => 1, 'flavor_id' => 1}]}) do
+      Fog::Compute[:openstack].add_flavor_access(1, 1).body
+    end
+
+    tests('remove_flavor_access(flavor_ref, tenant_id)').formats({'flavor_access' => []}) do
+      Fog::Compute[:openstack].remove_flavor_access(1, 1).body
+    end
+
+    tests('list_tenants_with_flavor_access(flavor_ref)').formats({'flavor_access' => [{'tenant_id' => nil, 'flavor_id' => 1}]}) do
+      Fog::Compute[:openstack].list_tenants_with_flavor_access(1).body
+    end
+
   end
 
   tests('failure') do


### PR DESCRIPTION
This commit adds the three API calls

```
add_flavor_access
remove_flavor_access
list_tenants_with_flavor_access
```

which allow to manage access rights of flavors in tenants.
