### PR TITLE
[xenserver] Added support to get VM by uuid

### DIFF
--- a/lib/fog/xenserver/models/compute/servers.rb
+++ b/lib/fog/xenserver/models/compute/servers.rb
@@ -48,6 +48,11 @@ module Fog
           get ref
         end
 
+        def get_by_uuid( uuid )
+          ref = service.get_vm_by_uuid( uuid )
+          get ref
+        end
+
         def get( vm_ref )
           if vm_ref && vm = service.get_record( vm_ref, 'VM' )
             new(vm)

--- a/lib/fog/xenserver/requests/compute/create_server.rb
+++ b/lib/fog/xenserver/requests/compute/create_server.rb
@@ -7,6 +7,10 @@ module Fog
           @connection.request({:parser => Fog::Parsers::XenServer::Base.new, :method => 'VM.get_by_name_label' }, label)
         end
         
+        def get_vm_by_uuid(uuid)
+          @connection.request({:parser => Fog::Parsers::XenServer::Base.new, :method => 'VM.get_by_uuid' }, uuid)
+        end
+
         def create_server_raw(config = {})
           config[:name_label] = config[:name] if config[:name]
           config.delete :name

--- a/tests/xenserver/models/compute/servers_tests.rb
+++ b/tests/xenserver/models/compute/servers_tests.rb
@@ -76,6 +76,7 @@ Shindo.tests('Fog::Compute[:xenserver] | servers collection', ['xenserver']) do
       server = conn.servers.create(:name => test_ephemeral_vm_name, 
                                    :template_name => test_template_name)
       test('by name') { servers.get_by_name(test_ephemeral_vm_name).kind_of? Fog::Compute::XenServer::Server }
+      test('by instance uuid') { servers.get_by_uuid(server.uuid).kind_of? Fog::Compute::XenServer::Server }
       test('by instance reference') { servers.get(server.reference).kind_of? Fog::Compute::XenServer::Server }
       server.destroy
     end


### PR DESCRIPTION
Sometimes its really confused to get vm by name label, if you have both with same name you need to make a double check on uuid.

Using this get_by_uuid you can get the exactly object using its uuid
