### PR TITLE
fix create_tenant Mock response description and name

### DIFF
--- a/lib/fog/openstack/requests/identity/create_tenant.rb
+++ b/lib/fog/openstack/requests/identity/create_tenant.rb
@@ -19,9 +19,9 @@ module Fog
           response.body = {
             'tenant' => {
               'id' => "df9a815161eba9b76cc748fd5c5af73e",
-              'description' => attributes['description'] || 'normal tenant',
+              'description' => attributes[:description] || 'normal tenant',
               'enabled' => true,
-              'name' => attributes['name'] || 'default'
+              'name' => attributes[:name] || 'default'
             }
           }
           response


### PR DESCRIPTION
The attributes hash keys are all symbols. Please reference:
https://github.com/fog/fog/blob/master/lib/fog/core/attributes.rb#L20
