### PR TITLE
Add joyent API version and network support

### DIFF
--- a/lib/fog/joyent/compute.rb
+++ b/lib/fog/joyent/compute.rb
@@ -11,6 +11,7 @@ module Fog
       recognizes :joyent_url
       recognizes :joyent_keyname
       recognizes :joyent_keyfile
+      recognizes :joyent_version
 
       model_path 'fog/joyent/models/compute'
       request_path 'fog/joyent/requests/compute'
@@ -71,7 +72,10 @@ module Fog
       request :delete_machine_tag
       request :delete_all_machine_tags
 
-
+      # Networks
+      collection :networks
+      model :network
+      request :list_networks
 
       class Mock
         def self.data
@@ -163,7 +167,7 @@ module Fog
 
           response
         rescue Excon::Errors::Error => e
-          raise_if_error(e.request, e.response)
+          raise_if_error!(e.request, e.response)
         end
 
         private

--- a/lib/fog/joyent/models/compute/network.rb
+++ b/lib/fog/joyent/models/compute/network.rb
@@ -1,0 +1,12 @@
+module Fog
+  module Compute
+    class Joyent
+      class Network < Fog::Model
+        identity :id
+
+        attribute :name
+
+      end
+    end
+  end
+end

--- a/lib/fog/joyent/models/compute/networks.rb
+++ b/lib/fog/joyent/models/compute/networks.rb
@@ -1,0 +1,15 @@
+require 'fog/joyent/models/compute/network'
+module Fog
+  module Compute
+    class Joyent
+      class Networks < Fog::Collection
+
+        model Fog::Compute::Joyent::Network
+
+        def all
+          load(service.list_networks.body)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/joyent/requests/compute/list_networks.rb
+++ b/lib/fog/joyent/requests/compute/list_networks.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Compute
+    class Joyent
+
+      class Mock
+        def list_networks(options={})
+          res = Excon::Response.new
+          res.status = 200
+          res.body = self.data[:networks].values
+          res
+        end
+      end
+
+      class Real
+        def list_networks(options={})
+          request(
+            :path => "/my/networks",
+            :method => "GET",
+            :query => options,
+            :expects => 200
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adding support for listing networks in the Joyent Cloud.
:joyent_version was defined in a way that it would always
fall back to the default '~6.5'. Creating servers with
a particular network requires setting :joyent_version to '~7.0'
or greater.
