### PR TITLE
[vsphere] searchIndex.FindByUuid datacenter parameter must be a RbVmomi::VIM::Datacenter

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_datacenters.rb
+++ b/lib/fog/vsphere/requests/compute/list_datacenters.rb
@@ -15,6 +15,7 @@ module Fog
 
         protected
 
+        # RbVmomi::VIM::Datacenter Array
         def raw_datacenters
           @raw_datacenters ||= @connection.rootFolder.childEntity.grep(RbVmomi::VIM::Datacenter)
         end


### PR DESCRIPTION
This call fails because datacenter has to be a RbVmomi::VIM::Datacenter object, not a string

```
vm = connection.get_virtual_machine("50111611-26e1-6576-a9c0-0c7ad15a47be", "XXX")
RbVmomi::Fault: InvalidRequest: vmodl.fault.InvalidRequest
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429/gems/rbvmomi-1.6.0/lib/rbvmomi/connection.rb:61:in `parse_response'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429/gems/rbvmomi-1.6.0/lib/rbvmomi/connection.rb:90:in `call'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429/gems/rbvmomi-1.6.0/lib/rbvmomi/basic_types.rb:203:in `_call'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429/gems/rbvmomi-1.6.0/lib/rbvmomi/basic_types.rb:74:in `block (2 levels) in init'
  from /Users/csanchez/dev/fog/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:15:in `get_vm_ref'
  from /Users/csanchez/dev/fog/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:6:in `get_virtual_machine'
  from (irb):18
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/cli.rb:619:in `console'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/vendor/thor/task.rb:27:in `run'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/vendor/thor/invocation.rb:120:in `invoke_task'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/vendor/thor.rb:344:in `dispatch'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/vendor/thor/base.rb:434:in `start'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/bin/bundle:20:in `block in <top (required)>'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/friendly_errors.rb:3:in `with_friendly_errors'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/bin/bundle:20:in `<top (required)>'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/bin/bundle:19:in `load'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/bin/bundle:19:in `<main>'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429/bin/ruby_noexec_wrapper:14:in `eval'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429/bin/ruby_noexec_wrapper:14:in `<main>'1.9.3-p429 :019 >
```

This call works 

```
vm = connection.get_virtual_machine("50111611-26e1-6576-a9c0-0c7ad15a47be", connection.get_raw_datacenter("XXX"))
```
