### PR TITLE
[fix] Corrected the service mocks for testing to respond with a 304 to values of If-Modified-Since that match Last-Modified

### DIFF
--- a/lib/fog/aws/requests/storage/get_object.rb
+++ b/lib/fog/aws/requests/storage/get_object.rb
@@ -87,7 +87,7 @@ module Fog
             if (object && !object[:delete_marker])
               if options['If-Match'] && options['If-Match'] != object['ETag']
                 response.status = 412
-              elsif options['If-Modified-Since'] && options['If-Modified-Since'] > Time.parse(object['Last-Modified'])
+              elsif options['If-Modified-Since'] && options['If-Modified-Since'] >= Time.parse(object['Last-Modified'])
                 response.status = 304
               elsif options['If-None-Match'] && options['If-None-Match'] == object['ETag']
                 response.status = 304

--- a/lib/fog/google/requests/storage/get_object.rb
+++ b/lib/fog/google/requests/storage/get_object.rb
@@ -73,7 +73,7 @@ module Fog
           if (bucket = self.data[:buckets][bucket_name]) && (object = bucket[:objects][object_name])
             if options['If-Match'] && options['If-Match'] != object['ETag']
               response.status = 412
-            elsif options['If-Modified-Since'] && options['If-Modified-Since'] > Time.parse(object['Last-Modified'])
+            elsif options['If-Modified-Since'] && options['If-Modified-Since'] >= Time.parse(object['Last-Modified'])
               response.status = 304
             elsif options['If-None-Match'] && options['If-None-Match'] == object['ETag']
               response.status = 304

--- a/lib/fog/hp/requests/storage/get_object.rb
+++ b/lib/fog/hp/requests/storage/get_object.rb
@@ -43,7 +43,7 @@ module Fog
             if (object = container[:objects][object_name])
               if options['If-Match'] && options['If-Match'] != object['ETag']
                 response.status = 412
-              elsif options['If-Modified-Since'] && options['If-Modified-Since'] > Time.parse(object['Last-Modified'])
+              elsif options['If-Modified-Since'] && options['If-Modified-Since'] >= Time.parse(object['Last-Modified'])
                 response.status = 304
               elsif options['If-None-Match'] && options['If-None-Match'] == object['ETag']
                 response.status = 304

--- a/lib/fog/internet_archive/requests/storage/get_object.rb
+++ b/lib/fog/internet_archive/requests/storage/get_object.rb
@@ -78,7 +78,7 @@ module Fog
             if (object && !object[:delete_marker])
               if options['If-Match'] && options['If-Match'] != object['ETag']
                 response.status = 412
-              elsif options['If-Modified-Since'] && options['If-Modified-Since'] > Time.parse(object['Last-Modified'])
+              elsif options['If-Modified-Since'] && options['If-Modified-Since'] >= Time.parse(object['Last-Modified'])
                 response.status = 304
               elsif options['If-None-Match'] && options['If-None-Match'] == object['ETag']
                 response.status = 304


### PR DESCRIPTION
The HTTP spec suggests that clients supply the value of Last-Modified that they previously received from the server to If-Modified-Since. When comparing If-Modified-Since > Last-Modified, however, the Mock object would fail to return a 304 for such a case.
