### PR TITLE
[Rackspace] add proxy support for Auth 2.0

### DIFF
--- a/lib/fog/rackspace/block_storage.rb
+++ b/lib/fog/rackspace/block_storage.rb
@@ -117,7 +117,8 @@ module Fog
           options = {
             :rackspace_api_key => @rackspace_api_key,
             :rackspace_username => @rackspace_username,
-            :rackspace_auth_url => @rackspace_auth_url
+            :rackspace_auth_url => @rackspace_auth_url,
+            :connection_options => @connection_options
           }
           super(options)
         end

--- a/lib/fog/rackspace/compute.rb
+++ b/lib/fog/rackspace/compute.rb
@@ -244,7 +244,8 @@ module Fog
              options = {
                :rackspace_api_key  => @rackspace_api_key,
                :rackspace_username => @rackspace_username,
-               :rackspace_auth_url => @rackspace_auth_url
+               :rackspace_auth_url => @rackspace_auth_url,
+               :connection_options => @connection_options
              }
              super(options)
            else

--- a/lib/fog/rackspace/compute_v2.rb
+++ b/lib/fog/rackspace/compute_v2.rb
@@ -174,7 +174,8 @@ module Fog
           options = {
             :rackspace_api_key => @rackspace_api_key,
             :rackspace_username => @rackspace_username,
-            :rackspace_auth_url => @rackspace_auth_url
+            :rackspace_auth_url => @rackspace_auth_url,
+            :connection_options => @connection_options
           }
           super(options)
         end

--- a/lib/fog/rackspace/databases.rb
+++ b/lib/fog/rackspace/databases.rb
@@ -119,7 +119,8 @@ module Fog
           options = {
             :rackspace_api_key  => @rackspace_api_key,
             :rackspace_username => @rackspace_username,
-            :rackspace_auth_url => @rackspace_auth_url
+            :rackspace_auth_url => @rackspace_auth_url,
+            :connection_options => @connection_options
           }
 
           super(options)

--- a/lib/fog/rackspace/dns.rb
+++ b/lib/fog/rackspace/dns.rb
@@ -162,7 +162,8 @@ module Fog
           options = {
             :rackspace_api_key  => @rackspace_api_key,
             :rackspace_username => @rackspace_username,
-            :rackspace_auth_url => @rackspace_auth_url
+            :rackspace_auth_url => @rackspace_auth_url,
+            :connection_options => @connection_options
           }
 
           super(options)

--- a/lib/fog/rackspace/load_balancers.rb
+++ b/lib/fog/rackspace/load_balancers.rb
@@ -150,7 +150,8 @@ module Fog
           options = {
             :rackspace_api_key => @rackspace_api_key,
             :rackspace_username => @rackspace_username,
-            :rackspace_auth_url => @rackspace_auth_url
+            :rackspace_auth_url => @rackspace_auth_url,
+            :connection_options => @connection_options
           }
           super(options)
         end

--- a/lib/fog/rackspace/service.rb
+++ b/lib/fog/rackspace/service.rb
@@ -54,7 +54,8 @@ module Fog
         hash = {
               :rackspace_api_key => identity_options[:rackspace_api_key],
               :rackspace_username => identity_options[:rackspace_username],
-              :rackspace_auth_url => identity_options[:rackspace_auth_url]
+              :rackspace_auth_url => identity_options[:rackspace_auth_url],
+              :connection_options => identity_options[:connection_options] || {}
         }
 
         @identity_service = Fog::Rackspace::Identity.new(hash)

--- a/lib/fog/rackspace/storage.rb
+++ b/lib/fog/rackspace/storage.rb
@@ -181,7 +181,8 @@ module Fog
             options = {
               :rackspace_api_key  => @rackspace_api_key,
               :rackspace_username => @rackspace_username,
-              :rackspace_auth_url => @rackspace_auth_url
+              :rackspace_auth_url => @rackspace_auth_url,
+              :connection_options => @connection_options
             }            
             super(options)
           else

--- a/tests/rackspace/block_storage_tests.rb
+++ b/tests/rackspace/block_storage_tests.rb
@@ -42,14 +42,17 @@ Shindo.tests('Fog::Rackspace::BlockStorage', ['rackspace']) do
     end
   end
 
-  tests('current authentation') do
+  tests('current authentication') do
     pending if Fog.mocking?
 
     tests('variables populated').succeeds  do
