### PR TITLE
[rackspace] updating to only parse json if the body of the response has data 

### DIFF
--- a/lib/fog/rackspace/service.rb
+++ b/lib/fog/rackspace/service.rb
@@ -55,7 +55,11 @@ module Fog
       private
 
       def process_response(response)
-        if response && response.body && response.body.is_a?(String) && Fog::Rackspace.json_response?(response)
+        if response &&
+           response.body &&
+           response.body.is_a?(String) &&
+           !response.body.strip.empty? &&
+           Fog::Rackspace.json_response?(response)
           begin
             response.body = Fog::JSON.decode(response.body)
           rescue MultiJson::DecodeError => e


### PR DESCRIPTION
We are still seeing issues like https://github.com/fog/fog/pull/2163, which seems to occur with some json parsers. This PR update's the Rackspace provider to only attempt to parse a response if it contains data.
