### PR TITLE
All OpenStack heat requests must contain User/Key.

### DIFF
--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -138,7 +138,9 @@ module Fog
               :headers  => {
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',
-                'X-Auth-Token' => @auth_token
+                'X-Auth-Token' => @auth_token,
+                'X-Auth-User'  => @openstack_username,
+                'X-Auth-Key'   => @openstack_api_key
               }.merge!(params[:headers] || {}),
               :host     => @host,
               :path     => "#{@path}/#{@tenant_id}/#{params[:path]}",


### PR DESCRIPTION
Updates the OpenStack Orchestration request() method
so that all requests contain the X-Auth-User and X-Auth-Key
headers.

Heat requires these parameters so that it can make subsequent requests
based on the users behalf.

For reference see here:

https://github.com/openstack/python-heatclient/blob/master/heatclient/common/http.py#L186
