### PR TITLE
Use meaningful error messages when interacting with Linode resources

### DIFF
--- a/lib/fog/linode/models/compute/flavors.rb
+++ b/lib/fog/linode/models/compute/flavors.rb
@@ -13,8 +13,8 @@ module Fog
 
         def get(id)
           new flavors(id).first
-        rescue Fog::Linode::Compute::NotFound
-          nil
+        rescue Fog::Linode::Compute::NotFound, ArgumentError
+          raise "Can not find a flavor with id #{id}"
         end
 
         private

--- a/lib/fog/linode/models/compute/images.rb
+++ b/lib/fog/linode/models/compute/images.rb
@@ -13,8 +13,8 @@ module Fog
 
         def get(id)
           new images(id).first
-        rescue Fog::Compute::Linode::NotFound
-          nil
+        rescue Fog::Compute::Linode::NotFound, ArgumentError
+          raise "Can not find an image with id #{id}"
         end
 
         private

--- a/lib/fog/linode/models/compute/kernels.rb
+++ b/lib/fog/linode/models/compute/kernels.rb
@@ -13,8 +13,8 @@ module Fog
 
         def get(id)
           new kernels(id).first
-        rescue Fog::Compute::Linode::NotFound
-          nil
+        rescue Fog::Compute::Linode::NotFound, ArgumentError
+          raise "Can not find a kernel with id #{id}"
         end
 
         private


### PR DESCRIPTION
I hope these simple changes save other people some debug time. Instead of raising nil and swallowing an exception these will now output a meaningful error message. I was getting the following error when using this via knife and passing in an image ID that no longer exists:

```
gems/fog-1.14.0/lib/fog/core/collection.rb:115:in `new': Initialization parameters must be an attributes hash, got NilClass nil (ArgumentError)
    from gems/fog-1.14.0/lib/fog/linode/models/compute/images.rb:15:in `get'
    from bundler/gems/knife-linode-02ecd558b064/lib/chef/knife/linode_server_create.rb:190:in `run'
    from gems/chef-11.4.2/lib/chef/knife.rb:460:in `run_with_pretty_exceptions'
    from gems/chef-11.4.2/lib/chef/knife.rb:173:in `run'
    from gems/chef-11.4.2/lib/chef/application/knife.rb:123:in `run'
    from gems/chef-11.4.2/bin/knife:25:in `<top (required)>'
    from bin/knife:23:in `load'
    from bin/knife:23:in `<main>'
```

Thanks!
