### PR TITLE
Adds documentation for CloudSigma

### DIFF
--- a/lib/fog/cloudsigma/docs/getting_started.md
+++ b/lib/fog/cloudsigma/docs/getting_started.md
@@ -6,7 +6,7 @@ In order to use CloudSigma with Fog, you must use Fog version 1.12.0 or later.
 
 ## Setting credentials
 
-Fog uses ~/.fog to store credentials. To add CloudSigma as your default provider, simply add the following:
+Fog uses `~/.fog` to store credentials. To add CloudSigma as your default provider, simply add the following:
 
     :default:
       :cloudsigma_username: user@example.com
@@ -44,7 +44,7 @@ What this does is to stop the server, unmount the previous drive, then we attach
 
 In order to actually run the installer, you need to open a VNC session to the server. This can be done bye issue the following command:
 
-    > serve.open_vnc
+    > server.open_vnc
 
 That will print out the VNC URL, among with other data. You can simply pass the value of 'vnc_url' into your VNC client. When opening the session, you also need to provide the password, which we set to 'foobar' during the server creation.
 


### PR DESCRIPTION
This adds documentation for CloudSigma. Could you also update the [Provider documentation](http://fog.io/about/provider_documentation.html) to point to this. Also this is a vendor provided library. We have also created an email address 'dev-support@cloudsigma.com' that can be added.
