### PR TITLE
[rackspace] fix non-SSL public CDN URLs

### DIFF
--- a/lib/fog/rackspace/storage.rb
+++ b/lib/fog/rackspace/storage.rb
@@ -77,6 +77,7 @@ module Fog
           require 'mime/types'
           @rackspace_api_key = options[:rackspace_api_key]
           @rackspace_username = options[:rackspace_username]
+          @rackspace_cdn_ssl = options[:rackspace_cdn_ssl]
         end
 
         def data
@@ -93,6 +94,10 @@ module Fog
 
         def region
           @rackspace_region
+        end
+
+        def ssl?
+          !!@rackspace_cdn_ssl
         end
 
       end
@@ -134,7 +139,7 @@ module Fog
         # @return [Boolean] return true if service is returning SSL-Secured URLs in public_url methods
         # @see Directory#public_url
         def ssl?
-          !rackspace_cdn_ssl.nil?
+          !!rackspace_cdn_ssl
         end
 
         # Resets presistent service connections

--- a/tests/rackspace/storage_tests.rb
+++ b/tests/rackspace/storage_tests.rb
@@ -112,5 +112,19 @@ Shindo.tests('Rackspace | Storage', ['rackspace']) do
     pending if Fog.mocking?    
      Fog::Storage[:rackspace].account
   end
+
+  tests('ssl') do
+    tests('ssl enabled') do
+      @service = Fog::Storage::Rackspace.new(:rackspace_cdn_ssl => true)
+      returns(true) { @service.ssl? }
+    end
+    tests('ssl disabled') do
+      @service = Fog::Storage::Rackspace.new(:rackspace_cdn_ssl => false)
+      returns(false) { @service.ssl? }
+
+      @service = Fog::Storage::Rackspace.new(:rackspace_cdn_ssl => nil)
+      returns(false) { @service.ssl? }
+    end
+  end
 end
 


### PR DESCRIPTION
The implementation of `Fog::Storage::Rackspace#ssl?` was broken when initialized with `rackspace_cdn_ssl: false`. Added tests and fixed the implementation.
