### PR TITLE
Accept public_key and public_key_path when creating GCE server

### DIFF
--- a/lib/fog/google/models/compute/server.rb
+++ b/lib/fog/google/models/compute/server.rb
@@ -70,8 +70,8 @@ module Fog
           end
 
           self.metadata.merge!({
-            "sshKeys" => "#{username}:#{File.read(public_key_path).strip}"
-          }) if public_key_path
+            "sshKeys" => "#{username}:#{public_key.strip}"
+          }) if public_key
 
           options = {
               'image' => image_name,


### PR DESCRIPTION
Earlier, the code forced the user to specify the :public_key_path
option when creating the server. In some cases, the user may want
to pass in the key itself (string), and not a path. This patch
changes the code to use the #public_key method, which will first
check if the key was specified, and only attempt to read the file
if it wasn't specified.
