### PR TITLE
[google|compute] servers.get don't catch errors

### DIFF
--- a/lib/fog/google/models/compute/servers.rb
+++ b/lib/fog/google/models/compute/servers.rb
@@ -25,8 +25,11 @@ module Fog
           response = nil
           if zone.nil?
             service.list_zones.body['items'].each do |zone|
-              response = service.get_server(identity, zone['name'])
-              break if response.status == 200
+              begin
+                response = service.get_server(identity, zone['name'])
+                break if response.status == 200
+              rescue Fog::Errors::Error
+              end
             end
           else
             response = service.get_server(identity, zone)


### PR DESCRIPTION
- If server is not present in first tested zone an error is raised
  and not catched

@icco thoughts ?
