### PR TITLE
Renamed Fog::AWS::SES::Real#verify_domain to #verify_domain_identity.

### DIFF
--- a/lib/fog/aws/requests/ses/verify_domain_identity.rb
+++ b/lib/fog/aws/requests/ses/verify_domain_identity.rb
@@ -16,7 +16,7 @@ module Fog
         #     * 'ResponseMetadata'<~Hash>:
         #       * 'VerificationToken'<~String> - Verification token
         #       * 'RequestId'<~String> - Id of request
-        def verify_domain(domain)
+        def verify_domain_identity(domain)
           request({
             'Action'           => 'VerifyDomainIdentity',
             'Domain'           => domain,


### PR DESCRIPTION
- Match the AWS SES API.
