### PR TITLE
Must check for nil before checking for empty

### DIFF
--- a/lib/fog/cloudstack/models/compute/servers.rb
+++ b/lib/fog/cloudstack/models/compute/servers.rb
@@ -23,7 +23,7 @@ module Fog
 
         def get(server_id)
           servers = service.list_virtual_machines('id' => server_id)["listvirtualmachinesresponse"]["virtualmachine"]
-          unless servers.empty? || servers.nil?
+          unless servers.nil? || servers.empty?
             new(servers.first)
           end
         rescue Fog::Compute::Cloudstack::BadRequest


### PR DESCRIPTION
Error message gems/fog-1.14.0/lib/fog/cloudstack/models/compute/servers.rb:26:in `get': undefined method`empty?' for nil:NilClass (NoMethodError)
