### PR TITLE
[google|compute] Query global projects when get/list'ing compute images.

### DIFF
--- a/lib/fog/google/examples/get_list_images.rb
+++ b/lib/fog/google/examples/get_list_images.rb
@@ -1,0 +1,27 @@
+def test
+  connection = Fog::Compute.new({ :provider => "Google" })
+
+  # puts 'Listing images in all projects...'
+  # puts '---------------------------------'
+  images = connection.images.all
+  raise 'Could not LIST the images' unless images
+  # puts images.inspect
+
+  # puts 'Fetching a single image from a global project...'
+  # puts '------------------------------------------------'
+  img = connection.images.get('debian-6-squeeze-v20130515')
+  raise 'Could not GET the image' unless img
+  # puts img.inspect
+
+  # First, get the name of an image that is in the users 'project' (not global)
+  custom_img_name = images.detect { |img| img.project == img.service.project }
+  # Run the next test only if there is a custom image available
+  if custom_img_name
+    # puts 'Fetching a single image from the custom project'
+    # puts '----------------------------------------------'
+    img = connection.images.get(custom_img_name)
+    raise 'Could not GET the (custom) image' unless img
+    # puts img.inspect
+  end
+
+end

--- a/lib/fog/google/models/compute/image.rb
+++ b/lib/fog/google/models/compute/image.rb
@@ -12,28 +12,27 @@ module Fog
         attribute :creation_timestamp, :aliases => 'creationTimestamp'
         attribute :description
         attribute :preferred_kernel, :aliases => 'preferredKernel'
+
+        # This attribute is not available in the representation of an
+        # 'image' returned by the GCE servser (see GCE API). However,
+        # images are a global resource and a user can query for images
+        # across projects. Therefore we try to remember which project
+        # the image belongs to by tracking it in this attribute.
         attribute :project
+
+        # A RawDisk, e.g. -
+        # {
+        #   :source         => url_to_gcs_file,
+        #   :container_type => 'TAR',
+        #   :sha1Checksum   => ,
+        # }
+        attribute :raw_disk
+
 
         def reload
           requires :name
 
-          data = {}
-
-          # Try looking for the image in known projects
-          [
-            self.service.project,
-            'google',
-            'debian-cloud',
-            'centos-cloud',
-          ].each do |owner|
-            begin
-              data = service.get_image(name, owner).body
-              data[:project] = owner
-            rescue
-            end
-          end
-
-          raise ArgumentError, 'Specified image was not found' if data.empty?
+          data = service.get_image(name, self.project).body
 
           self.merge_attributes(data)
           self

--- a/lib/fog/google/models/compute/images.rb
+++ b/lib/fog/google/models/compute/images.rb
@@ -9,27 +9,53 @@ module Fog
 
         model Fog::Compute::Google::Image
 
+        GLOBAL_PROJECTS = [ 'google',
+                            'debian-cloud',
+                            'centos-cloud',
+                          ]
+
         def all
           data = []
-          [ self.service.project,
-            'google',
-            'debian-cloud',
-            'centos-cloud',
-          ].each do |project|
-            data += service.list_images(project).body["items"]
+          all_projects = GLOBAL_PROJECTS + [ self.service.project ]
+
+          all_projects.each do |project|
+            images = service.list_images(project).body["items"] || []
+
+            # Keep track of the project in which we found the image(s)
+            images.each { |img| img[:project] = project }
+            data += images
           end
+
           load(data)
         end
 
         def get(identity)
-          data = connection.get_image(identity).body
+          # Search own project before global projects
+          all_projects = [ self.service.project ] + GLOBAL_PROJECTS
+
+          data = nil
+          all_projects.each do |project|
+            begin
+              data = service.get_image(identity, project).body
+              data[:project] = project
+            rescue Fog::Errors::Error
+              next
+            else
+              break
+            end
+          end
+
+          # If it wasn't found in any project, raise
+          if data.nil?
+            raise Fog::Errors::Error.new('Unable to find the specified image '\
+                                         'in the following projects: '\
+                                         "#{all_projects.join(', ')}")
+          end
+
           new(data)
-        rescue Excon::Errors::NotFound
-          nil
         end
 
       end
-
     end
   end
 end

--- a/lib/fog/google/requests/compute/insert_server.rb
+++ b/lib/fog/google/requests/compute/insert_server.rb
@@ -30,8 +30,7 @@ module Fog
 
           if options.has_key? 'image'
             image_name = options.delete 'image'
-            # We don't know the owner of the image.
-            image = images.create({:name => image_name})
+            image = images.get(image_name)
             @image_url = @api_url + image.resource_url
             body_object['image'] = @image_url
           end


### PR DESCRIPTION
```
This patch refactors some of the code that would query global
projects when get'ing images. It makes the list of global projects
a constant on the Images collection, so that both 'get' and 'list'
can use the same list of projects to query.

Also, when bootstrapping/create'ing a server, the validation of
the specified image name is done by trying to 'get' the image
instead of 'save'ing it.
```
