### PR TITLE
Hp provider addition: ensure that hp_auth_version is loaded as symbol

### DIFF
--- a/lib/fog/hp/block_storage.rb
+++ b/lib/fog/hp/block_storage.rb
@@ -105,7 +105,9 @@ module Fog
           @connection_options = options[:connection_options] || {}
           ### Set an option to use the style of authentication desired; :v1 or :v2 (default)
           ### A symbol is required, we should ensure that the value is loaded as a symbol
-          auth_version = options[:hp_auth_version].to_sym || :v2
+          auth_version = options[:hp_auth_version] || :v2
+          auth_version = auth_version.to_s.downcase.to_sym
+
           ### Pass the service name for object storage to the authentication call
           options[:hp_service_type] = "Block Storage"
           @hp_tenant_id = options[:hp_tenant_id]

--- a/lib/fog/hp/cdn.rb
+++ b/lib/fog/hp/cdn.rb
@@ -80,7 +80,9 @@ module Fog
           @connection_options = options[:connection_options] || {}
           ### Set an option to use the style of authentication desired; :v1 or :v2 (default)
           ### A symbol is required, we should ensure that the value is loaded as a symbol
-          auth_version = options[:hp_auth_version].to_sym || :v2
+          auth_version = options[:hp_auth_version] || :v2
+          auth_version = auth_version.to_s.downcase.to_sym
+
           ### Pass the service name for object storage to the authentication call
           options[:hp_service_type] = "CDN"
           @hp_tenant_id = options[:hp_tenant_id]

--- a/lib/fog/hp/compute.rb
+++ b/lib/fog/hp/compute.rb
@@ -189,7 +189,9 @@ module Fog
           @connection_options = options[:connection_options] || {}
           ### Set an option to use the style of authentication desired; :v1 or :v2 (default)
           ### A symbol is required, we should ensure that the value is loaded as a symbol
-          auth_version = options[:hp_auth_version].to_sym || :v2
+          auth_version = options[:hp_auth_version] || :v2
+          auth_version = auth_version.to_s.downcase.to_sym
+          
           ### Pass the service name for compute via the options hash
           options[:hp_service_type] = "Compute"
           @hp_tenant_id = options[:hp_tenant_id]

--- a/lib/fog/hp/storage.rb
+++ b/lib/fog/hp/storage.rb
@@ -264,7 +264,9 @@ module Fog
           @connection_options = options[:connection_options] || {}
           ### Set an option to use the style of authentication desired; :v1 or :v2 (default)
           ### A symbol is required, we should ensure that the value is loaded as a symbol
-          auth_version = options[:hp_auth_version].to_sym || :v2
+          auth_version = options[:hp_auth_version] || :v2
+          auth_version = auth_version.to_s.downcase.to_sym
+          
           ### Pass the service name for object storage to the authentication call
           options[:hp_service_type] = "Object Storage"
           @hp_tenant_id = options[:hp_tenant_id]


### PR DESCRIPTION
We had some problems with this configuration key. If the key is not a symbol within the configuration file, the provider raises NotFound errors. This small fix guarantees that the configuration value is always passed as a symbol.
