### PR TITLE
[rackspace] added transaction id to monitoring exceptions

### DIFF
--- a/lib/fog/rackspace.rb
+++ b/lib/fog/rackspace.rb
@@ -19,7 +19,7 @@ module Fog
           "[#{status} | #{transaction_id}] #{super}"
         end
 
-        def self.slurp(error)
+        def self.slurp(error, service=nil)
           data = nil
           message = nil
           status_code = nil
@@ -69,7 +69,7 @@ module Fog
         #TODO - Need to find a better way to print out these validation errors when they are thrown
         attr_reader :validation_errors
 
-        def self.slurp(error)
+        def self.slurp(error, service=nil)
           new_error = super(error)
           unless new_error.response_data.nil? or new_error.response_data['badRequest'].nil?
             new_error.instance_variable_set(:@validation_errors, new_error.response_data['badRequest']['validationErrors'])

--- a/lib/fog/rackspace/compute.rb
+++ b/lib/fog/rackspace/compute.rb
@@ -204,13 +204,13 @@ module Fog
         def request(params, parse_json = true, &block)
           super(params, parse_json, &block)
         rescue Excon::Errors::NotFound => error
-          raise NotFound.slurp(error, region)
+          raise NotFound.slurp(error, self)
         rescue Excon::Errors::BadRequest => error
-          raise BadRequest.slurp error
+          raise BadRequest.slurp(error, self)
         rescue Excon::Errors::InternalServerError => error
-          raise InternalServerError.slurp error
+          raise InternalServerError.slurp(error, self)
         rescue Excon::Errors::HTTPStatusError => error
-          raise ServiceError.slurp error
+          raise ServiceError.slurp(error, self)
         end
 
         def service_net?

--- a/lib/fog/rackspace/databases.rb
+++ b/lib/fog/rackspace/databases.rb
@@ -88,13 +88,13 @@ module Fog
         def request(params, parse_json = true, &block)
           super(params, parse_json, &block)
         rescue Excon::Errors::NotFound => error
-          raise NotFound.slurp(error, region)
+          raise NotFound.slurp(error, self)
         rescue Excon::Errors::BadRequest => error
-          raise BadRequest.slurp error
+          raise BadRequest.slurp(error, self)
         rescue Excon::Errors::InternalServerError => error
-          raise InternalServerError.slurp error
+          raise InternalServerError.slurp(error, self)
         rescue Excon::Errors::HTTPStatusError => error
-          raise ServiceError.slurp error
+          raise ServiceError.slurp(error, self)
         end
 
         def endpoint_uri(service_endpoint_url=nil)

--- a/lib/fog/rackspace/dns.rb
+++ b/lib/fog/rackspace/dns.rb
@@ -115,17 +115,17 @@ module Fog
           begin
             super(params, parse_json, &block)
           rescue Excon::Errors::NotFound => error
-            raise NotFound.slurp(error, region)
+            raise NotFound.slurp(error, self)
           rescue Excon::Errors::BadRequest => error
-            raise BadRequest.slurp error
+            raise BadRequest.slurp(error, self)
           rescue Excon::Errors::InternalServerError => error
-            raise InternalServerError.slurp error
+            raise InternalServerError.slurp(error, self)
           rescue Excon::Errors::ServiceUnavailable => error
-            raise ServiceUnavailable.slurp error
+            raise ServiceUnavailable.slurp(error, self)
           rescue Excon::Errors::Conflict => error
-            raise Conflict.slurp error
+            raise Conflict.slurp(error, self)
           rescue Excon::Errors::HTTPStatusError => error
-            raise ServiceError.slurp error
+            raise ServiceError.slurp(error, self)
           end
         end
 

--- a/lib/fog/rackspace/load_balancers.rb
+++ b/lib/fog/rackspace/load_balancers.rb
@@ -122,13 +122,13 @@ module Fog
         def request(params, parse_json = true, &block)
           super(params, parse_json, &block)
         rescue Excon::Errors::NotFound => error
-          raise NotFound.slurp(error, region)
+          raise NotFound.slurp(error, self)
         rescue Excon::Errors::BadRequest => error
-          raise BadRequest.slurp error
+          raise BadRequest.slurp(error, self)
         rescue Excon::Errors::InternalServerError => error
-          raise InternalServerError.slurp error
+          raise InternalServerError.slurp(error, self)
         rescue Excon::Errors::HTTPStatusError => error
-          raise ServiceError.slurp error
+          raise ServiceError.slurp(error, self)
         end
 
         def authenticate(options={})

--- a/lib/fog/rackspace/monitoring.rb
+++ b/lib/fog/rackspace/monitoring.rb
@@ -116,22 +116,26 @@ module Fog
           @uri = super(@rackspace_endpoint || service_endpoint_url, :rackspace_monitoring_url)
         end
 
+        def request_id_header
+         "X-Response-Id"
+        end
+
         private
 
         def request(params, parse_json = true, &block)
           super(params, parse_json, &block)
           rescue Excon::Errors::BadRequest => error
-            raise BadRequest.slurp error
+            raise BadRequest.slurp(error, self)
           rescue Excon::Errors::Conflict => error
-            raise Conflict.slurp error
+            raise Conflict.slurp(error, self)
           rescue Excon::Errors::NotFound => error
-            raise NotFound.slurp(error, region)
+            raise NotFound.slurp(error, self)
           rescue Excon::Errors::ServiceUnavailable => error
-            raise ServiceUnavailable.slurp error
+            raise ServiceUnavailable.slurp(error, self)
           rescue Excon::Errors::InternalServerError => error
-            raise InternalServerError.slurp error
+            raise InternalServerError.slurp(error, self)
           rescue Excon::Errors::HTTPStatusError => error
-            raise ServiceError.slurp error
+            raise ServiceError.slurp(error, self)
         end
 
         def authenticate


### PR DESCRIPTION
Adding transaction id to monitoring exceptions. I also updated exception handling to pass the service into the `slurp` method for compute, databases, dns and load balancers.
