### PR TITLE
[aws|rds]: PubliclyAccessible is boolean.

### DIFF
--- a/lib/fog/aws/parsers/rds/db_parser.rb
+++ b/lib/fog/aws/parsers/rds/db_parser.rb
@@ -47,9 +47,9 @@ module Fog
               'DBInstanceStatus', 'DBInstanceIdentifier', 'EngineVersion', 
               'PreferredBackupWindow', 'PreferredMaintenanceWindow', 
               'AvailabilityZone', 'MasterUsername', 'DBName', 'LicenseModel',
-              'DBSubnetGroupName', 'PubliclyAccessible'
+              'DBSubnetGroupName'
               @db_instance[name] = value
-            when 'MultiAZ', 'AutoMinorVersionUpgrade'
+            when 'MultiAZ', 'AutoMinorVersionUpgrade', 'PubliclyAccessible'
               if value == 'false'
                 @db_instance[name] = false
               else


### PR DESCRIPTION
The PubliclyAccessible attribute for the AWS::RDS::Server should be
parsed as a boolean (similarly to MultiAZ).
