### PR TITLE
[openstack|compute] Add support for config_drive

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -31,6 +31,7 @@ module Fog
         attribute :user_id
         attribute :key_name
         attribute :fault
+        attribute :config_drive
         attribute :os_dcf_disk_config, :aliases => 'OS-DCF:diskConfig'
         attribute :os_ext_srv_attr_host, :aliases => 'OS-EXT-SRV-ATTR:host'
         attribute :os_ext_srv_attr_hypervisor_hostname, :aliases => 'OS-EXT-SRV-ATTR:hypervisor_hostname'
@@ -280,6 +281,7 @@ module Fog
             'availability_zone' => availability_zone,
             'user_data' => user_data_encoded,
             'key_name'    => key_name,
+            'config_drive' => config_drive,
             'security_groups' => @security_groups,
             'min_count'   => @min_count,
             'max_count'   => @max_count,

--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -13,7 +13,7 @@ module Fog
           }
 
           vanilla_options = ['metadata', 'accessIPv4', 'accessIPv6',
-                             'availability_zone', 'user_data', 'key_name', 'adminPass']
+                             'availability_zone', 'user_data', 'key_name', 'adminPass', 'config_drive']
           vanilla_options.select{|o| options[o]}.each do |key|
             data['server'][key] = options[key]
           end
@@ -122,6 +122,7 @@ module Fog
             'created'    => '2012-09-27T00:04:18Z',
             'updated'    => '2012-09-27T00:04:27Z',
             'user_id'    => @openstack_username,
+            'config_drive' => options['config_drive'] || '',
           }
 
           response_data = {

--- a/tests/openstack/requests/compute/server_tests.rb
+++ b/tests/openstack/requests/compute/server_tests.rb
@@ -16,6 +16,7 @@ Shindo.tests('Fog::Compute[:openstack] | server requests', ['openstack']) do
     'created'    => String,
     'updated'    => String,
     'user_id'    => String,
+    'config_drive' => String,
   }
 
   @create_format = {


### PR DESCRIPTION
Add support for the [config_drive extended attribute](http://api.openstack.org/api-ref.html#ext-os-createserverext) when creating a server.
