### PR TITLE
Ease the restriction on version of nokogiri

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_dependency('mime-types')
   s.add_dependency('net-scp', '~>1.1')
   s.add_dependency('net-ssh', '>=2.1.3')
-  s.add_dependency('nokogiri', '~>1.5.0')
+  s.add_dependency('nokogiri', '>=1.5.0')
   s.add_dependency('ruby-hmac')
 
   ## List your development dependencies here. Development dependencies are


### PR DESCRIPTION
We want to be able to use Nokogiri 1.6.0 in a project that also requires Fog. This is because of a problem with earlier versions of Nokogiri and LibXML 2.9[1]. We ran all the Fog tests against Nokogiri 1.6.0 and everything passes.

The Fog README states that it should work with Ruby 1.8.7 and Ruby 1.9, but Nokogiri 1.6.0 will complain if you try to use it with anything less than Ruby 1.9.2. We appreciate that this might prevent this pull request making it back to master.

[1] https://github.com/sparklemotion/nokogiri/issues/829
