### PR TITLE
fix for linode using public ip blocks in 192.*

### DIFF
--- a/lib/fog/linode/models/compute/server.rb
+++ b/lib/fog/linode/models/compute/server.rb
@@ -19,7 +19,7 @@ module Fog
         end
 
         def public_ip_address
-          ips.find{|ip| ip.ip !~ /^192/}.ip
+          ips.find{|ip| ip.ip !~ /^192\.168\./}.ip
         end
 
         def disks


### PR DESCRIPTION
Linode now assigns some public ip addresses in the 192.\* range, which is ignored by the current regex.  This causes public_ip_address to throw an exception
