### PR TITLE
[vcloud_director] Fix listing catalog items when only a single item exists

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -172,6 +172,10 @@ module Fog
           items = item_list.map {|item| get_by_id(item[:id])}
           load(items)
         end
+
+        def ensure_list(items)
+          items.is_a?(Hash) ? [items] : items
+        end
       end
 
       class Real

--- a/lib/fog/vcloud_director/models/compute/catalog_items.rb
+++ b/lib/fog/vcloud_director/models/compute/catalog_items.rb
@@ -12,10 +12,6 @@ module Fog
 
         private
 
-        def ensure_list(items)
-          items.is_a?(Hash) ? [items] : items
-        end
-
         def item_list
           data = service.get_catalog(catalog.id).body
           items = ensure_list(data[:CatalogItems][:CatalogItem]).select { |link| link[:type] == "application/vnd.vmware.vcloud.catalogItem+xml" }

--- a/lib/fog/vcloud_director/models/compute/organizations.rb
+++ b/lib/fog/vcloud_director/models/compute/organizations.rb
@@ -19,7 +19,7 @@ module Fog
 
         def item_list
           data = service.get_organizations.body
-          orgs = data[:Org].is_a?(Hash) ? [data[:Org]] : data[:Org]
+          orgs = ensure_list(data[:Org])
           orgs.each {|org| service.add_id_from_href!(org)}
           orgs
         end

--- a/lib/fog/vcloud_director/models/compute/tasks.rb
+++ b/lib/fog/vcloud_director/models/compute/tasks.rb
@@ -21,7 +21,7 @@ module Fog
 
         def item_list
           data = service.get_tasks_list(organization.id).body
-          tasks = data[:Task].is_a?(Array) ? data[:Task] : [data[:Task]]
+          tasks = ensure_list(data[:Task])
           tasks.each {|task| service.add_id_from_href!(task)}
         end
 


### PR DESCRIPTION
Listing catalog items fails if the catalog only contains a single item. This is caused by `data[:CatalogItems][:CatalogItem]` containing a hash instead of expected list of hashes. Fix it by wrapping hash in a list, i.e. the same way it is handled in case of organizations.
