### PR TITLE
Add ability to specify availability zone for subnet during creation

### DIFF
--- a/lib/fog/aws/models/compute/subnet.rb
+++ b/lib/fog/aws/models/compute/subnet.rb
@@ -43,7 +43,9 @@ module Fog
 
         def save
           requires :vpc_id, :cidr_block
-          data = service.create_subnet(vpc_id, cidr_block).body['subnetSet'].first
+          options = {}
+          options['AvailabilityZone'] = availability_zone if availability_zone
+          data = service.create_subnet(vpc_id, cidr_block, options).body['subnetSet'].first
           new_attributes = data.reject {|key,value| key == 'requestId'}
           merge_attributes(new_attributes)
           true

--- a/tests/aws/models/compute/subnet_tests.rb
+++ b/tests/aws/models/compute/subnet_tests.rb
@@ -1,5 +1,5 @@
 Shindo.tests("Fog::Compute[:aws] | subnet", ['aws']) do
   @vpc=Fog::Compute[:aws].vpcs.create('cidr_block' => '10.0.10.0/24')
-  model_tests(Fog::Compute[:aws].subnets, {:vpc_id => @vpc.id, :cidr_block => '10.0.10.0/28'}, true)
+  model_tests(Fog::Compute[:aws].subnets, {:vpc_id => @vpc.id, :cidr_block => '10.0.10.0/28', :availability_zone => 'us-east-1b'}, true)
   @vpc.destroy
 end

--- a/tests/aws/models/compute/subnets_tests.rb
+++ b/tests/aws/models/compute/subnets_tests.rb
@@ -1,6 +1,6 @@
 Shindo.tests("Fog::Compute[:aws] | subnets", ['aws']) do
   @vpc=Fog::Compute[:aws].vpcs.create('cidr_block' => '10.0.10.0/28')
-  collection_tests(Fog::Compute[:aws].subnets, { :vpc_id => @vpc.id, :cidr_block => '10.0.10.0/28'}, true)
+  collection_tests(Fog::Compute[:aws].subnets, { :vpc_id => @vpc.id, :cidr_block => '10.0.10.0/28', :availability_zone => 'us-east-1c'}, true)
   @vpc.destroy
 end
 


### PR DESCRIPTION
The AvailabilityZone option wasn't being passed to create_subnet so I attempted to add it.
