### PR TITLE
[rackspace|compute_v2] renaming keypairs to key_pairs 

### DIFF
--- a/lib/fog/rackspace/compute_v2.rb
+++ b/lib/fog/rackspace/compute_v2.rb
@@ -54,8 +54,8 @@ module Fog
       collection :attachments
       model :network
       collection :networks
-      model :keypair
-      collection :keypairs
+      model :key_pair
+      collection :key_pairs
 
       request_path 'fog/rackspace/requests/compute_v2'
       request :list_servers

--- a/lib/fog/rackspace/models/compute_v2/key_pair.rb
+++ b/lib/fog/rackspace/models/compute_v2/key_pair.rb
@@ -3,7 +3,7 @@ require 'fog/core/model'
 module Fog
   module Compute
     class RackspaceV2
-      class Keypair < Fog::Model
+      class KeyPair < Fog::Model
 
         # @!attribute [rw] name
         # @return [String] the keypair name

--- a/lib/fog/rackspace/models/compute_v2/key_pairs.rb
+++ b/lib/fog/rackspace/models/compute_v2/key_pairs.rb
@@ -1,13 +1,13 @@
 require 'fog/core/collection'
-require 'fog/rackspace/models/compute_v2/keypair'
+require 'fog/rackspace/models/compute_v2/key_pair'
 
 module Fog
   module Compute
     class RackspaceV2
 
-      class Keypairs < Fog::Collection
+      class KeyPairs < Fog::Collection
 
-        model Fog::Compute::RackspaceV2::Keypair
+        model Fog::Compute::RackspaceV2::KeyPair
 
         # Fetch the list of known keypairs
         # @return [Fog::Compute::RackspaceV2::Keypairs] the retreived keypairs

--- a/tests/rackspace/models/compute_v2/keypairs_tests.rb
+++ b/tests/rackspace/models/compute_v2/keypairs_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests('Fog::Compute::RackspaceV2 | keypairs', ['rackspace']) do
+Shindo.tests('Fog::Compute::RackspaceV2 | key_pairs', ['rackspace']) do
   service = Fog::Compute::RackspaceV2.new
 
   name  = Fog::Mock.random_letters(32)
@@ -7,36 +7,36 @@ Shindo.tests('Fog::Compute::RackspaceV2 | keypairs', ['rackspace']) do
   tests("API access") do
     begin
         tests("create").succeeds do
-          key = service.keypairs.create({:name => name})
+          key = service.key_pairs.create({:name => name})
         end
 
         tests("list all").succeeds do
-          service.keypairs.all
+          service.key_pairs.all
         end
 
         tests("get").succeeds do
-          service.keypairs.get(name)
+          service.key_pairs.get(name)
         end
 
         tests("delete").succeeds do
-          key = nil if service.keypairs.destroy(name)
+          key = nil if service.key_pairs.destroy(name)
           key == nil
         end
 
         tests("get unknown").returns(nil) do
-          service.keypairs.get(Fog::Mock.random_letters(32))
+          service.key_pairs.get(Fog::Mock.random_letters(32))
         end
 
         tests("delete unknown").raises(Fog::Compute::RackspaceV2::NotFound) do
-            service.keypairs.destroy(Fog::Mock.random_letters(32))
+            service.key_pairs.destroy(Fog::Mock.random_letters(32))
         end
 
         tests("create again after delete").succeeds do
-          key = service.keypairs.create({:name => name})
+          key = service.key_pairs.create({:name => name})
         end
 
         tests("create already existing").raises(Fog::Compute::RackspaceV2::ServiceError) do
-          service.keypairs.create({:name => name})
+          service.key_pairs.create({:name => name})
         end
 
     ensure


### PR DESCRIPTION
This PR renames keypairs to key_pairs to match the other compute providers.

@bartvercammen Sorry I missed this in my review. I just wanted you to be aware in case you need to make a change on your end.
