### PR TITLE
[openvz] updates openvz exit code to check for openvz_connect_command 

### DIFF
--- a/tests/openvz/helper.rb
+++ b/tests/openvz/helper.rb
@@ -28,7 +28,7 @@ def openvz_fog_test_server_destroy
 end
 
 at_exit do
-  unless Fog.mocking?
+  unless Fog.mocking? || Fog.credentials[:openvz_connect_command].nil?
     server = openvz_service.servers.find { |s| s.name == '104' }
     if server
       server.wait_for(120) do


### PR DESCRIPTION
Updates openvz exit code to check for openvz_connect_command before attempting to run command in order prevent shindo from crashing when running live tests against a non-openvz cloud provider.
