### PR TITLE
Various atmos enhancements around file meta-data

### DIFF
--- a/lib/fog/atmos/models/storage/file.rb
+++ b/lib/fog/atmos/models/storage/file.rb
@@ -11,6 +11,7 @@ module Fog
         attribute :content_length,  :aliases => ['bytes', 'Content-Length'], :type => :integer
         attribute :content_type,    :aliases => ['content_type', 'Content-Type']
         attribute :objectid,        :aliases => :ObjectID
+        attribute :created_at,      :aliases => :ctime
 
         def body
           attributes[:body] ||= if objectid
@@ -42,14 +43,15 @@ module Fog
           true
         end
 
-        # def owner=(new_owner)
-        #   if new_owner
-        #     attributes[:owner] = {
-        #       :display_name => new_owner['DisplayName'],
-        #       :id           => new_owner['ID']
-        #     }
-        #   end
-        # end
+        def meta_data
+         requires :directory, :key
+          service.get_namespace([directory.key, key].join('/') + "?metadata/system")
+        end
+
+        def file_size
+          data = meta_data
+          meta_data.headers["x-emc-meta"].match(/size=\d+/).to_s.gsub(/size=/,"")
+        end
 
         def public=(new_public)
           # NOOP - we don't need to flag files as public, getting the public URL for a file handles it.

--- a/lib/fog/atmos/models/storage/files.rb
+++ b/lib/fog/atmos/models/storage/files.rb
@@ -24,6 +24,11 @@ module Fog
           data[:DirectoryEntry] = [data[:DirectoryEntry]] if data[:DirectoryEntry].kind_of? Hash
           files = data[:DirectoryEntry].select {|de| de[:FileType] == 'regular'}
           files.each do |s|
+            data = service.head_namespace(directory.key + s[:Filename], :parse => false)
+            headers = Hash[data.headers["x-emc-meta"].split(", ").collect{|s|s.split("=")}]
+            s[:content_length] = data.headers["Content-Length"]
+            s[:content_type] = data.headers["Content-Type"]
+            s[:created_at] = headers["ctime"]
             s[:directory] = directory
           end
           # TODO - Load additional file meta?


### PR DESCRIPTION
Extract created_at, content_length, content_type from headers when reading files. 
Add explicit system metadata request method and file_size (atmos does not report directly on file sizes > 10mb)
