### PR TITLE
[vcloud-director] fixed fog to load vdc with single or zero resource entities

### DIFF
--- a/lib/fog/vcloud_director/models/compute/vapps.rb
+++ b/lib/fog/vcloud_director/models/compute/vapps.rb
@@ -21,7 +21,7 @@ module Fog
                         
         def item_list
           data = service.get_vdc(vdc.id).body
-          return [] if data[:ResourceEntities].is_a?(String)
+          return [] if data[:ResourceEntities].empty?
           resource_entities = data[:ResourceEntities][:ResourceEntity].is_a?(Hash) ? [ data[:ResourceEntities][:ResourceEntity] ] : data[:ResourceEntities][:ResourceEntity]
           items = resource_entities.select { |link| link[:type] == "application/vnd.vmware.vcloud.vApp+xml" }
           items.each{|item| service.add_id_from_href!(item) }


### PR DESCRIPTION
Fog code fails to describe the vdcs with zero or single resource entities.

This is because the underlying API does not return Array, when vdc has single or no resource entities. 

This causes parser to return following : 
- String (in case of zero resource entities)
- Hash (in case of one resource entity)
- Array (in case of more than one resource entities)

The fog throws error since it always expects an array. Fixed this behavior.
