### PR TITLE
use params instead of prep

### DIFF
--- a/lib/fog/rackspace/models/monitoring/base.rb
+++ b/lib/fog/rackspace/models/monitoring/base.rb
@@ -19,8 +19,8 @@ module Fog
         end
 
         def compare?(b)
-          a_o = prep
-          b_o = b.prep
+          a_o = params
+          b_o = b.params
           remain = a_o.reject {|key, value| b_o[key] === value}
           remain.empty?
         end


### PR DESCRIPTION
In the transfer from rackspace-monitoring-rb to fog prep got changed to params, updating compare to match.
