### PR TITLE
Add a parameter to servers.all for rackspace v2 to make it the same as other providers

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/servers.rb
+++ b/lib/fog/rackspace/models/compute_v2/servers.rb
@@ -16,8 +16,9 @@ module Fog
         # @raise [Fog::Compute::RackspaceV2::InternalServerError] - HTTP 500
         # @raise [Fog::Compute::RackspaceV2::ServiceError]
         # @note Fog's current implementation only returns 1000 servers
+        # @note The filter parameter on the method is just to maintain compatability with other providers that support filtering.
         # @see http://docs.rackspace.com/servers/api/v2/cs-devguide/content/List_Servers-d1e2078.html
-        def all
+        def all(filters = {})
           data = service.list_servers.body['servers']
           load(data)
         end


### PR DESCRIPTION
This is just to add a dud parameter to the method to make it possible to call `servers.all` on the `Fog::Compute` object the same way across the different providers.
