### PR TITLE
[rackspace] fix excluding extra characters in Rackspace.escape

### DIFF
--- a/lib/fog/rackspace.rb
+++ b/lib/fog/rackspace.rb
@@ -130,7 +130,10 @@ module Fog
 
     # CGI.escape, but without special treatment on spaces
     def self.escape(str,extra_exclude_chars = '')
-      str.gsub(/([^a-zA-Z0-9_.-#{extra_exclude_chars}]+)/) do
+      # '-' is a special character inside a regex class so it must be first or last.
+      # Add extra excludes before the final '-' so it always remains trailing, otherwise
+      # an unwanted range is created by mistake.
+      str.gsub(/([^a-zA-Z0-9_.#{extra_exclude_chars}-]+)/) do
         '%' + $1.unpack('H2' * $1.bytesize).join('%').upcase
       end
     end

--- a/tests/rackspace/url_encoding_tests.rb
+++ b/tests/rackspace/url_encoding_tests.rb
@@ -1,3 +1,5 @@
 Shindo.tests('Rackspace | url_encoding', ['rackspace']) do
-  returns( Fog::Rackspace.escape( "is this my file?.jpg" ) ) { "is%20this%20my%20file%3F.jpg" }
+  returns("is%20this%20my%20file%3F.jpg") { Fog::Rackspace.escape("is this my file?.jpg") }
+  returns("foo/bar") { Fog::Rackspace.escape("foo/bar", "/") }
+  returns("foo%2Fbar") { Fog::Rackspace.escape("foo/bar", "0") }
 end


### PR DESCRIPTION
This regex was subtly broken when extra excluded chars were passed in. The only extra excluded chars passed in (inside fog) is `'/'`, which coincidentally combines with the leading `.-` to make the character range `.-/`. Easily fixed by making sure that `-` is always last in the character class.
