### PR TITLE
Create a Snapshot based on a Disk

### DIFF
--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -42,6 +42,7 @@ module Fog
       request :insert_image
       request :insert_network
       request :insert_server
+      request :insert_snapshot
 
       request :set_metadata
 

--- a/lib/fog/google/models/compute/disk.rb
+++ b/lib/fog/google/models/compute/disk.rb
@@ -84,6 +84,29 @@ module Fog
           self
         end
 
+        def create_snapshot(snap_name, snap_desc)
+          requires :name
+          requires :zone_name
+
+          if snap_name.nil? or snap_name.empty?
+            raise ArgumentError, 'Invalid snapshot name'
+          end
+
+          options = {
+            'name'        => snap_name,
+            'description' => snap_desc,
+          }
+
+          service.insert_snapshot(name, self.zone, service.project, options)
+          data = service.backoff_if_unfound {
+            service.get_snapshot(snap_name, service.project).body
+          }
+          service.snapshots.merge_attributes(data)
+
+          # Try to return the representation of the snapshot we created
+          service.snapshots.get(snap_name)
+        end
+
         RUNNING_STATE = "READY"
 
       end

--- a/lib/fog/google/models/compute/snapshot.rb
+++ b/lib/fog/google/models/compute/snapshot.rb
@@ -15,6 +15,7 @@ module Fog
         attribute :source_disk       , :aliases => 'sourceDisk'
         attribute :source_disk_id    , :aliases => 'sourceDiskId'
         attribute :description
+        attribute :status
 
         def reload
           requires :name

--- a/lib/fog/google/requests/compute/insert_snapshot.rb
+++ b/lib/fog/google/requests/compute/insert_snapshot.rb
@@ -1,0 +1,49 @@
+module Fog
+  module Compute
+    class Google
+
+      class Mock
+
+        def insert_snapshot(snap_name)
+          Fog::Mock.not_implemented
+        end
+
+      end
+
+      class Real
+
+        def insert_snapshot(disk_name, zone_name, project=@project, opts={})
+
+          # This is unfortunate, since we might be called from 2 contexts
+          # 1. disk.snapshot <-- here validation of disk_name is not needed
+          # 2. snapshot.create <-- here we must validate the disk_name
+          #
+          # Validation would involve 'get'ing the disk by that name. This is
+          # redundant (and expensive) for case (1) which is likely the common
+          # codepath. So we won't do it.
+
+          api_method = @compute.disks.create_snapshot
+
+          parameters = {
+            'disk'    => disk_name,
+            'zone'    => zone_name,
+            'project' => @project,
+          }
+
+          snap_name = opts.delete('name')
+          raise ArgumentError.new('Must specify snapshot name') unless snap_name
+          body_object = { 'name' => snap_name }
+
+          # Merge in any remaining options (description)
+          body_object.merge(opts)
+
+          result = self.build_result(api_method, parameters,
+                                     body_object)
+          response = self.build_response(result)
+        end
+
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This patch introduces 2 ways of inserting a snapshot.
1. By calling disk#create_snapshot
2. By "inserting" into the snapshot collection (snapshot#create)

The latter doesn't directly map back to the Google API (create is not exposed on the snapshots collection), but I've implemented it here in any case. I'm open to discussing whether we should to this (the latter) at all (because validating all the params becomes a little more complex).
