### PR TITLE
Fixing incorrect boolean expression; should have been string comparison

### DIFF
--- a/lib/fog/aws/parsers/redshift/cluster_parser.rb
+++ b/lib/fog/aws/parsers/redshift/cluster_parser.rb
@@ -81,7 +81,7 @@ module Fog
             when 'ClusterCreateTime'
               @cluster[name] = Time.parse(value)
             when 'AllowVersionUpgrade', 'Encrypted', 'PubliclyAccessible'
-              @cluster[name] = (value == true)
+              @cluster[name] = (value == "true")
             when 'Address'
               @cluster['EndPoint'][name] = value            
             when 'Port'

--- a/lib/fog/aws/parsers/redshift/cluster_snapshot_parser.rb
+++ b/lib/fog/aws/parsers/redshift/cluster_snapshot_parser.rb
@@ -52,7 +52,7 @@ module Fog
             when 'SnapshotCreateTime', 'ClusterCreateTime'
               @snapshot['Snapshot'][name] = Time.parse(value)
             when 'Encrypted'
-              @snapshot['Snapshot'][name] = (value == true)
+              @snapshot['Snapshot'][name] = (value == "true")
             when 'TotalBackupSizeInMegaBytes', 'ActualIncrementalBackupSizeInMegaBytes', 'BackupProgressInMegaBytes', 'CurrentBackupRateInMegaBytesPerSecond'
               @snapshot['Snapshot'][name] = value.to_f
             when 'AccountId'

--- a/lib/fog/aws/parsers/redshift/describe_cluster_parameters.rb
+++ b/lib/fog/aws/parsers/redshift/describe_cluster_parameters.rb
@@ -35,7 +35,7 @@ module Fog
             when 'ParameterName', 'ParameterValue', 'Description', 'Source', 'DataType', 'AllowedValues', 'MinimumEngineVersion'
               @parameter[name] = value
             when 'IsModifiable'
-              @parameter[name] = (value == true)
+              @parameter[name] = (value == "true")
             when 'Parameter'
               @response['Parameters'] << {name => @parameter}
               @parameter = {}

--- a/lib/fog/aws/parsers/redshift/describe_default_cluster_parameters.rb
+++ b/lib/fog/aws/parsers/redshift/describe_default_cluster_parameters.rb
@@ -36,7 +36,7 @@ module Fog
             when 'ParameterName', 'ParameterValue', 'Description', 'Source', 'DataType', 'AllowedValues', 'MinimumEngineVersion'
               @parameter[name] = value
             when 'IsModifiable'
-              @parameter[name] = (value == true)
+              @parameter[name] = (value == "true")
             when 'Parameter'
               @response['Parameters'] << {name => @parameter}
               @parameter = {}


### PR DESCRIPTION
Enables correct values for several boolean redshift cluster and snapshot fields.