-      @service = Fog::Rackspace::BlockStorage.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0'
+      @service = Fog::Rackspace::BlockStorage.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0', :connection_options => {:ssl_verify_peer => true}
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(false, "path populated") { @service.instance_variable_get("@uri").host.nil? }
-      returns(false, "identity service was used") { @service.instance_variable_get("@identity_service").nil? }
+
+      identity_service = @service.instance_variable_get("@identity_service")
+      returns(false, "identity service was used") { identity_service.nil? }
+      returns(true, "connection_options are passed") { identity_service.instance_variable_get("@connection_options").has_key?(:ssl_verify_peer) }
       @service.list_volumes
     end
     tests('dfw region').succeeds  do

--- a/tests/rackspace/cdn_tests.rb
+++ b/tests/rackspace/cdn_tests.rb
@@ -43,10 +43,13 @@ Shindo.tests('Fog::CDN::Rackspace', ['rackspace']) do
     pending if Fog.mocking?
     
     tests('variables populated').succeeds do
-      @service = Fog::CDN::Rackspace.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0'
+      @service = Fog::CDN::Rackspace.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0', :connection_options => { :ssl_verify_peer => true }
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(false, "path populated") { @service.instance_variable_get("@uri").path.nil? }
-      returns(false, "identity service was used") { @service.instance_variable_get("@identity_service").nil? }
+      identity_service = @service.instance_variable_get("@identity_service")
+      returns(false, "identity service was used") { identity_service.nil? }
+      returns(true, "connection_options are passed") { identity_service.instance_variable_get("@connection_options").has_key?(:ssl_verify_peer) }
+
       @service.get_containers
     end
     tests('dfw region').succeeds do

--- a/tests/rackspace/compute_tests.rb
+++ b/tests/rackspace/compute_tests.rb
@@ -43,11 +43,13 @@ Shindo.tests('Rackspace | Compute', ['rackspace']) do
     pending if Fog.mocking?
 
     tests('variables populated').succeeds do
-      @service = Fog::Compute::Rackspace.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0'
+      @service = Fog::Compute::Rackspace.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0', :connection_options => { :ssl_verify_peer => true }
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(true) { (@service.instance_variable_get("@uri").host == 'servers.api.rackspacecloud.com') != nil }
 
-      returns(false, "identity service was used") { @service.instance_variable_get("@identity_service").nil? }
+      identity_service = @service.instance_variable_get("@identity_service")
+      returns(false, "identity service was used") { identity_service.nil? }
+      returns(true, "connection_options are passed") { identity_service.instance_variable_get("@connection_options").has_key?(:ssl_verify_peer) }
       @service.list_flavors
     end
 

--- a/tests/rackspace/compute_v2_tests.rb
+++ b/tests/rackspace/compute_v2_tests.rb
@@ -46,10 +46,12 @@ Shindo.tests('Fog::Compute::RackspaceV2', ['rackspace']) do
     pending if Fog.mocking?
     
     tests('variables populated').succeeds do
-      @service = Fog::Compute::RackspaceV2.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0'
+      @service = Fog::Compute::RackspaceV2.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0', :connection_options => {:ssl_verify_peer => true}
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(false, "path populated") { @service.instance_variable_get("@uri").host.nil? }
-      returns(false, "identity service was used") { @service.instance_variable_get("@identity_service").nil? }
+      identity_service = @service.instance_variable_get("@identity_service")
+      returns(false, "identity service was used") { identity_service.nil? }
+      returns(true, "connection_options are passed") { identity_service.instance_variable_get("@connection_options").has_key?(:ssl_verify_peer) }
       @service.list_flavors
     end
     tests('dfw region').succeeds do

--- a/tests/rackspace/databases_tests.rb
+++ b/tests/rackspace/databases_tests.rb
@@ -46,10 +46,13 @@ Shindo.tests('Fog::Rackspace::Databases', ['rackspace']) do |variable|
     pending if Fog.mocking?
 
     tests('variables populated').succeeds do
-      @service = Fog::Rackspace::Databases.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0'
+      @service = Fog::Rackspace::Databases.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0', :connection_options => { :ssl_verify_peer => true }
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(false, "path populated") { @service.instance_variable_get("@uri").nil? }
-      returns(false, "identity service was used") { @service.instance_variable_get("@identity_service").nil? }
+
+      identity_service = @service.instance_variable_get("@identity_service")
+      returns(false, "identity service was used") { identity_service.nil? }
+      returns(true, "connection_options are passed") { identity_service.instance_variable_get("@connection_options").has_key?(:ssl_verify_peer) }
       @service.flavors
     end
     tests('dfw region').succeeds do

