### PR TITLE
support "name" on cloudstack deploy

### DIFF
--- a/lib/fog/cloudstack/models/compute/server.rb
+++ b/lib/fog/cloudstack/models/compute/server.rb
@@ -87,6 +87,7 @@ module Fog
             'zoneid'            => zone_id,
             'networkids'        => network_ids,
             'diskofferingid'    => disk_offering_id,
+            'name'              => name,
             'displayname'       => display_name,
             'group'             => group,
             'domainid'          => domain_id,


### PR DESCRIPTION
The 'name' option is supported, but wasn't implemented for some reason, for CloudStack. This meant spinning up VMs with Fog would result in a random, UUID, name for the VM. The name flows through to the VM as its hostname, so this was pretty gruesome.

This tiny patch fixes that behaviour.
