### PR TITLE
[google|compute] Fix metadata bug.

### DIFF
--- a/lib/fog/google/models/compute/server.rb
+++ b/lib/fog/google/models/compute/server.rb
@@ -74,6 +74,10 @@ module Fog
 
           # You can have multiple SSH keys, seperated by newlines.
           # https://developers.google.com/compute/docs/console?hl=en#sshkeys
+          if !self.metadata["sshKeys"]
+            self.metadata["sshKeys"] = ""
+          end
+
           if !self.metadata["sshKeys"].empty?
             self.metadata["sshKeys"] += "\n"
           end


### PR DESCRIPTION
Works for when you have metadata, but no sshKeys metadata.
