### PR TITLE
[AWS|ASG] filtering for ASG Scaling Activities

### DIFF
--- a/lib/fog/aws/models/auto_scaling/activities.rb
+++ b/lib/fog/aws/models/auto_scaling/activities.rb
@@ -4,14 +4,22 @@ module Fog
   module AWS
     class AutoScaling
       class Activities < Fog::Collection
-
         model Fog::AWS::AutoScaling::Activity
 
-        def all
+        attribute :filters
+
+        # Creates a new scaling policy.
+        def initialize(attributes={})
+          self.filters = attributes
+          super(attributes)
+        end
+
+        def all(filters = filters)
           data = []
           next_token = nil
+          self.filters = filters
           loop do
-            result = service.describe_scaling_activities('NextToken' => next_token).body['DescribeScalingActivitiesResult']
+            result = service.describe_scaling_activities(filters.merge('NextToken' => next_token)).body['DescribeScalingActivitiesResult']
             data += result['Activities']
             next_token = result['NextToken']
             break if next_token.nil?


### PR DESCRIPTION
Allow easy filtering of ASG Scaling Activities from attributes on collection initializer. Both of these forms work:

``` ruby
FogWrap.auto_scaling_api.activities("AutoScalingGroupName" => "my-asg-name")
FogWrap.auto_scaling_api.activities.all("AutoScalingGroupName" => "my-asg-name")
```

Didn't see any tests for the ASG activities for me to update :cry: 
