### PR TITLE
Remove webmock.

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -65,7 +65,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('fission')
   s.add_development_dependency('pry')
   s.add_development_dependency('google-api-client', '~>0.6.2')
-  s.add_development_dependency('webmock', '~>1.14')
 #  s.add_development_dependency('ruby-libvirt','~>0.4.0')
 
   s.files = `git ls-files`.split("\n")

--- a/tests/openstack/requests/storage/object_tests.rb
+++ b/tests/openstack/requests/storage/object_tests.rb
@@ -58,8 +58,6 @@ Shindo.tests('Fog::Storage[:openstack] | object requests', ["openstack"]) do
     tests("put_object with block") do
       pending if Fog.mocking?
 
-      WebMock.disable! # https://github.com/bblimke/webmock/issues/307
-
       tests("#put_object('fogobjecttests', 'fog_object', &block)").succeeds do
         begin
           file = lorem_file
@@ -71,8 +69,6 @@ Shindo.tests('Fog::Storage[:openstack] | object requests', ["openstack"]) do
           file.close
         end
       end
-
-      WebMock.enable!
 
       tests('#get_object').succeeds do
         Fog::Storage[:openstack].get_object('fogobjecttests', 'fog_block_object').body == lorem_file.read


### PR DESCRIPTION
Now that VCR has gone, WebMock can probably go too. I'm assuming the only remaining mention of WebMock is a workaround for the presence of WebMock.

/cc @dgutov
