### PR TITLE
[vcloud_director] 'Set-Cookie' may be lowercase

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -206,7 +206,7 @@ module Fog
            :parser    => Fog::ToHashDocument.new,
            :path      => "/api/sessions"  # curl http://example.com/api/versions | grep LoginUrl
          })
-         response.headers['Set-Cookie']
+         response.headers['Set-Cookie'] || response.headers['set-cookie']
        end
        
          


### PR DESCRIPTION
As per @b7f8db97b15f1dc48541f5f2781f70fb2b743267 for the vcloud provider, required for (at least one|some) vCloud service providers.
