### PR TITLE
[digitalocean] Rename do to docean in examples

### DIFF
--- a/lib/fog/digitalocean/examples/getting_started.md
+++ b/lib/fog/digitalocean/examples/getting_started.md
@@ -22,7 +22,7 @@ First, create a connection to the host:
 ```ruby
 require 'fog'
 
-do = Fog::Compute.new({
+docean = Fog::Compute.new({
   :provider => 'DigitalOcean',
   :digitalocean_api_key   => 'poiuweoruwoeiuroiwuer', # your API key here
   :digitalocean_client_id => 'lkjasoidfuoiu'          # your client key here

--- a/lib/fog/digitalocean/models/compute/server.rb
+++ b/lib/fog/digitalocean/models/compute/server.rb
@@ -76,12 +76,12 @@ module Fog
         #
         # Usually called by Fog::Collection#create
         #
-        #   do = Fog::Compute.new({
+        #   docean = Fog::Compute.new({
         #     :provider => 'DigitalOcean',
         #     :digitalocean_api_key   => 'key-here',      # your API key here
         #     :digitalocean_client_id => 'client-id-here' # your client key here
         #   })
-        #   do.servers.create :name => 'foobar',
+        #   docean.servers.create :name => 'foobar',
         #                     :image_id  => image_id_here,
         #                     :flavor_id => flavor_id_here,
         #                     :region_id => region_id_here


### PR DESCRIPTION
Avoids using a reserved word, and `docean` is also used elsewhere in
the getting started guide.
