### PR TITLE
openstack | add min_count, max_count, return_reservation_id

### DIFF
--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -13,7 +13,10 @@ module Fog
           }
 
           vanilla_options = ['metadata', 'accessIPv4', 'accessIPv6',
-                             'availability_zone', 'user_data', 'key_name', 'adminPass', 'config_drive']
+                             'availability_zone', 'user_data', 'key_name', 
+                             'adminPass', 'config_drive', 'min_count', 'max_count',
+                             'return_reservation_id'
+                            ]
           vanilla_options.select{|o| options[o]}.each do |key|
             data['server'][key] = options[key]
           end

--- a/tests/openstack/requests/compute/server_tests.rb
+++ b/tests/openstack/requests/compute/server_tests.rb
@@ -25,6 +25,10 @@ Shindo.tests('Fog::Compute[:openstack] | server requests', ['openstack']) do
     'links'           => Array,
     'security_groups' => Fog::Nullable::Array,
   }
+  
+  @reservation_format = {
+    'reservation_id' => String,
+  }
 
   @image_format = {
     'created'   => Fog::Nullable::String,
@@ -59,6 +63,25 @@ Shindo.tests('Fog::Compute[:openstack] | server requests', ['openstack']) do
       Fog::Compute[:openstack].get_server_details(@server_id).body['server']
     end
 
+    #MULTI_CREATE
+    tests('#create_server("test", #{@image_id} , 19, {"min_count" => 2, "return_reservation_id" => "True"})').formats(@reservation_format, false) do
+      data = Fog::Compute[:openstack].create_server("test", @image_id, @flavor_id, {"min_count" => 2, "return_reservation_id" => "True"}).body
+      @reservation_id = data['reservation_id']
+      data
+    end
+    
+    tests('#validate_multi_create') do
+      passed = false
+      @multi_create_servers = Fog::Compute[:openstack].list_servers_detail({'reservation_id' => @reservation_id}).body['servers'].map{|server| server['id']}
+      if (@multi_create_servers.size == 2)
+        passed = true
+      end
+    end
+    
+    @multi_create_servers.each {|server|
+      Fog::Compute[:openstack].servers.get(server).destroy
+    }
+   
     #LIST
     #NOTE: we can remove strict=false if we remove uuid from GET /servers
     tests('#list_servers').formats({'servers' => [OpenStack::Compute::Formats::SUMMARY]}, false) do


### PR DESCRIPTION
adds the ability to create multiple nodes in one request to the openstack provider.  
