### PR TITLE
Protect against missing fields in rackspace endpoint documents

### DIFF
--- a/lib/fog/rackspace/models/identity/service_catalog.rb
+++ b/lib/fog/rackspace/models/identity/service_catalog.rb
@@ -70,7 +70,8 @@ module Fog
         def endpoints_from_array(endpoints)
           hash = {}
           endpoints.each do |endpoint|
-            region = endpoint["region"].downcase.to_sym
+            region_name = endpoint["region"]
+            region = region_name ? region_name.downcase.to_sym : :global
             url = endpoint["publicURL"].freeze
             hash[region] = url
           end


### PR DESCRIPTION
This PR will prevent catastrophic failure when building a list of endpoints where some endpoints have missing fields.

In a specific case a rackspace api endpoint returned no region key

'{"tenantId"=>"654557", "publicURL"=>"https://backup.api.rackspacecloud.com/v1.0/654557"}'

As a guard against this case, this commit sets the region to be global
should it not be defined in the endpoint hash

This is the simplest fix possible, we could expand it to validate keys, have defaults etc. 
