### PR TITLE
[google|compute] Update bootstrap image to debian-7-wheezy-v20130816.

### DIFF
--- a/lib/fog/google/models/compute/servers.rb
+++ b/lib/fog/google/models/compute/servers.rb
@@ -47,7 +47,7 @@ module Fog
         def bootstrap(new_attributes = {})
           defaults = {
             :name => "fog-#{Time.now.to_i}",
-            :image_name => "debian-7-wheezy-v20130617",
+            :image_name => "debian-7-wheezy-v20130816",
             :machine_type => "n1-standard-1",
             :zone_name => "us-central1-b",
             :private_key_path => File.expand_path("~/.ssh/id_rsa"),


### PR DESCRIPTION
Just keeping things up to date.
