### PR TITLE
Issue 2242 - atmos storage passes invalid parse attribute.  

### DIFF
--- a/lib/fog/atmos/storage.rb
+++ b/lib/fog/atmos/storage.rb
@@ -155,8 +155,10 @@ module Fog
           signature = Base64.encode64( digest ).chomp()
           params[:headers]["x-emc-signature"] = signature
 
-          parse = params[:parse]
-          
+          params.delete(:host) #invalid excon request parameter
+
+          parse = params.delete(:parse)        
+        
           begin
             response = @connection.request(params, &block)
           rescue Excon::Errors::HTTPStatusError => error


### PR DESCRIPTION
Grab parse attribute before it hits the excon connection

See also: 
https://github.com/fog/fog/issues/2242
