### PR TITLE
Add support for gluster volumes in libvirt

### DIFF
--- a/lib/fog/google/models/compute/flavors.rb
+++ b/lib/fog/google/models/compute/flavors.rb
@@ -10,7 +10,8 @@ module Fog
         model Fog::Compute::Google::Flavor
 
         def all
-          data = connection.list_machine_types.body["items"]
+          zone = service.list_zones.body['items'].first
+          data = connection.list_machine_types(zone['name']).body["items"]
           load(data)
         end
 

--- a/lib/fog/libvirt/models/compute/server.rb
+++ b/lib/fog/libvirt/models/compute/server.rb
@@ -123,7 +123,15 @@ module Fog
 
         def volumes
           # lazy loading of volumes
-          @volumes ||= (@volumes_path || []).map{|path| service.volumes.all(:path => path).first }
+          @volumes ||= (@volumes_path || []).map do |path|
+            # try to know if path is a fully-qualified path
+            # or a name for network devices
+            if path =~ /\A((\/)|([a-z]:\\))/
+              service.volumes.all(:path => path).first
+            else
+              service.volumes.all(:name => File.basename(path)).first
+            end
+          end
         end
 
         def private_ip_address

--- a/lib/fog/libvirt/requests/compute/list_domains.rb
+++ b/lib/fog/libvirt/requests/compute/list_domains.rb
@@ -29,7 +29,12 @@ module Fog
         end
 
         def domain_volumes xml
-          xml_elements(xml, "domain/devices/disk/source", "file")
+          domain_volumes = xml_elements(xml, "domain/devices/disk/source", "file")
+          if domain_volumes.any?
+            return domain_volumes
+          else
+            return xml_elements(xml, "domain/devices/disk/source", "name")
+          end
         end
 
         def boot_order xml


### PR DESCRIPTION
I added support for gluster disk on Libvirt.
Gluster disk doesn't have file attribute but does have name.
In glusterfs name are like 'gluster_volume_name/file'
See example:
    <disk type='network' device='disk'>
      <driver name='qemu' type='raw' cache='none'/>
      <source protocol='gluster' name='gv0/testglustervm.example.com-disk1'>
        <host name='127.0.0.1'/>
      </source>
      <target dev='vda' bus='virtio'/>
      <alias name='virtio-disk0'/>
    </disk>


See http://libvirt.org/formatdomain.html#elementsDisks