### PR TITLE
OpenStack orchestration update_stack fixes.

### DIFF
--- a/lib/fog/openstack/requests/orchestration/update_stack.rb
+++ b/lib/fog/openstack/requests/orchestration/update_stack.rb
@@ -5,23 +5,22 @@ module Fog
 
         # Update a stack.
         #
+        # @param [String] stack_id ID of the stack to update.
         # @param [String] stack_name Name of the stack to update.
         # @param [Hash] options
-        #   * :template_body [String] Structure containing the template body.
+        #   * :template [String] Structure containing the template body.
         #   or (one of the two Template parameters is required)
         #   * :template_url [String] URL of file containing the template body.
         #   * :parameters [Hash] Hash of providers to supply to template.
         #
-        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_UpdateStack.html
-        #
-        def update_stack(stack_name, options = {})
+        def update_stack(stack_id, stack_name, options = {})
           params = {
             :stack_name => stack_name
           }.merge(options)
 
           request(
             :expects  => 202,
-            :path => 'stacks',
+            :path => "stacks/#{stack_name}/#{stack_id}",
             :method => 'PUT',
             :body => MultiJson.encode(params)
           )


### PR DESCRIPTION
The update_stack call requires an ID and NAME to be included in
the URL of the PUT request.

See API docs here:

  http://api.openstack.org/api-ref-orchestration.html
