### PR TITLE
removing coveralls support for Ruby 1.9.2 in hopes of fixing #1921

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -189,11 +189,10 @@ require "tasks/changelog_task"
 Fog::Rake::ChangelogTask.new
 
 task :coveralls_push_workaround do
-  # use_coveralls = ( Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.9.2'))
-  # # ENV['COVERAGE'] = 'false' if ( Gem::Version.new(RUBY_VERSION) <= Gem::Version.new('1.9.2'))
-  # if (ENV['COVERAGE'] != 'false') && use_coveralls
-  #   require 'coveralls/rake/task'
-  #   Coveralls::RakeTask.new
-  #   Rake::Task["coveralls:push"].invoke
-  # end
+  use_coveralls = (Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.9.2'))
+  if (ENV['COVERAGE'] != 'false') && use_coveralls
+    require 'coveralls/rake/task'
+    Coveralls::RakeTask.new
+    Rake::Task["coveralls:push"].invoke
+  end
 end

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -1,7 +1,7 @@
 require 'simplecov'
-require 'coveralls'
 
-unless ENV['COVERAGE'] == 'false'
+if ENV['COVERAGE'] != 'false' && RUBY_VERSION != "1.9.2"
+  require 'coveralls'
   SimpleCov.command_name "shindo:#{Process.pid.to_s}"
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
     SimpleCov::Formatter::HTMLFormatter,


### PR DESCRIPTION
removing coveralls support for Ruby 1.9.2 in hopes of fixing #1921

@maxlinc is the appropriate way to disable coveralls for Ruby 1.9.2?
