### PR TITLE
Signature method requires x-amz-security-token header.

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -491,13 +491,14 @@ DATA
           refresh_credentials_if_expired
 
           expires = Fog::Time.now.to_date_header
+
+          params[:headers]['x-amz-security-token'] = @aws_session_token if @aws_session_token
           signature = signature(params, expires)
 
           params = request_params(params)
           params.delete(:port) unless params[:port]
 
           params[:headers]['Date'] = expires
-          params[:headers]['x-amz-security-token'] = @aws_session_token if @aws_session_token
           params[:headers]['Authorization'] = "AWS #{@aws_access_key_id}:#{signature}"
           # FIXME: ToHashParser should make this not needed
           original_params = params.dup


### PR DESCRIPTION
Before this change, when making requests to S3 on an instance using IAM role credentials I would receive that the signature was bad. While tracing the string_to_sign vs what AWS expected,  I found that this header was missing.
