### PR TITLE
Fix autoincrement when creating a flavor if private flavors exist.

### DIFF
--- a/lib/fog/openstack/models/compute/flavors.rb
+++ b/lib/fog/openstack/models/compute/flavors.rb
@@ -9,8 +9,8 @@ module Fog
 
         model Fog::Compute::OpenStack::Flavor
 
-        def all
-          data = service.list_flavors_detail.body['flavors']
+        def all(options = {})
+          data = service.list_flavors_detail(options).body['flavors']
           load(data)
         end
 

--- a/lib/fog/openstack/requests/compute/create_flavor.rb
+++ b/lib/fog/openstack/requests/compute/create_flavor.rb
@@ -12,7 +12,7 @@ module Fog
         def create_flavor(attributes)
           # Get last flavor id
           flavor_ids = Array.new
-          flavors = list_flavors_detail.body['flavors']
+          flavors = list_flavors_detail.body['flavors'] + list_flavors_detail(:is_public => false).body['flavors']
           flavors.each do |flavor|
             flavor_ids << flavor['id'].to_i
           end

--- a/lib/fog/openstack/requests/compute/list_flavors_detail.rb
+++ b/lib/fog/openstack/requests/compute/list_flavors_detail.rb
@@ -3,11 +3,12 @@ module Fog
     class OpenStack
       class Real
 
-        def list_flavors_detail
+        def list_flavors_detail(options = {})
           request(
             :expects  => [200, 203],
             :method   => 'GET',
-            :path     => 'flavors/detail.json'
+            :path     => 'flavors/detail.json',
+            :query    => options
           )
         end
 
@@ -15,7 +16,7 @@ module Fog
 
       class Mock
 
-        def list_flavors_detail
+        def list_flavors_detail(options = {})
           response = Excon::Response.new
           response.status = 200
           response.body = {


### PR DESCRIPTION
Before, only public flavors were considered when finding the next free ID. That could lead to the case where the calculated ID was already taken which lead to a conflict. This happened whenever the user tried to create a private flavor via fog and then another (private OR public) flavor afterwards. Now, we also take private flavors into account, so the conflict cannot happen anymore.

As a side effect, it is now also possible to just return all private flavors, using the :is_public => false filter on the list_flavors_detail API call or the flavors collection.
