### PR TITLE
[rackspace|monitoring] Add alarm update test

### DIFF
--- a/tests/rackspace/requests/monitoring/alarm_tests.rb
+++ b/tests/rackspace/requests/monitoring/alarm_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests('Fog::Rackspace::Monitoring | alarm_tests', ['rackspace','rackspace_monitoring','foo']) do
+Shindo.tests('Fog::Rackspace::Monitoring | alarm_tests', ['rackspace','rackspace_monitoring']) do
   pending if Fog.mocking?
 
   account = Fog::Rackspace::Monitoring.new


### PR DESCRIPTION
The bug that previously caused this test to return an unexpected status (502) has been fixed, uncommenting the test.
