### PR TITLE
Convert the raw_message for send_raw_email, just in case.

### DIFF
--- a/lib/fog/aws/requests/ses/send_raw_email.rb
+++ b/lib/fog/aws/requests/ses/send_raw_email.rb
@@ -30,7 +30,7 @@ module Fog
 
           request({
             'Action'          => 'SendRawEmail',
-            'RawMessage.Data' => Base64.encode64(raw_message).chomp!,
+            'RawMessage.Data' => Base64.encode64(raw_message.to_s).chomp!,
             :parser           => Fog::Parsers::AWS::SES::SendRawEmail.new
           }.merge(params))
         end


### PR DESCRIPTION
- This allows others to directly send Mail::Message objects via
  send_raw_email.
