### PR TITLE
[openstack|image] Fix image reload

### DIFF
--- a/lib/fog/openstack/models/image/images.rb
+++ b/lib/fog/openstack/models/image/images.rb
@@ -16,7 +16,7 @@ module Fog
         end
 
         def find_by_id(id)
-          self.find {|image| image.id == id}
+          all.find {|image| image.id == id}
         end
         alias_method :get, :find_by_id
 


### PR DESCRIPTION
Instead of returning the cached image in collection, get (or find_by_id) method
should refresh the image data. This will fix the reload method, as actually it
doesn't really reload the image details.
