### PR TITLE
[google|compute] all method in Google::Compute::Servers should have filters argument

### DIFF
--- a/lib/fog/google/models/compute/servers.rb
+++ b/lib/fog/google/models/compute/servers.rb
@@ -9,14 +9,14 @@ module Fog
 
         model Fog::Compute::Google::Server
 
-        def all(zone=nil)
-          if zone.nil?
+        def all(filters={})
+          if filters['zone'].nil?
             data = []
             service.list_zones.body['items'].each do |zone|
               data += service.list_servers(zone['name']).body["items"] || []
             end
           else
-            data = service.list_servers(zone).body["items"] || []
+            data = service.list_servers(filters['zone']).body["items"] || []
           end
           load(data)
         end


### PR DESCRIPTION
I think this is a convention in all Compute providers.

Thoughts ?
