### PR TITLE
[aws|elb] add new style default security group

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -80,6 +80,7 @@ module Fog
       request :delete_volume
       request :delete_vpc
       request :deregister_image
+      request :describe_account_attributes
       request :describe_addresses
       request :describe_availability_zones
       request :describe_dhcp_options
@@ -192,7 +193,15 @@ module Fog
                       }
                     ],
                     'ownerId'             => owner_id
-                  }
+                  },
+                  'amazon-elb-sg' => {
+                    'groupDescription'   => 'amazon-elb-sg',
+                    'groupName'          => 'amazon-elb-sg',
+                    'groupId'            => 'amazon-elb',
+                    'ownerId'            => 'amazon-elb',
+                    'ipPermissionsEgree' => [],
+                    'ipPermissions'      => [],
+                  },
                 },
                 :network_interfaces => {},
                 :snapshots => {},
@@ -205,7 +214,33 @@ module Fog
                 :subnets => [],
                 :vpcs => [],
                 :dhcp_options => [],
-                :internet_gateways => []
+                :internet_gateways => [],
+                :account_attributes => [
+                  {
+                    "values"        => ["5"],
+                    "attributeName" => "vpc-max-security-groups-per-interface"
+                  },
+                  {
+                    "values"        => ["20"],
+                    "attributeName" => "max-instances"
+                  },
+                  {
+                    "values"        => ["EC2", "VPC"],
+                    "attributeName" => "supported-platforms"
+                  },
+                  {
+                    "values"        => ["none"],
+                    "attributeName" => "default-vpc"
+                  },
+                  {
+                    "values"        => ["5"],
+                    "attributeName" => "max-elastic-ips"
+                  },
+                  {
+                    "values"        => ["5"],
+                    "attributeName" => "vpc-max-elastic-ips"
+                  }
+                ]
               }
             end
           end
@@ -254,6 +289,11 @@ module Fog
           end
 
           images
+        end
+
+        def ec2_compatibility_mode(enabled=true)
+          values = enabled ? ["EC2", "VPC"] : ["VPC"]
+          self.data[:account_attributes].detect { |h| h["attributeName"] == "supported-platforms" }["values"] = values
         end
 
         def apply_tag_filters(resources, filters, resource_id_key)

