### PR TITLE
Fog::Mock - random ip address generation

### DIFF
--- a/lib/fog/core.rb
+++ b/lib/fog/core.rb
@@ -8,6 +8,7 @@ require 'formatador'
 require 'openssl'
 require 'time'
 require 'timeout'
+require 'ipaddr'
 
 # internal core dependencies
 require "fog/version"

--- a/lib/fog/core/mock.rb
+++ b/lib/fog/core/mock.rb
@@ -34,6 +34,22 @@ module Fog
       raise Fog::Errors::MockNotImplemented.new("Contributions welcome!")
     end
 
+    def self.random_ip(opts = {:version => :v4})
+      version = opts[:version]
+      if version == :v6
+        bit_length = 128
+        family = Socket::AF_INET6
+      elsif version == :v4
+        bit_length = 32
+        family = Socket::AF_INET
+      else
+        raise ArgumentError, "Unknown IP version: #{version}"
+      end
+
+      seed = 1 + rand((2**bit_length)-1)
+      IPAddr.new(seed, family).to_s
+    end
+
     def self.random_base64(length)
       random_selection(
         "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/",

--- a/tests/core/mocking_tests.rb
+++ b/tests/core/mocking_tests.rb
@@ -52,6 +52,21 @@ Shindo.tests('Fog mocking', 'core') do
     end
   end
 
+  tests('Fog::Mock.random_ip') do
+    tests('Fog::Mock.random_ip').returns(true, "default to ipv4") do
+      IPAddr.new(Fog::Mock.random_ip).ipv4?
+    end
+    tests('Fog::Mock.random_ip').returns(true, "explicit ipv4") do
+      IPAddr.new(Fog::Mock.random_ip({:version => :v4})).ipv4?
+    end
+    tests('Fog::Mock.random_ip({:version => :v6})').returns(true, "changes to ipv6") do
+      IPAddr.new(Fog::Mock.random_ip({:version => :v6})).ipv6?
+    end
+    tests('Fog::Mock.random_ip({:version => :v5})').raises(ArgumentError) do
+      IPAddr.new(Fog::Mock.random_ip({:version => :v5})).ipv4?
+    end
+  end
+
   tests('Fog::Mock.not_implemented').raises(Fog::Errors::MockNotImplemented) do
     Fog::Mock.not_implemented
   end


### PR DESCRIPTION
It looks like most providers have implemented their own (often similar) methods to generate dummy IPv4 and IPv6 addresses.  It also looks like most, if not all, of them sometimes return invalid addresses like "476.4.7.4" (the 476 is too high for a valid IP address).

This adds support for Fog::Mock.random_ip (with v4 vs v6 options) so providers don't need to implement their own using Fog::Mock.random_number.

I did not include fixes in provider mocks to use the new method, but it looks like the bug exists in at least these providers:
rackspace
aws
cloudstack
ecloud
hp
ibm
internet_archive
