### PR TITLE
Add alias for openstack availablilty zone server attribute

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -21,7 +21,7 @@ module Fog
         attribute :progress
         attribute :accessIPv4
         attribute :accessIPv6
-        attribute :availability_zone
+        attribute :availability_zone, :aliases => 'OS-EXT-AZ:availability_zone'
         attribute :user_data_encoded
         attribute :state,       :aliases => 'status'
         attribute :created,     :type => :time


### PR DESCRIPTION
The availability zone attribute in server API messages is actually
OS-EXT-AZ:availability_zone.  Adding the alias will correctly map the
availability zone values into fog responses.
