### PR TITLE
[rackspace] Fixes potential recursive loop

### DIFF
--- a/lib/fog/rackspace/requests/identity/create_token.rb
+++ b/lib/fog/rackspace/requests/identity/create_token.rb
@@ -12,7 +12,7 @@ module Fog
             }
           }
 
-          request(
+          request_without_retry(
             :body => Fog::JSON.encode(data),
             :expects => [200, 203],
             :method => 'POST',

--- a/lib/fog/rackspace/service.rb
+++ b/lib/fog/rackspace/service.rb
@@ -30,6 +30,13 @@ module Fog
          self.send authentication_method, options
       end
 
+      def request_without_retry(params, parse_json = true, &block)
+        response = @connection.request(request_params(params), &block)
+
+        process_response(response) if parse_json
+        response
+      end
+
       def request(params, parse_json = true, &block)
         first_attempt = true
         begin

--- a/tests/rackspace/block_storage_tests.rb
+++ b/tests/rackspace/block_storage_tests.rb
@@ -105,10 +105,15 @@ Shindo.tests('Fog::Rackspace::BlockStorage', ['rackspace']) do
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service = Fog::Rackspace::BlockStorage.new  :rackspace_region => :ord
-    returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
-    @service.instance_variable_set("@auth_token", "bad-token")
-    returns(200) { @service.list_volumes.status }
+    tests('should reauth with valid credentials') do
+      @service = Fog::Rackspace::BlockStorage.new  :rackspace_region => :ord
+      returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
+      @service.instance_variable_set("@auth_token", "bad-token")
+      returns(200) { @service.list_volumes.status }
+    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) {Fog::Rackspace::BlockStorage.new :rackspace_api_key => 'bad_key' }
+    end
   end
 
 end

--- a/tests/rackspace/cdn_tests.rb
+++ b/tests/rackspace/cdn_tests.rb
@@ -99,10 +99,15 @@ Shindo.tests('Fog::CDN::Rackspace', ['rackspace']) do
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service = Fog::CDN::Rackspace.new
-    returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
-    @service.instance_variable_set("@auth_token", "bad-token")
-    returns(true) { [200, 204].include? @service.get_containers.status }
+    tests('should reauth with valid credentials') do
+      @service = Fog::CDN::Rackspace.new  :rackspace_region => :ord
+      returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
+      @service.instance_variable_set("@auth_token", "bad-token")
+      returns(true) { [200, 204].include? @service.get_containers.status }
+    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) { Fog::CDN::Rackspace.new :rackspace_api_key => 'bad_key' }
+    end
   end
 
   pending if Fog.mocking?

--- a/tests/rackspace/compute_tests.rb
+++ b/tests/rackspace/compute_tests.rb
@@ -91,9 +91,15 @@ Shindo.tests('Rackspace | Compute', ['rackspace']) do
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service =  Fog::Compute::Rackspace.new
-    returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
-    @service.instance_variable_set("@auth_token", "bad-token")
-    returns(true) { [200, 203].include?(@service.list_flavors.status) }
+    tests('should reauth with valid credentials') do
+      @service =  Fog::Compute::Rackspace.new
+      returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
+      @service.instance_variable_set("@auth_token", "bad-token")
+      returns(true) { [200, 203].include?(@service.list_flavors.status) }
+    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) { Fog::Compute::Rackspace.new :rackspace_api_key => 'bad_key' }
+    end
+
   end
 end

--- a/tests/rackspace/compute_v2_tests.rb
+++ b/tests/rackspace/compute_v2_tests.rb
@@ -104,10 +104,15 @@ Shindo.tests('Fog::Compute::RackspaceV2', ['rackspace']) do
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service = Fog::Compute::RackspaceV2.new
-    returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
-    @service.instance_variable_set("@auth_token", "bad_token")
-    returns(true) { [200, 203].include? @service.list_flavors.status }
+    tests('should reauth with valid credentials') do
+      @service = Fog::Compute::RackspaceV2.new
+      returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
+      @service.instance_variable_set("@auth_token", "bad_token")
+      returns(true) { [200, 203].include? @service.list_flavors.status }
+    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) { Fog::Compute::RackspaceV2.new :rackspace_api_key => 'bad_key' }
+    end
   end
 
 end

--- a/tests/rackspace/databases_tests.rb
+++ b/tests/rackspace/databases_tests.rb
@@ -105,10 +105,15 @@ Shindo.tests('Fog::Rackspace::Databases', ['rackspace']) do |variable|
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service = Fog::Rackspace::Databases.new
-    returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
-    @service.instance_variable_set("@auth_token", "bad_token")
-    returns(200) { @service.list_flavors.status }
+    tests('should reauth with valid credentials') do
+      @service = Fog::Rackspace::Databases.new
+      returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
+      @service.instance_variable_set("@auth_token", "bad_token")
+      returns(200) { @service.list_flavors.status }
+    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) { Fog::Rackspace::Databases.new :rackspace_api_key => 'bad_key' }
+    end
   end
 
   @service = Fog::Rackspace::Databases.new

