### PR TITLE
Allow legacy v1 auth for OpenStack

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -49,6 +49,15 @@ module Fog
     service(:volume,  'openstack/volume',  'Volume')
     service(:metering,  'openstack/metering',  'Metering')
 
+    def self.authenticate(options, connection_options = {})
+      case options[:openstack_auth_uri].path
+      when /v1(\.\d+)?/
+        authenticate_v1(options, connection_options)
+      else
+        authenticate_v2(options, connection_options)
+      end
+    end
+
     # legacy v1.0 style auth
     def self.authenticate_v1(options, connection_options = {})
       uri = options[:openstack_auth_uri]
@@ -69,7 +78,7 @@ module Fog
 
       return {
         :token => response.headers['X-Auth-Token'],
-        :server_management_url => response.headers['X-Server-Management-Url'],
+        :server_management_url => response.headers['X-Server-Management-Url'] || response.headers['X-Storage-Url'],
         :identity_public_endpoint => response.headers['X-Keystone']
       }
     end

--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -58,7 +58,7 @@ module Fog
         def reset_data
           self.class.data.delete(@openstack_username)
         end
-        
+
         def change_account(account)
           @original_path ||= @path
           version_string = @original_path.split('/')[1]
@@ -105,7 +105,7 @@ module Fog
         #     # List current user account details
         #     service = Fog::Storage[:openstack]
         #     service.request :method => 'HEAD'
-        #     
+        #
         # Would return something like:
         #
         #     Account:                      AUTH_1234
@@ -118,9 +118,9 @@ module Fog
         #
         #     service.change_account('AUTH_3333')
         #     service.request :method => 'HEAD'
-        # 
+        #
         # Would return something like:
-        #     
+        #
         #     Account:                      AUTH_3333
         #     Date:                         Tue, 05 Mar 2013 16:51:53 GMT
         #     X-Account-Bytes-Used:         23423433
@@ -130,9 +130,9 @@ module Fog
         # If we wan't to go back to our original admin account:
         #
         #     service.reset_account_name
-        # 
+        #
         def change_account(account)
-          @original_path ||= @path 
+          @original_path ||= @path
           version_string = @path.split('/')[1]
           @path = "/#{version_string}/#{account}"
         end
@@ -174,7 +174,7 @@ module Fog
         end
 
         private
-        
+
         def authenticate
           if !@openstack_management_url || @openstack_must_reauthenticate
             options = {
@@ -188,7 +188,7 @@ module Fog
               :openstack_endpoint_type => 'publicURL'
             }
 
-            credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)
+            credentials = Fog::OpenStack.authenticate(options, @connection_options)
 
             @current_user = credentials[:user]
             @current_tenant = credentials[:tenant]

--- a/tests/openstack/authenticate_tests.rb
+++ b/tests/openstack/authenticate_tests.rb
@@ -134,6 +134,28 @@ Shindo.tests('OpenStack | authenticate', ['openstack']) do
 
     end
 
+    tests("legacy v1 auth") do
+      headers = {
+        "X-Storage-Url"   => "https://swift.myhost.com/v1/AUTH_tenant",
+        "X-Auth-Token"    => "AUTH_yui193bdc00c1c46c5858788yuio0e1e2p",
+        "X-Trans-Id"      => "iu99nm9999f9b999c9b999dad9cd999e99",
+        "Content-Length"  => "0",
+        "Date"            => "Wed, 07 Aug 2013 11:11:11 GMT"
+      }
+
+      Excon.stub({:method => 'GET', :path => "/auth/v1.0"},
+                 {:status => 200, :body => "", :headers => headers})
+
+      returns("https://swift.myhost.com/v1/AUTH_tenant") do
+        Fog::OpenStack.authenticate_v1(
+          :openstack_auth_uri     => URI('https://swift.myhost.com/auth/v1.0'),
+          :openstack_username     => 'tenant:dev',
+          :openstack_api_key      => 'secret_key',
+          :openstack_service_type => %w[storage])[:server_management_url]
+      end
+
+    end
+
   ensure
     Excon.stubs.clear
     Excon.defaults[:mock] = @old_mock_value


### PR DESCRIPTION
This allows using "legacy" v1 auth for OpenStack, since we still use this version in production.
I had no idea how to write better tests, so if you could advise - please do.
