### PR TITLE
removing unnecessary :hosts parameters from dynect and openstack requests

### DIFF
--- a/lib/fog/dynect/dns.rb
+++ b/lib/fog/dynect/dns.rb
@@ -91,7 +91,7 @@ module Fog
             params[:headers]['Auth-Token'] = auth_token unless params[:path] == 'Session'
             params[:path] = "#{@path}/#{params[:path]}" unless params[:path] =~ %r{^#{Regexp.escape(@path)}/}
 
-            response = @connection.request(params.merge!({:host => @host}))
+            response = @connection.request(params)
 
             if response.body.empty?
               response.body = {}

--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -72,7 +72,6 @@ module Fog
           'X-Auth-Key'  => @openstack_api_key,
           'X-Auth-User' => @openstack_username
         },
-        :host     => uri.host,
         :method   => 'GET',
         :path     =>  (uri.path and not uri.path.empty?) ? uri.path : 'v1.0'
       })
@@ -108,7 +107,6 @@ module Fog
             :headers => {'Content-Type' => 'application/json',
                          'Accept' => 'application/json',
                          'X-Auth-Token' => body['access']['token']['id']},
-            :host    => uri.host,
             :method  => 'GET'
           })
 
@@ -206,7 +204,6 @@ module Fog
         :expects  => [200, 204],
         :headers  => {'Content-Type' => 'application/json'},
         :body     => Fog::JSON.encode(request_body),
-        :host     => uri.host,
         :method   => 'POST',
         :path     => (uri.path and not uri.path.empty?) ? uri.path : 'v2.0'
       })
@@ -221,7 +218,6 @@ module Fog
         :headers => {'Content-Type' => 'application/json',
                      'Accept' => 'application/json',
                      'X-Auth-Token' => auth_token},
-        :host    => uri.host,
         :method  => 'GET'
       })
 


### PR DESCRIPTION
Whenever tests are run with a Excon 0.27, we get the following warnings from the dynect and openstack requests:

```
The following keys are invalid: :host
```

This PR hopefully removes all of them.
