### PR TITLE
[vSphere] Support datacenters that are located below folders not in root...

### DIFF
--- a/lib/fog/vsphere/models/compute/datacenter.rb
+++ b/lib/fog/vsphere/models/compute/datacenter.rb
@@ -6,30 +6,31 @@ module Fog
 
         identity :id
         attribute :name
+        attribute :path
         attribute :status
 
         def clusters filters = { }
-          service.clusters({ :datacenter => name }.merge(filters))
+          service.clusters({ :datacenter => path.join("/") }.merge(filters))
         end
 
         def networks filters = { }
-          service.networks({ :datacenter => name }.merge(filters))
+          service.networks({ :datacenter => path.join("/") }.merge(filters))
         end
 
         def datastores filters = { }
-          service.datastores({ :datacenter => name }.merge(filters))
+          service.datastores({ :datacenter => path.join("/") }.merge(filters))
         end
 
         def vm_folders filters = { }
-          service.folders({ :datacenter => name, :type => :vm }.merge(filters))
+          service.folders({ :datacenter => path.join("/"), :type => :vm }.merge(filters))
         end
 
         def virtual_machines filters = {}
-          service.servers({ :datacenter => name }.merge(filters))
+          service.servers({ :datacenter => path.join("/") }.merge(filters))
         end
         
         def customfields filters = {}
-          service.customfields({ :datacenter => name}.merge(filters))
+          service.customfields({ :datacenter => path.join("/")}.merge(filters))
         end
 
         def to_s

--- a/lib/fog/vsphere/requests/compute/get_datacenter.rb
+++ b/lib/fog/vsphere/requests/compute/get_datacenter.rb
@@ -5,7 +5,7 @@ module Fog
         def get_datacenter name
           dc = find_raw_datacenter(name)
           raise(Fog::Compute::Vsphere::NotFound) unless dc
-          {:name => dc.name, :status => dc.overallStatus}
+          {:name => dc.name, :status => dc.overallStatus, :path => raw_getpathmo(dc) }
         end
 
         protected


### PR DESCRIPTION
## Background

In big vmware installations datacenters might be organized in subfolders.
Normally the vmware datacenters are located in the "root" folder of vmware but when having loads of dcs it is a common approach to organize the dcs in different folders.

Right now fog cannot cope with this problem.

If a datacenter is located in different folders no guests can be queried or selected as the referring datacenter cannot be found.
## Solution

This solution add a path to each datacenter that points to the location of the dc.
The path is an array of parent locations of the dc and will be recursively evaluated when searched for the dc name (see _raw_getpathmo_ in _lib/fog/vsphere/requests/compute/list_datacenters.rb_).

Let me know what you think.

Thanks Marc.
