### PR TITLE
[google|compute] When 'insert'ing a disk, don't try to create an image.

### DIFF
--- a/lib/fog/google/requests/compute/insert_disk.rb
+++ b/lib/fog/google/requests/compute/insert_disk.rb
@@ -20,13 +20,8 @@ module Fog
           }
 
           if image_name
-            begin
-              image = images.get(image_name)
-            rescue Fog::Errors::Error
-              # We don't know the owner of the image.
-              image = images.create({:name => image_name})
-            end
-
+            image = images.get(image_name)
+            raise ArgumentError.new('Invalid image specified') unless image
             @image_url = @api_url + image.resource_url
             parameters['sourceImage'] = @image_url
           end


### PR DESCRIPTION
This patch avoids trying to create an image when trying to insert a disk (because we don't have sufficient information to create an image at that point).

I'll fix up the `insert_disk` in a subsequent patch (align it better with the [API](https://developers.google.com/compute/docs/reference/latest/disks/insert))
