### PR TITLE
[google|compute] Accept/propagate the correct params when creating a new disk

### DIFF
--- a/lib/fog/google/models/compute/disk.rb
+++ b/lib/fog/google/models/compute/disk.rb
@@ -16,17 +16,28 @@ module Fog
         attribute :description, :aliases => 'description'
         attribute :size_gb, :aliases => 'sizeGb'
         attribute :self_link, :aliases => 'selfLink'
-        attribute :image_name, :aliases => 'image'
+        attribute :source_image, :aliases => 'sourceImage'
+        attribute :source_snapshot, :aliases => 'sourceSnapshot'
+        attribute :source_snapshot_id, :aliases => 'sourceSnapshot'
 
         def save
-          data = service.insert_disk(name, size_gb, zone_name, image_name).body
+          requires :name
+          requires :zone_name
+
+          options = {}
+          if source_image.nil?
+            options['sourceSnapshot'] = source_snapshot
+            options['sizeGb']         = size_gb
+          end
+
+          data = service.insert_disk(name, zone_name, source_image, options).body
           data = service.backoff_if_unfound {service.get_disk(name, zone_name).body}
           service.disks.merge_attributes(data)
         end
 
         def destroy
-          requires :name, :zone
-          service.delete_disk(name, zone)
+          requires :name, :zone_name
+          service.delete_disk(name, zone_name)
         end
 
         def zone

--- a/lib/fog/google/requests/compute/delete_disk.rb
+++ b/lib/fog/google/requests/compute/delete_disk.rb
@@ -12,7 +12,7 @@ module Fog
 
       class Real
 
-        def delete_disk(disk_name, zone_name=@default_zone)
+        def delete_disk(disk_name, zone_name)
           api_method = @compute.disks.delete
           parameters = {
             'project' => @project,

--- a/lib/fog/google/requests/compute/get_disk.rb
+++ b/lib/fog/google/requests/compute/get_disk.rb
@@ -12,7 +12,7 @@ module Fog
 
       class Real
 
-        def get_disk(disk_name, zone_name=@default_zone)
+        def get_disk(disk_name, zone_name)
           if zone_name.start_with? 'http'
             zone_name = zone_name.split('/')[-1]
           end

--- a/lib/fog/google/requests/compute/insert_disk.rb
+++ b/lib/fog/google/requests/compute/insert_disk.rb
@@ -12,7 +12,7 @@ module Fog
 
       class Real
 
-        def insert_disk(disk_name, disk_size, zone_name=@default_zone, image_name=nil)
+        def insert_disk(disk_name, zone_name, image_name=nil, opts={})
           api_method = @compute.disks.insert
           parameters = {
             'project' => @project,
@@ -26,10 +26,22 @@ module Fog
             parameters['sourceImage'] = @image_url
           end
 
-          body_object = {
-            'name' => disk_name,
-            'sizeGb' => disk_size,
-          }
+          body_object = { 'name' => disk_name }
+
+          # These must be present if image_name is not specified
+          if image_name.nil?
+            unless opts.has_key?(:sourceSnapshot) and opts.has_key?(:sizeGb)
+              raise ArgumentError.new('Must specify image OR snapshot and '\
+                                      'disk size when creating a disk.')
+            end
+
+            body_object['sizeGb'] = opts['sizeGb'].delete
+            # TODO 'get' the sourceSnapshot to validate that it exists?
+            body_object['sourceSnapshot'] = opts['sourceSnapshot'].delete
+          end
+
+          # Merge in any remaining options (only 'description' should remain)
+          body_object.merge(opts)
 
           result = self.build_result(api_method, parameters,
                                      body_object)

--- a/lib/fog/google/requests/compute/list_disks.rb
+++ b/lib/fog/google/requests/compute/list_disks.rb
@@ -12,7 +12,7 @@ module Fog
 
       class Real
 
-        def list_disks(zone_name=@default_zone)
+        def list_disks(zone_name)
           api_method = @compute.disks.list
           parameters = {
             'project' => @project,


### PR DESCRIPTION
This patch tries to match the [API](https://developers.google.com/compute/docs/reference/latest/disks/insert)  w.r.t disk insert(create). The user is now expected to pass one of `image_name` or `size` and `snapshot` when creating a disk.
