### PR TITLE
[openstack] Fix mocking for create server request.

### DIFF
--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -93,7 +93,7 @@ module Fog
           response.status = 202
 
           server_id = Fog::Mock.random_numbers(6).to_s
-          identity = Fog::Identity[:openstack]
+          identity = Fog::Identity::OpenStack.new :openstack_auth_url => credentials[:openstack_auth_url]
           user = identity.users.find { |u|
             u.name == @openstack_username
           }


### PR DESCRIPTION
A simple test like this

``` ruby
require 'spec_helper'

describe 'Bug' do
  it 'should not fail' do
    compute = Fog::Compute.new(
      :provider => 'openstack',
      :openstack_username => 'user',
      :openstack_api_key => 'pass',
      :openstack_tenant => 'tenant',
      :openstack_auth_url => 'http://auth/url',
    )

    server_def = {
      :name => 'name',
      :image_ref => 'image_ref',
      :flavor_ref => 'flavor',
      :key_name => 'key_name',
      :user_data => 'user_data',
    }

    server = compute.servers.create(server_def)
  end
end
```

fails with:

```
 ArgumentError:
   Missing required arguments: openstack_auth_url
```

for fog > 1.8.0.

Looks like it was introduced in [fog 1.9.0](https://github.com/fog/fog/blob/v1.9.0/lib/fog/openstack/requests/compute/create_server.rb#L65)
