### PR TITLE
[glesys] added options to resuse ip and/or ipv6 and description

### DIFF
--- a/lib/fog/glesys/models/compute/server.rb
+++ b/lib/fog/glesys/models/compute/server.rb
@@ -67,6 +67,12 @@ module Fog
             :rootpassword   => rootpassword,
             :transfer       => transfer     || "500",
           }
+
+          # optional options when creating a server:
+          [:ip, :ipv6, :description].each do |k|
+            options[k] = attributes[k] if attributes[k]
+          end
+
           data = service.create(options)
           merge_attributes(data.body['response']['server'])
           data.status == 200 ? true : false


### PR DESCRIPTION
Adding fog-suport for optional arguments in Glesys::Server#save to
support
https://github.com/GleSYS/API/wiki/functions_server#wiki-servercreate .
