### PR TITLE
[google|compute] Fix up the 'disk' api

### DIFF
--- a/lib/fog/google/models/compute/snapshot.rb
+++ b/lib/fog/google/models/compute/snapshot.rb
@@ -26,7 +26,7 @@ module Fog
         end
 
         def resource_url
-          "#{self.project}/global/snapshots/#{name}"
+          "#{self.service.project}/global/snapshots/#{name}"
         end
 
       end

--- a/lib/fog/google/requests/compute/insert_disk.rb
+++ b/lib/fog/google/requests/compute/insert_disk.rb
@@ -30,14 +30,16 @@ module Fog
 
           # These must be present if image_name is not specified
           if image_name.nil?
-            unless opts.has_key?(:sourceSnapshot) and opts.has_key?(:sizeGb)
+            unless opts.has_key?('sourceSnapshot') and opts.has_key?('sizeGb')
               raise ArgumentError.new('Must specify image OR snapshot and '\
                                       'disk size when creating a disk.')
             end
 
-            body_object['sizeGb'] = opts['sizeGb'].delete
-            # TODO 'get' the sourceSnapshot to validate that it exists?
-            body_object['sourceSnapshot'] = opts['sourceSnapshot'].delete
+            body_object['sizeGb'] = opts.delete('sizeGb')
+
+            snap = snapshots.get(opts.delete('sourceSnapshot'))
+            raise ArgumentError.new('Invalid source snapshot') unless snap
+            body_object['sourceSnapshot'] = @api_url + snap.resource_url
           end
 
           # Merge in any remaining options (only 'description' should remain)


### PR DESCRIPTION
A recent patch to introduce support for creating disks from
snapshots had a few problems:
1. Incorrect URL (to the snapshot resource) was being sent
2. Ruby syntax errors.

I looked into adding Shindo tests for this, but am not able to
since this request relies on a pre-existing snapshot which we
use for disk creation.
