### PR TITLE
Fix for https urls in atmos.

### DIFF
--- a/lib/fog/atmos/models/storage/file.rb
+++ b/lib/fog/atmos/models/storage/file.rb
@@ -60,7 +60,8 @@ module Fog
           file = directory.files.head(key)
           self.objectid = if file && file.to_s.strip != "" then file.attributes['x-emc-meta'].scan(/objectid=(\w+),/).flatten[0] else nil end
           if self.objectid && self.objectid.to_s.strip != ""
-            uri = URI::HTTP.build(:scheme => service.ssl? ? "http" : "https" , :host => service.host, :port => service.port.to_i, :path => "/rest/objects/#{self.objectid}" )
+            klass = service.ssl? ? URI::HTTPS : URI::HTTP
+            uri = klass.build(:host => service.host, :port => service.port.to_i, :path => "/rest/objects/#{self.objectid}" )
 
             sb = "GET\n"
             sb += uri.path.downcase + "\n"


### PR DESCRIPTION
URI::HTTP doesn't accept/use a "scheme" param, so all urls are being created with "http", regardless of whether service.ssl? is true or not.
