### PR TITLE
[google|compute] Add 'status' attribute to GCE images.

### DIFF
--- a/lib/fog/google/models/compute/image.rb
+++ b/lib/fog/google/models/compute/image.rb
@@ -28,6 +28,7 @@ module Fog
         # }
         attribute :raw_disk
 
+        attribute :status
 
         def reload
           requires :name


### PR DESCRIPTION
Subsequent 'get' or 'reload' of the image will cause this to be
populated, and the user will be able to tell when it is 'READY'.
