### PR TITLE
Avoid AWS Throttling on RDS Snapshots

### DIFF
--- a/lib/fog/aws/models/rds/snapshots.rb
+++ b/lib/fog/aws/models/rds/snapshots.rb
@@ -32,7 +32,7 @@ module Fog
         def all(filters = filters)
           self.filters.merge!(filters)
 
-          page = service.describe_db_snapshots(filters).body['DescribeDBSnapshotsResult']
+          page = service.describe_db_snapshots(self.filters).body['DescribeDBSnapshotsResult']
           self.filters[:marker] = page['Marker']
           load(page['DBSnapshots'])
         end


### PR DESCRIPTION
The method Fog::AWS::RDS::Snapshots#each overrides Enumerable#each, which can cause a large number of requests to AWS if, e.g., a call to #all is chained with a call to map.

This change renames the #each method to #each_page.
