### PR TITLE
Fix AWS S3 POST object restore SignatureDoesNotMatch error

### DIFF
--- a/lib/fog/aws/requests/storage/post_object_restore.rb
+++ b/lib/fog/aws/requests/storage/post_object_restore.rb
@@ -29,7 +29,7 @@ module Fog
 
           request({
             :headers  => headers,
-            :host     => "#{bucket_name}.#{@host}",
+            :bucket_name => bucket_name,
             :expects  => [200, 202, 409],
             :body     => data,
             :method   => 'POST',


### PR DESCRIPTION
POST object restore was using the bucket_name as a host prefix rather than in the canonical path as AWS was expecting. This resulted in getting results such as:

``` xml
<?xml version=\"1.0\" encoding=\"UTF-8\"?>
<Error>
  <Code>SignatureDoesNotMatch</Code>
  <Message>
    The request signature we calculated does not match the signature you provided.
    Check your key and signing method.
  </Message>
  <StringToSignBytes>…</StringToSignBytes>
  <RequestId>…</RequestId>
  <HostId>…</HostId>
  <SignatureProvided>…</SignatureProvided>
  <StringToSign>POST
AAjA1/2lcgEFNlhuhHDHBw==
application/xml
Mon, 30 Sep 2013 18:08:03 +0000
{bucket_name}/{object_name}?restore</StringToSign>
  <AWSAccessKeyId>…</AWSAccessKeyId>
</Error>
```

I narrowed it down to the StringToSign generated by `post_object_restore` not including the `bucket_name`. I'm not sure why this used to work honestly. Maybe AWS got stricter?
