### PR TITLE
Add VPC security groups to the RDS instances.

### DIFF
--- a/lib/fog/aws/models/rds/server.rb
+++ b/lib/fog/aws/models/rds/server.rb
@@ -31,6 +31,7 @@ module Fog
         attribute :license_model, :aliases => 'LicenseModel'
         attribute :db_subnet_group_name, :aliases => 'DBSubnetGroupName'
         attribute :publicly_accessible, :aliases => 'PubliclyAccessible'
+        attribute :vpc_security_groups, :aliases => 'VpcSecurityGroups'
 
         attr_accessor :password, :parameter_group_name, :security_group_names, :port
 

--- a/lib/fog/aws/parsers/rds/db_parser.rb
+++ b/lib/fog/aws/parsers/rds/db_parser.rb
@@ -33,6 +33,11 @@ module Fog
             when 'DBParameterGroups'
               @in_db_parameter_groups = true
               @db_parameter_groups = []
+            when 'VpcSecurityGroupMembership'
+              @vpc_security_group = {}
+            when 'VpcSecurityGroups'
+              @in_vpc_security_groups = true
+              @vpc_security_groups = []
             end
             
           end
@@ -81,20 +86,37 @@ module Fog
             when 'DBSecurityGroups'
               @in_db_security_groups = false
               @db_instance['DBSecurityGroups'] = @db_security_groups
-            when 'Status', 'DBSecurityGroupName'
-              if @in_db_security_groups
-                @db_security_group[name]=value
-              end
+            when 'DBSecurityGroupName'
+              @db_security_group[name]=value
             when 'DBSecurityGroup'
               @db_security_groups << @db_security_group
               @db_security_group = {}
             
+            when 'VpcSecurityGroups'
+              @in_vpc_security_groups = false
+              @db_instance['VpcSecurityGroups'] = @vpc_security_groups
+            when 'VpcSecurityGroupMembership'
+              @vpc_security_groups << @vpc_security_group
+              @vpc_security_group = {}
+            when 'VpcSecurityGroupId'
+              @vpc_security_group[name] = value
             when 'AllocatedStorage'
               if @in_pending_modified_values
                 @pending_modified_values[name] = value.to_i
               else
                 @db_instance[name] = value.to_i
               end
+
+            when 'Status'
+              # Unfortunately, status is used in VpcSecurityGroupMemebership and
+              # DBSecurityGroups
+              if @in_db_security_groups
+                @db_security_group[name]=value
+              end
+              if @in_vpc_security_groups
+                @vpc_security_group[name] = value
+              end
+
             when 'Address'
               @endpoint[name] = value
             when 'Port'


### PR DESCRIPTION
Amazon splits credentials between DB Security and VPC Security Groups
for RDS instances. Fog currently does not parse the VPC security
groups. This patch adds that attribute to a Fog::AWS::RDS::Server.
