### PR TITLE
[cli] Changes `fog --version` short option to `-v`

### DIFF
--- a/bin/fog
+++ b/bin/fog
@@ -12,7 +12,7 @@ options = OptionParser.new do |opts|
     Fog.credentials_path = file
   end
 
-  opts.on_tail('-V', '--version', 'Prints the version') do
+  opts.on_tail('-v', '--version', 'Prints the version') do
     puts Fog::VERSION
     exit
   end


### PR DESCRIPTION
Looking at a number of similar Ruby based tools, Bundler, Rubygems, Pry
and IRB all use lowercase v for the short option for `--version`

Ruby itself uses `-v` for verbose but without any further arguments
prints the version and exits.
