### PR TITLE
[google|compute] Infer the 'image' URL correctly when inserting a server.

### DIFF
--- a/lib/fog/google/models/compute/image.rb
+++ b/lib/fog/google/models/compute/image.rb
@@ -18,19 +18,23 @@ module Fog
           requires :name
 
           data = {}
-          if project
-            data = service.get_image(name, project).body
-          elsif
-            [ 'google', 'debian-cloud', 'centos-cloud' ].each do |owner|
-              begin
-                data = service.get_image(name, owner).body
-                data[:project] = owner
-              rescue
-              end
+
+          # Try looking for the image in known projects
+          [ self.service.project,
+            'google'            ,
+            'debian-cloud'      ,
+            'centos-cloud'      ,
+          ].each do |owner|
+            begin
+              data = service.get_image(name, owner).body
+              data[:project] = owner
+            rescue
             end
           end
-          self.merge_attributes(data)
 
+          raise ArgumentError, 'Specified image was not found' if data.empty?
+
+          self.merge_attributes(data)
           self
         end
 


### PR DESCRIPTION
When inserting (creating) a new server, using a private (project
specific) image, the code would infer the resource URI for the
image incorrectly, because it would try to find the image in the
current project using an incorrect method to access the name of
the project. This patch fixes the variable reference, and changes
the loop logic to try all known project names in the same fashion.

Refs #1933
