### PR TITLE
[google|compute] Allow users to create images.

### DIFF
--- a/lib/fog/google/examples/image_create.rb
+++ b/lib/fog/google/examples/image_create.rb
@@ -1,0 +1,18 @@
+def test
+  connection = Fog::Compute.new({ :provider => "Google" })
+
+  rawdisk = {
+    :source         => nil, # 'http://some_valid_url_to_rootfs_tarball'
+    :container_type => 'TAR',
+  }
+
+  # Can't test this unless the 'source' points to a valid URL
+  return if rawdisk[:source].nil?
+
+  img = connection.image.create(:name             => 'test-image',
+                                :preferred_kernel => 'gce-v20130603',
+                                :description      => 'Test image (via fog)',
+                                :raw_disk         => rawdisk)
+
+  img.reload # will raise if image was not saved correctly
+end

--- a/lib/fog/google/models/compute/image.rb
+++ b/lib/fog/google/models/compute/image.rb
@@ -40,8 +40,26 @@ module Fog
 
         def save
           requires :name
+          requires :preferred_kernel
+          requires :raw_disk
 
-          reload
+          options = {
+            'preferredKernel' => preferred_kernel,
+            'rawDisk'         => raw_disk,
+            'description'     => description,
+          }
+
+          service.insert_image(name, options)
+
+          data = service.backoff_if_unfound {
+            service.get_image(self.name).body
+          }
+
+          # Track the name of the project in which we insert the image
+          data.merge!('project' => service.project)
+          self.project = self.service.project
+
+          service.images.merge_attributes(data)
         end
 
         def resource_url

--- a/lib/fog/google/requests/compute/insert_image.rb
+++ b/lib/fog/google/requests/compute/insert_image.rb
@@ -12,22 +12,29 @@ module Fog
 
       class Real
 
-        def insert_image(image_name, source)
+        def insert_image(image_name, options={})
           api_method = @compute.images.insert
+
           parameters = {
             'project' => @project,
           }
+
+          kernel_url = @api_url + 'google/global/kernels/' + \
+                      options.delete('preferredKernel').to_s
+
           body_object = {
-            "name" => image_name,
-            "sourceType" => "RAW",
-            "source" => source,
-            "preferredKernel" => '',
+            'sourceType'      => 'RAW',
+            'name'            => image_name,
+            'rawDisk'         => options.delete('rawDisk'),
+            'preferredKernel' => kernel_url,
           }
 
-          result = self.build_result(
-            api_method,
-            parameters,
-            body_object=body_object)
+          # Merge in the remaining params (only 'description' should remain)
+          body_object.merge(options)
+
+          result = self.build_result(api_method,
+                                     parameters,
+                                     body_object=body_object)
           response = self.build_response(result)
         end
 


### PR DESCRIPTION
In order to support this, we change the Image#save to accept
params from the user, and call insert_image. Also, we populate
the image model with the project name before returning the
object to the user.
