### PR TITLE
[core] exclude :headers from symbolization for real this time

### DIFF
--- a/lib/fog/core/credentials.rb
+++ b/lib/fog/core/credentials.rb
@@ -58,7 +58,7 @@ module Fog
     if args.is_a? Hash
       copy = Array.new
       args.each do |key, value|
-        obj = symbolize_credential?(key) ? value : self.symbolize_credentials(value)
+        obj = symbolize_credential?(key) ? self.symbolize_credentials(value) : value
         copy.push(key.to_sym, obj)
       end
       Hash[*copy]

--- a/tests/core/connection_tests.rb
+++ b/tests/core/connection_tests.rb
@@ -13,16 +13,6 @@ Shindo.tests('Fog::Core::Connection', ['core']) do
     end
   end
 
-  tests('new("http://example.com", false, options")') do
-    options = {
-      :headers => {'User-Agent' => 'custom agent'}
-    }
-    @instance = Fog::Core::Connection.new("http://example.com", true, options)
-    tests('user agent').returns('custom agent') do
-      @instance.instance_variable_get(:@excon).data[:headers]['User-Agent']
-    end
-  end
-
   tests('new("http://example.com", true)') do
     Fog::Core::Connection.new("http://example.com", true)
   end

--- a/tests/core/credential_tests.rb
+++ b/tests/core/credential_tests.rb
@@ -63,4 +63,25 @@ Shindo.tests do
       Fog.credentials_path
     }
   end
+
+  tests('symbolize_credential?') do
+    returns(true, "username") { Fog.symbolize_credential?(:username) }
+    returns(false, "headers") { Fog.symbolize_credential?(:headers) }
+  end
+
+  tests('symbolize_credentials') do
+    h = {
+      "a" => 3,
+      :something => 2,
+      "connection_options" => {"val" => 5},
+      :headers => { 'User-Agent' => "my user agent" }
+      }
+
+      returns({
+        :a => 3,
+        :something => 2,
+        :connection_options => {:val => 5},
+        :headers => { 'User-Agent' => "my user agent" }
+        }) { Fog.symbolize_credentials h }
+  end
 end

--- a/tests/core/service_tests.rb
+++ b/tests/core/service_tests.rb
@@ -1,0 +1,26 @@
+Shindo.tests('Fog::Service', ['core']) do
+
+  class TestService < Fog::Service
+    recognizes :generic_user, :generic_api_key
+
+    class Real
+      attr_reader :options
+
+      def initialize(opts={})
+        @options = opts
+      end
+    end
+
+    class Mock < Real
+    end
+  end
+
+  tests('Properly passes headers') do
+    user_agent = 'Generic Fog Client'
+    params = { :generic_user => "bob", :generic_api_key => '1234', :connection_options => {:headers => { 'User-Agent' => user_agent }}}
+    service = TestService.new(params)
+
+    returns('User-Agent' => user_agent) { service.options[:connection_options][:headers] }
+  end
+
+end

--- a/tests/rackspace/cdn_tests.rb
+++ b/tests/rackspace/cdn_tests.rb
@@ -102,7 +102,7 @@ Shindo.tests('Fog::CDN::Rackspace', ['rackspace']) do
     @service = Fog::CDN::Rackspace.new
     returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
     @service.instance_variable_set("@auth_token", "bad-token")
-    returns(204) { @service.head_containers.status }
+    returns(true) { [200, 204].include? @service.get_containers.status }
   end
 
   pending if Fog.mocking?


### PR DESCRIPTION
This PR revisits PR #2056 where I did not really exclude headers from symbolization. Good catch @burns!

I have also added lots of tests.
