### PR TITLE
[aws|sts] Add support for the AssumeRole STS method.  

### DIFF
--- a/lib/fog/aws/parsers/sts/assume_role.rb
+++ b/lib/fog/aws/parsers/sts/assume_role.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Parsers
+    module AWS
+      module STS
+
+        class AssumeRole < Fog::Parsers::Base
+
+          def reset
+            @response = {}
+          end
+
+          def end_element(name)
+            case name
+            when 'SessionToken', 'SecretAccessKey', 'Expiration', 'AccessKeyId'
+              @response[name] = @value.strip
+            when 'Arn', 'AssumedRoleId'
+              @response[name] = @value.strip
+            when 'PackedPolicySize'
+              @response[name] = @value
+            when 'RequestId'
+              @response[name] = @value
+            end
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/sts/assume_role.rb
+++ b/lib/fog/aws/requests/sts/assume_role.rb
@@ -1,0 +1,46 @@
+module Fog
+  module AWS
+    class STS
+      class Real
+
+        require 'fog/aws/parsers/sts/assume_role'
+        
+        # Assume Role
+        #
+        # ==== Parameters
+        # * role_session_name<~String> - An identifier for the assumed role.
+        # * role_arn<~String> - The ARN of the role the caller is assuming.
+        # * external_id<~String> - An optional unique identifier required by the assuming role's trust identity.
+        # * policy<~String> - An optional JSON policy document
+        # * duration<~Integer> - Duration (of seconds) for the assumed role credentials to be valid (default 3600)
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'Arn'<~String>: The ARN of the assumed role/user
+        #     * 'AccessKeyId'<~String>: The AWS access key of the temporary credentials for the assumed role
+        #     * 'SecretAccessKey'<~String>: The AWS secret key of the temporary credentials for the assumed role
+        #     * 'SessionToken'<~String>: The AWS session token of the temporary credentials for the assumed role
+        #     * 'Expiration'<~Time>: The expiration time of the temporary credentials for the assumed role
+        #
+        # ==== See Also
+        # http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html
+        #
+
+        def assume_role(role_session_name, role_arn, external_id=nil, policy=nil, duration=3600)
+          request({
+            'Action'          => 'AssumeRole',
+            'RoleSessionName' => role_session_name,
+            'RoleArn'         => role_arn,
+            'Policy'          => policy && Fog::JSON.encode(policy),
+            'DurationSeconds' => duration,
+            'ExternalId'      => external_id,
+            :idempotent       => true,
+            :parser           => Fog::Parsers::AWS::STS::AssumeRole.new
+          })
+        end
+        
+      end
+    end
+  end
+end

--- a/tests/aws/requests/sts/assume_role_tests.rb
+++ b/tests/aws/requests/sts/assume_role_tests.rb
@@ -1,0 +1,19 @@
+Shindo.tests('AWS::STS | assume role', ['aws']) do
+
+	@policy = {"Statement" => [{"Effect" => "Allow", "Action" => "*", "Resource" => "*"}]}
+
+	@response_format = {
+		'SessionToken' => String,
+		'SecretAccessKey' => String,
+		'Expiration' => String,
+		'AccessKeyId' => String,
+		'Arn' => String,
+		'RequestId' => String
+	}
+	
+	tests("#assume_role('rolename', 'assumed_role_session', 'external_id', #{@policy.inspect}, 900)").formats(@response_format) do
+		pending if Fog.mocking?
+		Fog::AWS[:sts].assume_role("rolename","assumed_role_session","external_id", @policy, 900).body
+	end
+
+end


### PR DESCRIPTION
Also enable the ability for the STS service to use IAM profiles to grab credentials off the EC2 instance, as is in place for the other Fog AWS services.
