### PR TITLE
[openstack|storage] Added temporary signed URL support

### DIFF
--- a/lib/fog/openstack/requests/storage/get_object_https_url.rb
+++ b/lib/fog/openstack/requests/storage/get_object_https_url.rb
@@ -18,8 +18,8 @@ module Fog
         # ==== See Also
         # http://docs.rackspace.com/files/api/v1/cf-devguide/content/Create_TempURL-d1a444.html
         def get_object_https_url(container, object, expires, options = {})
-          if @rackspace_temp_url_key.nil?
-            raise ArgumentError, "Storage must my instantiated with the :rackspace_temp_url_key option"
+          if @openstack_temp_url_key.nil?
+            raise ArgumentError, "Storage must my instantiated with the :openstack_temp_url_key option"
           end
 
           method         = 'GET'
@@ -28,7 +28,7 @@ module Fog
           object_path_unescaped = "#{@path}/#{Fog::OpenStack.escape(container)}/#{object}"
           string_to_sign = "#{method}\n#{expires}\n#{object_path_unescaped}"
 
-          hmac = Fog::HMAC.new('sha1', @rackspace_temp_url_key)
+          hmac = Fog::HMAC.new('sha1', @openstack_temp_url_key)
           sig  = sig_to_hex(hmac.sign(string_to_sign))
 
           "https://#{@host}#{object_path_escaped}?temp_url_sig=#{sig}&temp_url_expires=#{expires}"

--- a/lib/fog/openstack/requests/storage/post_set_meta_temp_url_key.rb
+++ b/lib/fog/openstack/requests/storage/post_set_meta_temp_url_key.rb
@@ -8,7 +8,7 @@ module Fog
         # used to generate signed expiring URLs.
         #
         # Once the key has been set with this request you should create new
-        # Storage objects with the :rackspace_temp_url_key option then use
+        # Storage objects with the :openstack_temp_url_key option then use
         # the get_object_https_url method to generate expiring URLs.
         #
         # *** CAUTION *** changing this secret key will invalidate any expiring

--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -9,7 +9,7 @@ module Fog
                  :openstack_api_key
       recognizes :persistent, :openstack_service_name,
                  :openstack_service_type, :openstack_tenant,
-                 :openstack_region
+                 :openstack_region, :openstack_temp_url_key
 
       model_path 'fog/openstack/models/storage'
       model       :directory
@@ -86,6 +86,7 @@ module Fog
           @openstack_region       = options[:openstack_region]
           @openstack_tenant       = options[:openstack_tenant]
           @connection_options     = options[:connection_options] || {}
+          @openstack_temp_url_key = options[:openstack_temp_url_key]
           authenticate
           @persistent = options[:persistent] || false
           @connection = Fog::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)


### PR DESCRIPTION
This commit allows user to configure `:openstack_temp_url_key` parameter to be able to use `get_object_https_url` functionality.