--- a/lib/fog/aws/parsers/compute/describe_account_attributes.rb
+++ b/lib/fog/aws/parsers/compute/describe_account_attributes.rb
@@ -1,0 +1,42 @@
+module Fog
+  module Parsers
+    module Compute
+      module AWS
+
+        class DescribeAccountAttributes < Fog::Parsers::Base
+          def reset
+            @attribute = { 'values' => []}
+            @account_attributes = []
+            @response = { 'accountAttributeSet' => [] }
+          end
+
+          def start_element(name, attrs = [])
+            super
+            case name
+            when 'attributeValueSet'
+              @in_attribute_value_set = true
+            end
+          end
+
+          def end_element(name)
+            case name
+            when 'attributeName'
+              @attribute[name] = value
+            when 'attributeValue'
+              @attribute['values'] << value
+            when['requestId']
+              @response[name] = value
+            when 'item'
+              @response['accountAttributeSet'] << @attribute
+              @attribute = { 'values' => []} unless @in_attribute_value_set
+            when 'attributeValueSet'
+              @in_attribute_value_set = false
+            else
+            end
+            @response['accountAttributeSet'].uniq!
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/compute/describe_account_attributes.rb
+++ b/lib/fog/aws/requests/compute/describe_account_attributes.rb
@@ -1,0 +1,49 @@
+module Fog
+  module Compute
+    class AWS
+      class Real
+
+        require 'fog/aws/parsers/compute/describe_account_attributes'
+
+        # Describe account attributes
+        #
+        # ==== Parameters
+        # * filters<~Hash> - List of filters to limit results with
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'requestId'<~String> = Id of request
+        #     * 'accountAttributeSet'<~Array>:
+        #       * 'attributeName'<~String> - supported-platforms
+        #       * 'attributeValueSet'<~Array>:
+        #         * 'attributeValue'<~String> - Value of attribute
+        #
+        # {Amazon API Reference}[http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeAccountAttributes.html]
+
+        def describe_account_attributes(filters = {})
+          params = Fog::AWS.indexed_filters(filters)
+          request({
+            'Action'    => 'DescribeAccountAttributes',
+            :idempotent => true,
+            :parser     => Fog::Parsers::Compute::AWS::DescribeAccountAttributes.new
+          }.merge!(params))
+        end
+      end
+
+      class Mock
+        def describe_account_attributes(filters = {})
+          account_attributes = self.data[:account_attributes]
+
+          Excon::Response.new(
+            :status => 200,
+            :body => {
+              'requestId'           => Fog::AWS::Mock.request_id,
+              'accountAttributeSet' => account_attributes
+            }
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/elb/create_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer.rb
@@ -74,15 +74,29 @@ module Fog
 
           dns_name = Fog::AWS::ELB::Mock.dns_name(lb_name, @region)
 
+          region = availability_zones ? availability_zones.first.gsub(/[a-z]$/, '') : "us-east-1"
+          supported_platforms = Fog::Compute::AWS::Mock.data[region][@aws_access_key_id][:account_attributes].detect { |h| h["attributeName"] == "supported-platforms" }["values"]
+          security_group = if supported_platforms.include?("EC2")
+                             Fog::Compute::AWS::Mock.data[region][@aws_access_key_id][:security_groups]['amazon-elb-sg']
+                           else
+                             if default_sg = Fog::Compute::AWS::Mock.data[region][@aws_access_key_id][:security_groups].values.detect { |sg| sg['groupName'] =~ /default_elb/ }
+                               default_sg
+                             else
+                               default_sg_name   = "default_elb_#{Fog::Mock.random_hex(6)}"
+                               default_sg = {
+                                 'groupDescription'    => 'default elb security group',
+                                 'groupName'           => default_sg_name,
+                                 'groupId'             => Fog::AWS::Mock.security_group_id,
+                                 'ipPermissionsEgress' => [],
+                                 'ipPermissions'       => [],
+                                 'ownerId'             => self.data[:owner_id]
+                               }
+                               Fog::Compute::AWS::Mock.data[region][@aws_access_key_id][:security_groups][default_sg_name] = default_sg
+                             end
+                             default_sg
+                           end
 
-          Fog::Compute::AWS::Mock.data[@region][@aws_access_key_id][:security_groups]['amazon-elb-sg'] ||= {
-            'groupDescription'   => 'amazon-elb-sg',
-            'groupName'          => 'amazon-elb-sg',
-            'groupId'            => 'amazon-elb',
-            'ownerId'            => 'amazon-elb',
-            'ipPermissionsEgree' => [],
-            'ipPermissions'      => [],
-          }
+
 
           self.data[:load_balancers][lb_name] = {
             'AvailabilityZones' => availability_zones,
@@ -115,7 +129,7 @@ module Fog
               'Proper' => []
             },
             'SourceSecurityGroup' => {
-              'GroupName' => '',
+              'GroupName' => security_group['groupName'],
               'OwnerAlias' => ''
             }
           }

--- a/tests/aws/requests/compute/client_tests.rb
+++ b/tests/aws/requests/compute/client_tests.rb
@@ -1,0 +1,25 @@
+Shindo.tests('Fog::Compute[:aws] | account tests', ['aws']) do
+  if Fog.mocking?
+    tests('check for vpc') do
+      tests('supports both vpc and ec2 in compatibility mode').succeeds do
+        client = Fog::Compute[:aws]
+        client.ec2_compatibility_mode(true)
+        data = Fog::Compute[:aws].describe_account_attributes.body
+        data['accountAttributeSet'].any? { |s| [*s["values"]].include?("VPC") && [*s["values"]].include?("EC2") }
+      end
+      tests('supports VPC in vpc mode').succeeds do
+        client = Fog::Compute[:aws]
+        client.ec2_compatibility_mode(true)
+        data = Fog::Compute[:aws].describe_account_attributes.body
+        data['accountAttributeSet'].any? { |s| [*s["values"]].include?("VPC") }
+      end
+
+      tests('does not support VPC and EC2 in vpc mode').succeeds do
+        client = Fog::Compute[:aws]
+        client.ec2_compatibility_mode(false)
+        data = Fog::Compute[:aws].describe_account_attributes.body
+        !data['accountAttributeSet'].any? { |s| [*s["values"]].include?("VPC") && [*s["values"]].include?("EC2") }
+      end
+    end
+  end
+end


### PR DESCRIPTION
- AWS VPC enabled accounts have a new style security
  group separate from the 'amazon-elb-sg' group.
- added describe account attributes call
- use account attributes to determine elb security group
