### PR TITLE
[rackspace|compute] adding parameter to save method 

### DIFF
--- a/lib/fog/rackspace/models/compute/server.rb
+++ b/lib/fog/rackspace/models/compute/server.rb
@@ -65,7 +65,7 @@ module Fog
           true
         end
 
-        def save
+        def save(options = {})
           raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
           requires :flavor_id, :image_id
           options = {


### PR DESCRIPTION
I have added a non-used parameter to the Fog::Compute::Rackspace::Server so that it has the same method signature as Fog::Compute::Rackspace::Server. This should make it easier to write fog code that's common to both server versions.
