### PR TITLE
[rackspace] hardcoding flavor_id used by mock data

### DIFF
--- a/lib/fog/rackspace/mock_data.rb
+++ b/lib/fog/rackspace/mock_data.rb
@@ -7,8 +7,9 @@ module Fog
       def data
         @@data ||= Hash.new do |hash, key|
           hash[key] = begin
+
             #Compute V2
-            flavor_id  = Fog.credentials[:rackspace_flavor_id] ||= Fog::Mock.random_numbers(1)
+            flavor_id  = Fog.credentials[:rackspace_flavor_id] ||= '3'
             image_id   = Fog.credentials[:rackspace_image_id] ||= Fog::Rackspace::MockData.uuid
             image_name = Fog::Mock.random_letters(6)
             network_id = Fog::Rackspace::MockData.uuid


### PR DESCRIPTION
This PR hopes to address issue https://github.com/fog/fog/issues/2138. 

The Rackspace mock implementation creates flavors with an random id. It seems these failures creep up when the randomly generated flavor id is 0 as the flavor helper uses 0 to tst not found exceptions.  This PR just hard codes flavor ids to 3.
