### PR TITLE
[rackspace] Don't parse JSON in delete_server response

### DIFF
--- a/lib/fog/rackspace/requests/compute_v2/delete_server.rb
+++ b/lib/fog/rackspace/requests/compute_v2/delete_server.rb
@@ -12,11 +12,11 @@ module Fog
         # @raise [Fog::Compute::RackspaceV2::ServiceError]
         # @see http://docs.rackspace.com/servers/api/v2/cs-devguide/content/Delete_Server-d1e2883.html
         def delete_server(server_id)
-          request(
+          request({
             :expects => [204],
             :method => 'DELETE',
             :path => "servers/#{server_id}"
-          )
+          }, false)
         end
       end
 


### PR DESCRIPTION
The Rackspace API replies with an empty response to delete_server
requests, but includes a header enforcing the application/json
content-type.

This commit disables JSON parsing on `delete_server` requests,
which prevents the appearance of these warnings:

> [WARNING] Error Parsing response json - 781: unexpected token at ''
