### PR TITLE
NoMethodError:undefined method 'request' for #Excon::Errors::SocketError

### DIFF
--- a/lib/fog/joyent/compute.rb
+++ b/lib/fog/joyent/compute.rb
@@ -165,7 +165,7 @@ module Fog
           end
 
           response
-        rescue Excon::Errors::Error => e
+        rescue Excon::Errors::HTTPStatusError => e
           raise_if_error!(e.request, e.response)
         end
 


### PR DESCRIPTION
Only HTTPStatusError has request and response

Fixes NoMethodError:undefined method 'request' for #Excon::Errors::SocketError:0x62540a41

```
NoMethodError:undefined method `request' for #<Excon::Errors::SocketError:0x62540a41>, 
/gems/fog-1.15.0/lib/fog/joyent/compute.rb:169:in `request'
/gems/fog-1.15.0/lib/fog/joyent/requests/compute/list_machines.rb:16:in `list_machines'
/gems/fog-1.15.0/lib/fog/joyent/models/compute/servers.rb:12:in `all'
/gems/fog-1.15.0/lib/fog/core/collection.rb:141:in `lazy_load'
/gems/fog-1.15.0/lib/fog/core/collection.rb:22:in `map'
```
