### PR TITLE
[vsphere] Fix NoMethodError: undefined method in list_virtual_machines

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
+++ b/lib/fog/vsphere/requests/compute/list_virtual_machines.rb
@@ -9,7 +9,7 @@ module Fog
 
           options[:folder] ||= options['folder']
           if options['instance_uuid'] then
-            [service.get_virtual_machine(options['instance_uuid'])]
+            [get_virtual_machine(options['instance_uuid'])]
           elsif options[:folder] && options[:datacenter] then
             list_all_virtual_machines_in_folder(options[:folder], options[:datacenter])
           else


### PR DESCRIPTION
Fix for 

```
1.9.3-p429 :055 >   vms = connection.list_virtual_machines({'instance_uuid' => "50111611-26e1-6576-a9c0-0c7ad15a47be"})
NoMethodError: undefined method `get_virtual_machine' for Fog::Compute::Vsphere:Class
  from /Users/csanchez/dev/fog/lib/fog/vsphere/requests/compute/list_virtual_machines.rb:12:in `list_virtual_machines'
  from (irb):55
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/cli.rb:619:in `console'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/vendor/thor/task.rb:27:in `run'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/vendor/thor/invocation.rb:120:in `invoke_task'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/vendor/thor.rb:344:in `dispatch'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/vendor/thor/base.rb:434:in `start'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/bin/bundle:20:in `block in <top (required)>'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/lib/bundler/friendly_errors.rb:3:in `with_friendly_errors'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/gems/bundler-1.3.5.1/bin/bundle:20:in `<top (required)>'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/bin/bundle:19:in `load'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429@global/bin/bundle:19:in `<main>'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429/bin/ruby_noexec_wrapper:14:in `eval'
  from /Users/csanchez/.rvm/gems/ruby-1.9.3-p429/bin/ruby_noexec_wrapper:14:in `<main>'
```