--- a/tests/rackspace/dns_tests.rb
+++ b/tests/rackspace/dns_tests.rb
@@ -85,10 +85,15 @@ Shindo.tests('Fog::DNS::Rackspace', ['rackspace']) do
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service =Fog::DNS::Rackspace.new
-    returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
-    @service.instance_variable_set("@auth_token", "bad_token")
-    returns(200) { @service.list_domains.status }
+    tests('should reauth with valid credentials') do
+      @service = Fog::DNS::Rackspace.new
+      returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
+      @service.instance_variable_set("@auth_token", "bad_token")
+      returns(200) { @service.list_domains.status }
+    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) { Fog::DNS::Rackspace.new :rackspace_api_key => 'bad_key' }
+    end
   end
 
   tests('array_to_query_string') do

--- a/tests/rackspace/identity_tests.rb
+++ b/tests/rackspace/identity_tests.rb
@@ -16,10 +16,15 @@ Shindo.tests('Fog::Rackspace::Identity', ['rackspace']) do
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service = Fog::Rackspace::Identity.new  :rackspace_region => :ord
-    returns(true, "auth token populated") { !@service.auth_token.nil? }
-    @service.instance_variable_set("@auth_token", "bad-token")
-    returns(true) { [200, 203].include? @service.list_tenants.status }
+    tests('should reauth with valid credentials') do
+      @service = Fog::Rackspace::Identity.new  :rackspace_region => :ord
+      returns(true, "auth token populated") { !@service.auth_token.nil? }
+      @service.instance_variable_set("@auth_token", "bad-token")
+      returns(true) { [200, 203].include? @service.list_tenants.status }
+    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) { Fog::Rackspace::Identity.new :rackspace_api_key => 'bad_key' }
+    end
   end
 
 end

--- a/tests/rackspace/load_balancer_tests.rb
+++ b/tests/rackspace/load_balancer_tests.rb
@@ -105,10 +105,14 @@ Shindo.tests('Fog::Rackspace::LoadBalancers', ['rackspace']) do
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service = Fog::Rackspace::LoadBalancers.new
-    returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
-    @service.instance_variable_set("@auth_token", "bad-token")
-    returns(200) { @service.list_load_balancers.status }
+    tests('should reauth with valid credentials') do
+      @service = Fog::Rackspace::LoadBalancers.new
+      returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
+      @service.instance_variable_set("@auth_token", "bad-token")
+      returns(200) { @service.list_load_balancers.status }    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) { Fog::Rackspace::LoadBalancers.new:rackspace_api_key => 'bad_key' }
+    end
   end
 
   pending if Fog.mocking?

--- a/tests/rackspace/monitoring_tests.rb
+++ b/tests/rackspace/monitoring_tests.rb
@@ -63,10 +63,15 @@ Shindo.tests('Fog::Rackspace::Monitoring', ['rackspace','rackspace_monitoring'])
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service = Fog::Rackspace::Monitoring.new
-    returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
-    @service.instance_variable_set("@auth_token", "bad_token")
-    returns(true) { [200, 203].include? @service.list_entities.status }
+    tests('should reauth with valid credentials') do
+      @service = Fog::Rackspace::Monitoring.new
+      returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
+      @service.instance_variable_set("@auth_token", "bad_token")
+      returns(true) { [200, 203].include? @service.list_entities.status }
+    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) { Fog::Rackspace::Monitoring.new :rackspace_api_key => 'bad_key' }
+    end
   end
 
 end

--- a/tests/rackspace/storage_tests.rb
+++ b/tests/rackspace/storage_tests.rb
@@ -102,10 +102,15 @@ Shindo.tests('Rackspace | Storage', ['rackspace']) do
   tests('reauthentication') do
     pending if Fog.mocking?
 
-    @service = Fog::Storage::Rackspace.new
-    returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
-    @service.instance_variable_set("@auth_token", "bad-token")
-    returns(204) { @service.head_containers.status }
+    tests('should reauth with valid credentials') do
+      @service = Fog::Storage::Rackspace.new
+      returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
+      @service.instance_variable_set("@auth_token", "bad-token")
+      returns(204) { @service.head_containers.status }
+    end
+    tests('should terminate with incorrect credentials') do
+      raises(Excon::Errors::Unauthorized) { Fog::Storage::Rackspace.new :rackspace_api_key => 'bad_key' }
+    end
   end
     
   tests('account').succeeds do


### PR DESCRIPTION
This pull request addresses issue #2080. If fog is given invalid credentials, fog will continue to re-authenticate until a stack trace exception occurs.

This PR introduces a a `request_without_retry` method which is used by the `create_token` request method.
