### PR TITLE
Increased IOPS limit to 4000.

### DIFF
--- a/lib/fog/aws/requests/compute/create_volume.rb
+++ b/lib/fog/aws/requests/compute/create_volume.rb
@@ -13,7 +13,7 @@ module Fog
         # * options<~Hash>
         #   * 'SnapshotId'<~String> - Optional, snapshot to create volume from
         #   * 'VolumeType'<~String> - Optional, volume type. standard or io1, default is standard.
-        #   * 'Iops'<~Integer> - Number of IOPS the volume supports. Required if VolumeType is io1, must be between 1 and 1000.
+        #   * 'Iops'<~Integer> - Number of IOPS the volume supports. Required if VolumeType is io1, must be between 1 and 4000.
         #
         # ==== Returns
         # * response<~Excon::Response>:
@@ -83,8 +83,8 @@ module Fog
                 raise Fog::Compute::AWS::Error.new("VolumeIOPSLimit => Volume iops of #{iops} is too low; minimum is 100.")
               end
 
-              if iops > 2000
-                raise Fog::Compute::AWS::Error.new("VolumeIOPSLimit => Volume iops of #{iops} is too high; maximum is 2000.")
+              if iops > 4000
+                raise Fog::Compute::AWS::Error.new("VolumeIOPSLimit => Volume iops of #{iops} is too high; maximum is 4000.")
               end
             end
 

--- a/tests/aws/requests/compute/volume_tests.rb
+++ b/tests/aws/requests/compute/volume_tests.rb
@@ -192,9 +192,9 @@ Shindo.tests('Fog::Compute[:aws] | volume requests', ['aws']) do
       Fog::Compute[:aws].create_volume(@server.availability_zone, 10, 'VolumeType' => 'io1', 'Iops' => 99)
     end
 
-    # iops invalid value (greater than 2000)
-    tests("#create_volume('#{@server.availability_zone}', 1024, 'VolumeType' => 'io1', 'Iops' => 2001)").raises(Fog::Compute::AWS::Error) do
-      Fog::Compute[:aws].create_volume(@server.availability_zone, 1024, 'VolumeType' => 'io1', 'Iops' => 2001)
+    # iops invalid value (greater than 4000)
+    tests("#create_volume('#{@server.availability_zone}', 1024, 'VolumeType' => 'io1', 'Iops' => 4001)").raises(Fog::Compute::AWS::Error) do
+      Fog::Compute[:aws].create_volume(@server.availability_zone, 1024, 'VolumeType' => 'io1', 'Iops' => 4001)
     end
 
     @volume.destroy


### PR DESCRIPTION
The IOPS limit for EBS volumes has been increased to 4000.

See http://aws.typepad.com/aws/2013/05/provision-up-to-4k-iops-per-ebs-volume.html