--- a/tests/rackspace/dns_tests.rb
+++ b/tests/rackspace/dns_tests.rb
@@ -47,11 +47,14 @@ Shindo.tests('Fog::DNS::Rackspace', ['rackspace']) do
     pending if Fog.mocking?
 
     tests('variables populated').succeeds do
-      @service = Fog::DNS::Rackspace.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0'
+      @service = Fog::DNS::Rackspace.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0', :connection_options => { :ssl_verify_peer => true }
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(false, "path populated") { @service.instance_variable_get("@uri").host.nil? }
       returns(true, "contains tenant id") {  (@service.instance_variable_get("@uri").path =~ /\/v1\.0\/\d+$/) != nil} #dns does not error if tenant id is missing
-      returns(false, "identity service was used") { @service.instance_variable_get("@identity_service").nil? }
+
+      identity_service = @service.instance_variable_get("@identity_service")
+      returns(false, "identity service was used") { identity_service.nil? }
+      returns(true, "connection_options are passed") { identity_service.instance_variable_get("@connection_options").has_key?(:ssl_verify_peer) }
       @service.list_domains
     end
     tests('custom endpoint') do

--- a/tests/rackspace/load_balancer_tests.rb
+++ b/tests/rackspace/load_balancer_tests.rb
@@ -46,10 +46,12 @@ Shindo.tests('Fog::Rackspace::LoadBalancers', ['rackspace']) do
     pending if Fog.mocking?
 
     tests('variables populated').succeeds do
-      @service = Fog::Rackspace::LoadBalancers.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0'
+      @service = Fog::Rackspace::LoadBalancers.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0', :connection_options => { :ssl_verify_peer => true }
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(false, "path populated") { @service.instance_variable_get("@uri").host.nil? }
-      returns(false, "identity service was used") { @service.instance_variable_get("@identity_service").nil? }
+      identity_service = @service.instance_variable_get("@identity_service")
+      returns(false, "identity service was used") { identity_service.nil? }
+      returns(true, "connection_options are passed") { identity_service.instance_variable_get("@connection_options").has_key?(:ssl_verify_peer) }
       @service.list_load_balancers
     end
     tests('dfw region').succeeds do

--- a/tests/rackspace/requests/identity/token_tests.rb
+++ b/tests/rackspace/requests/identity/token_tests.rb
@@ -53,6 +53,15 @@ Shindo.tests('Fog::Rackspace::Identity | tokens', ['rackspace']) do
     tests('#create_token').formats(ACCESS_FORMAT) do
       service.create_token(username, api_key).body
     end
+
+    tests('uses connection options').returns(true) do
+      identity_service = Fog::Rackspace::Identity.new(:connection_options => { :ssl_verify_peer => true })
+
+      connection = identity_service.instance_variable_get("@connection")
+      excon = connection.instance_variable_get("@excon")
+      data = excon.instance_variable_get("@data")
+      data.has_key?(:ssl_verify_peer)
+    end
   end
 
   tests('failure') do

--- a/tests/rackspace/storage_tests.rb
+++ b/tests/rackspace/storage_tests.rb
@@ -43,10 +43,13 @@ Shindo.tests('Rackspace | Storage', ['rackspace']) do
     pending if Fog.mocking?
     
     tests('variables populated').succeeds do
-      @service = Fog::Storage::Rackspace.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0'
+      @service = Fog::Storage::Rackspace.new :rackspace_auth_url => 'https://identity.api.rackspacecloud.com/v2.0', :connection_options => { :ssl_verify_peer => true }
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(false, "path populated") { @service.instance_variable_get("@uri").nil? }
-      returns(false, "identity service was used") { @service.instance_variable_get("@identity_service").nil? }
+
+      identity_service = @service.instance_variable_get("@identity_service")
+      returns(false, "identity service was used") { identity_service.nil? }
+      returns(true, "connection_options are passed") { identity_service.instance_variable_get("@connection_options").has_key?(:ssl_verify_peer) }
       @service.head_containers
     end
     tests('dfw region').succeeds do


### PR DESCRIPTION
Auth 2.0 was not passing the connection_options hash onto the identity service consequently users were unable to use proxies with Auth 2.0. This pull request addresses that issue. 
