### PR TITLE
[AWS|ASG] parse ScalingPolicy MinAdjustmentStep

### DIFF
--- a/lib/fog/aws/parsers/auto_scaling/describe_policies.rb
+++ b/lib/fog/aws/parsers/auto_scaling/describe_policies.rb
@@ -20,13 +20,13 @@ module Fog
           def reset_alarm
             @alarm = {}
           end
-          
+
           def start_element(name, attrs = [])
             super
             case name
             when 'Alarms'
-              @in_alarms = true              
-            end            
+              @in_alarms = true
+            end
           end
 
           def end_element(name)
@@ -36,7 +36,7 @@ module Fog
 
             when 'AdjustmentType', 'AutoScalingGroupName', 'PolicyARN', 'PolicyName'
               @scaling_policy[name] = value
-            when 'Cooldown', 'ScalingAdjustment'
+            when 'Cooldown', 'MinAdjustmentStep', 'ScalingAdjustment'
               @scaling_policy[name] = value.to_i
 
             when 'NextToken'
@@ -47,7 +47,7 @@ module Fog
 
             when 'DescribePoliciesResponse'
               @response['DescribePoliciesResult'] = @results
-            
+
             when 'Alarms'
               @in_alarms = false
             when 'member'


### PR DESCRIPTION
For some reason this attribute was missing from the parser. Proof that
it exists:

http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_ScalingPolicy.html
