### PR TITLE
fixing typo in raising exception

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -334,7 +334,7 @@ module Fog
             puts e.response.status
             puts CGI::unescapeHTML(e.response.body)
           end
-          raise @e
+          raise e
         end
 
         def process_task(response_body)


### PR DESCRIPTION
This was not caught on Travis because it runs test in mock mode. This causes failures when we run tests in non-mock mode.
