### PR TITLE
[AWS|SQS] Fix iam credentials not being refreshed

### DIFF
--- a/lib/fog/aws/sqs.rb
+++ b/lib/fog/aws/sqs.rb
@@ -111,6 +111,8 @@ module Fog
         end
 
         def request(params)
+          refresh_credentials_if_expired
+
           idempotent  = params.delete(:idempotent)
           parser      = params.delete(:parser)
           path        = params.delete(:path)


### PR DESCRIPTION
When using temporary IAM credentials, SQS wasn't checking whether they were expired or not
