### PR TITLE
Fix Fog::Compute::Google::Flavor all method

### DIFF
--- a/lib/fog/google/models/compute/flavors.rb
+++ b/lib/fog/google/models/compute/flavors.rb
@@ -10,7 +10,8 @@ module Fog
         model Fog::Compute::Google::Flavor
 
         def all
-          data = connection.list_machine_types.body["items"]
+          zone = service.list_zones.body['items'].first
+          data = connection.list_machine_types(zone['name']).body["items"]
           load(data)
         end
 


### PR DESCRIPTION
- list_machine_types takes one zone as argument
