### PR TITLE
Fix parameter group assignment when creating AWS::Elasticache clusters

### DIFF
--- a/lib/fog/aws/models/elasticache/cluster.rb
+++ b/lib/fog/aws/models/elasticache/cluster.rb
@@ -29,6 +29,8 @@ module Fog
         attribute :notification_config,
           :aliases => 'NotificationConfiguration', :type => :hash
 
+        attr_accessor :parameter_group_name
+
         def ready?
           status == 'available'
         end
@@ -57,7 +59,7 @@ module Fog
               :port                         => port,
               :preferred_availablility_zone => zone,
               :preferred_maintenance_window => maintenance_window,
-              :parameter_group_name => parameter_group['CacheParameterGroupName'],
+              :parameter_group_name         => parameter_group_name || parameter_group['CacheParameterGroupName'],
             }
           )
         end


### PR DESCRIPTION
Fixed an issue where if you specified a parameter group on AWS Elasticache cluster creation, it wasn't assigned to the parameter group.
