### PR TITLE
[rackspace|block_storage] updated Volume#create to honor snapshot_id attribute

### DIFF
--- a/lib/fog/rackspace/models/block_storage/volume.rb
+++ b/lib/fog/rackspace/models/block_storage/volume.rb
@@ -104,7 +104,8 @@ module Fog
             :display_name => display_name,
             :display_description => display_description,
             :volume_type => volume_type,
-            :availability_zone => availability_zone
+            :availability_zone => availability_zone,
+            :snapshot_id => attributes[:snapshot_id]
           })
           merge_attributes(data.body['volume'])
           true


### PR DESCRIPTION
The Volume#create method does not pass the `snapshot_id` attribute to the request layer. This PR address that.
