### PR TITLE
[core] Exclude :headers hash from symbolize_credentials

### DIFF
--- a/lib/fog/core/credentials.rb
+++ b/lib/fog/core/credentials.rb
@@ -50,11 +50,16 @@ module Fog
     @credentials = new_credentials
   end
 
+  def self.symbolize_credential?(key)
+    ![:headers].include?(key)
+  end
+
   def self.symbolize_credentials(args)
     if args.is_a? Hash
       copy = Array.new
       args.each do |key, value|
-        copy.push(key.to_sym, self.symbolize_credentials(value))
+        obj = symbolize_credential?(key) ? value : self.symbolize_credentials(value)
+        copy.push(key.to_sym, obj)
       end
       Hash[*copy]
     else

--- a/tests/core/connection_tests.rb
+++ b/tests/core/connection_tests.rb
@@ -13,6 +13,16 @@ Shindo.tests('Fog::Core::Connection', ['core']) do
     end
   end
 
+  tests('new("http://example.com", false, options")') do
+    options = {
+      :headers => {'User-Agent' => 'custom agent'}
+    }
+    @instance = Fog::Core::Connection.new("http://example.com", true, options)
+    tests('user agent').returns('custom agent') do
+      @instance.instance_variable_get(:@excon).data[:headers]['User-Agent']
+    end
+  end
+
   tests('new("http://example.com", true)') do
     Fog::Core::Connection.new("http://example.com", true)
   end


### PR DESCRIPTION
This PR excludes :headers from the symbolization make it possible to override default headers.
