### PR TITLE
AWS Data Pipeline delete endpoint does not return a JSON body string

### DIFF
--- a/lib/fog/aws/requests/data_pipeline/delete_pipeline.rb
+++ b/lib/fog/aws/requests/data_pipeline/delete_pipeline.rb
@@ -9,8 +9,7 @@ module Fog
         # ==== Parameters
         # * PipelineId <~String> - The id of the pipeline to delete
         # ==== Returns
-        # * response<~Excon::Response>:
-        #   * body<~Hash>:
+        # * success<~Boolean> - Whether the delete was successful
         def delete_pipeline(id)
           params = { 'pipelineId' => id }
 
@@ -19,7 +18,7 @@ module Fog
             :headers => { 'X-Amz-Target' => 'DataPipeline.DeletePipeline' },
           })
 
-          Fog::JSON.decode(response.body)
+          200 == response.status
         end
 
       end

--- a/tests/aws/requests/data_pipeline/pipeline_tests.rb
+++ b/tests/aws/requests/data_pipeline/pipeline_tests.rb
@@ -46,7 +46,7 @@ Shindo.tests('AWS::DataPipeline | pipeline_tests', ['aws', 'data_pipeline']) do
       Fog::AWS[:data_pipeline].activate_pipeline(@pipeline_id)
     end
 
-    tests("#delete_pipeline") do
+    tests("#delete_pipeline").returns(true) do
       Fog::AWS[:data_pipeline].delete_pipeline(@pipeline_id)
     end
 


### PR DESCRIPTION
I was getting a JSON parse error from the delete_pipeline method.  Looks like Amazon's API may have changed since this was implemented.
