### PR TITLE
[openstack | storage] Allow passing Content-Disposition header when saving file

### DIFF
--- a/lib/fog/openstack/models/storage/file.rb
+++ b/lib/fog/openstack/models/storage/file.rb
@@ -10,6 +10,7 @@ module Fog
 
         attribute :content_length,  :aliases => ['bytes', 'Content-Length'], :type => :integer
         attribute :content_type,    :aliases => ['content_type', 'Content-Type']
+        attribute :content_disposition, :aliases => ['content_disposition', 'Content-Disposition']
         attribute :etag,            :aliases => ['hash', 'Etag']
         attribute :last_modified,   :aliases => ['last_modified', 'Last-Modified'], :type => :time
         attribute :access_control_allow_origin, :aliases => ['Access-Control-Allow-Origin']
@@ -72,6 +73,7 @@ module Fog
         def save(options = {})
           requires :body, :directory, :key
           options['Content-Type'] = content_type if content_type
+          options['Content-Disposition'] = content_disposition if content_disposition
           options['Access-Control-Allow-Origin'] = access_control_allow_origin if access_control_allow_origin
           options['Origin'] = origin if origin
           options.merge!(metadata_to_headers)

--- a/tests/openstack/models/storage/file_tests.rb
+++ b/tests/openstack/models/storage/file_tests.rb
@@ -2,6 +2,10 @@ Shindo.tests('Fog::OpenStack::Storage | file', ['openstack']) do
 
   pending if Fog.mocking?
 
+  def object_attributes(file=@instance)
+    @instance.service.head_object(@directory.key, file.key).headers
+  end
+
   def object_meta_attributes
     @instance.service.head_object(@directory.key, @instance.key).headers.reject {|k, v| !(k =~ /X-Object-Meta-/)}
   end
@@ -67,7 +71,22 @@ Shindo.tests('Fog::OpenStack::Storage | file', ['openstack']) do
         end
 
       end
-    
+
+      tests('#content_disposition') do
+        before do
+          @instance = @directory.files.create :key => 'meta-test', :body => lorem_file, :content_disposition => 'ho-ho-ho'
+        end
+
+        after do
+          clear_metadata
+          @instance.save
+        end
+
+        tests("sets Content-Disposition on create").returns("ho-ho-ho") do
+          object_attributes(@instance)["Content-Disposition"]
+        end
+      end
+
       tests('#metadata keys') do
         
         after do


### PR DESCRIPTION
Allows to save Content-Disposition as part of the file metadata
