### PR TITLE
[vSphere] Support passing of a distributed switch for each interface.

### DIFF
--- a/lib/fog/vsphere/models/compute/interface.rb
+++ b/lib/fog/vsphere/models/compute/interface.rb
@@ -13,6 +13,7 @@ module Fog
         attribute :summary
         attribute :type
         attribute :key
+        attribute :virtualswitch
 
         def initialize(attributes={} )
           super defaults.merge(attributes)

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -50,7 +50,7 @@ module Fog
         end
 
         def create_nic_backing nic, attributes
-          raw_network = get_raw_network(nic.network, attributes[:datacenter])
+          raw_network = get_raw_network(nic.network, attributes[:datacenter], if nic.virtualswitch then nic.virtualswitch end)
 
           if raw_network.kind_of? RbVmomi::VIM::DistributedVirtualPortgroup
             RbVmomi::VIM.VirtualEthernetCardDistributedVirtualPortBackingInfo(

--- a/lib/fog/vsphere/requests/compute/get_network.rb
+++ b/lib/fog/vsphere/requests/compute/get_network.rb
@@ -10,14 +10,14 @@ module Fog
 
         protected
 
-        def get_raw_network(name, datacenter_name)
+        def get_raw_network(name, datacenter_name, distributedswitch_name=nil)
           dc = find_raw_datacenter(datacenter_name)
 
           @connection.serviceContent.viewManager.CreateContainerView({
             :container  => dc.networkFolder,
             :type       =>  ["Network"],
             :recursive  => true
-          }).view.select{|n| n.name == name}.first
+          }).view.select { |n| n.name == name and (not distributedswitch_name or n.config.distributedVirtualSwitch.name == distributedswitch_name)}.first
         end
       end
 


### PR DESCRIPTION
## Background:

Remark: This is only related to the vSphere implementation of fog.

It is not yet possible with fog to create a nic (nic backing) on a vmware guest on different distributed switches that host the same network but are located in different datacenters.
Until now there is no option to add a nic with a specific distributed switch aside the nic configuration.

This leads to guests not being created.
Error message:

```
RbVmomi::Fault: failed to create vm: InvalidArgument: A specified parameter was not correct.
spec.deviceChange.device.port.switchUuid
        from /usr/share/foreman/.gem/ruby/1.9.1/gems/fog-1.11.1/lib/fog/vsphere/requests/compute/create_vm.rb:27:in `rescue in create_vm'
        from /usr/share/foreman/.gem/ruby/1.9.1/gems/fog-1.11.1/lib/fog/vsphere/requests/compute/create_vm.rb:8:in `create_vm'
        from /usr/share/foreman/.gem/ruby/1.9.1/gems/fog-1.11.1/lib/fog/vsphere/models/compute/server.rb:211:in `save'
        from /usr/share/foreman/.gem/ruby/1.9.1/gems/fog-1.11.1/lib/fog/core/collection.rb:52:in `create'
        from (irb):15:in `<main>'
        from /usr/share/foreman/.gem/ruby/1.9.1/gems/fog-1.11.1/bin/fog:54:in `block in <main>'
        from /usr/share/foreman/.gem/ruby/1.9.1/gems/fog-1.11.1/bin/fog:54:in `catch'
        from /usr/share/foreman/.gem/ruby/1.9.1/gems/fog-1.11.1/bin/fog:54:in `<main>'
```

The message _A specified parameter was not correct. spec.deviceChange.device.port.switchUuid_ is the relevant error message from vmware.

The error is located at the place where the raw network is selected from vsphere as follows (lib/fog/vsphere/requests/compute/get_network.rb):

```
          @connection.serviceContent.viewManager.CreateContainerView({
            :container  => dc.networkFolder,
            :type       =>  ["Network"],
            :recursive  => true
          }).view.select{|n| n.name == name}.first
```

This will select the first distributed switch to be found matching the required network name. Nevertheless if the same network is used in different dcs always the same distributed switch is selected.
This will fail in one of the two dcs as a special distributed switch is required.
## Solution:

It would be an option to pass the required distributed switch along with the interface to be created (optional).
If there is no distributed switch passed as option the code is executed as before but otherwise the network for this given distributed switch is selected.

The solution might look as follows:

```
          @connection.serviceContent.viewManager.CreateContainerView({
            :container  => dc.networkFolder,
            :type       =>  ["Network"],
            :recursive  => true
          }).view.select { |n| n.name == name and (not distributedswitch_name or n.config.distributedVirtualSwitch.name == distributedswitch_name)}.first
```

This pull request solves this critical problem with this aproach.

Any better ideas?

Let me know what you think.
Marc.
