### PR TITLE
[Cloudstack|Compute] Add support for keypair and userdata when creating ...

### DIFF
--- a/lib/fog/cloudstack/models/compute/server.rb
+++ b/lib/fog/cloudstack/models/compute/server.rb
@@ -34,6 +34,8 @@ module Fog
         attribute :root_device_id,                          :aliases => 'rootdeviceid'
         attribute :root_device_type,                        :aliases => 'rootdevicetype'
         attribute :group
+        attribute :key_name,                                :aliases => 'keypair'
+        attribute :user_data,                                :aliases => 'userdata'
         attribute :security_group_list,    :type => :array, :aliases => 'securitygroup'
         attribute :nics,                   :type => :array, :aliases => 'nic'
 
@@ -92,6 +94,8 @@ module Fog
             'ipaddress'         => ip_address,
             'iptonetworklist'   => ip_to_network_list,
             'projectid'         => project_id,
+            'keypair'           => key_name,
+            'userdata'           => user_data,
           }
 
           options.merge!('networkids' => network_ids) if network_ids


### PR DESCRIPTION
Change to be able to specify a keypair and userdata when creating a cloudstack vm.
