### PR TITLE
[rackspace] fixing broken tests

### DIFF
--- a/tests/rackspace/block_storage_tests.rb
+++ b/tests/rackspace/block_storage_tests.rb
@@ -79,7 +79,7 @@ Shindo.tests('Fog::Rackspace::BlockStorage', ['rackspace']) do
     pending if Fog.mocking?
 
     tests('no params').succeeds do
-      @service = Fog::Rackspace::BlockStorage.new
+      @service = Fog::Rackspace::BlockStorage.new :rackspace_region => nil
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(true) { (@service.instance_variable_get("@uri").host =~ /dfw/) != nil }
       @service.list_volumes

--- a/tests/rackspace/cdn_tests.rb
+++ b/tests/rackspace/cdn_tests.rb
@@ -76,7 +76,7 @@ Shindo.tests('Fog::CDN::Rackspace', ['rackspace']) do
     pending if Fog.mocking?
     
     tests('no params').succeeds do
-      @service = Fog::CDN::Rackspace.new
+      @service = Fog::CDN::Rackspace.new :rackspace_region => nil
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(true, "uses DFW") { (@service.instance_variable_get("@uri").host =~ /cdn1/) != nil }
       @service.get_containers

--- a/tests/rackspace/compute_tests.rb
+++ b/tests/rackspace/compute_tests.rb
@@ -65,7 +65,7 @@ Shindo.tests('Rackspace | Compute', ['rackspace']) do
     pending if Fog.mocking?
 
     tests('no params').succeeds do
-      @service = Fog::Compute::Rackspace.new
+      @service = Fog::Compute::Rackspace.new :rackspace_region => nil
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(true) { (@service.instance_variable_get("@uri").host == 'servers.api.rackspacecloud.com') != nil }
       @service.list_flavors

--- a/tests/rackspace/compute_v2_tests.rb
+++ b/tests/rackspace/compute_v2_tests.rb
@@ -78,7 +78,7 @@ Shindo.tests('Fog::Compute::RackspaceV2', ['rackspace']) do
     pending if Fog.mocking?
 
     tests('no params').succeeds do
-      @service = Fog::Compute::RackspaceV2.new
+      @service = Fog::Compute::RackspaceV2.new :rackspace_region => nil
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(true) { (@service.instance_variable_get("@uri").host =~ /dfw/) != nil }
       @service.list_flavors

--- a/tests/rackspace/databases_tests.rb
+++ b/tests/rackspace/databases_tests.rb
@@ -79,7 +79,7 @@ Shindo.tests('Fog::Rackspace::Databases', ['rackspace']) do |variable|
     pending if Fog.mocking?
 
     tests('no params').succeeds do
-      @service = Fog::Rackspace::Databases.new
+      @service = Fog::Rackspace::Databases.new :rackspace_region => nil
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(true) { (@service.instance_variable_get("@uri").host =~ /dfw/) != nil }
       @service.flavors

--- a/tests/rackspace/dns_tests.rb
+++ b/tests/rackspace/dns_tests.rb
@@ -69,7 +69,7 @@ Shindo.tests('Fog::DNS::Rackspace', ['rackspace']) do
     pending if Fog.mocking?
 
     tests('no params').succeeds do
-      @service = Fog::DNS::Rackspace.new
+      @service = Fog::DNS::Rackspace.new :rackspace_region => nil
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(false, "path populated") { @service.instance_variable_get("@uri").host.nil? }
       returns(true, "contains tenant id") {  (@service.instance_variable_get("@uri").path =~ /\/v1\.0\/\d+$/) != nil} #dns does not error if tenant id is missing

--- a/tests/rackspace/load_balancer_tests.rb
+++ b/tests/rackspace/load_balancer_tests.rb
@@ -78,7 +78,7 @@ Shindo.tests('Fog::Rackspace::LoadBalancers', ['rackspace']) do
     pending if Fog.mocking?
 
     tests('no params').succeeds do
-      @service = Fog::Rackspace::LoadBalancers.new
+      @service = Fog::Rackspace::LoadBalancers.new :rackspace_region => nil
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(true) { (@service.instance_variable_get("@uri").host =~ /dfw/) != nil }
       @service.list_load_balancers

--- a/tests/rackspace/storage_tests.rb
+++ b/tests/rackspace/storage_tests.rb
@@ -76,7 +76,7 @@ Shindo.tests('Rackspace | Storage', ['rackspace']) do
     pending if Fog.mocking?
     
     tests('no params').succeeds do
-      @service = Fog::Storage::Rackspace.new
+      @service = Fog::Storage::Rackspace.new :rackspace_region => nil
       returns(true, "auth token populated") { !@service.send(:auth_token).nil? }
       returns(true) { (@service.instance_variable_get("@uri").host =~ /dfw\d/) != nil }
       @service.head_containers


### PR DESCRIPTION
If `:rackspace_region` is specified in `tests/.fog` it causes the default region tests to break. This PR sets the `:rackspace_region` to `nil` in the default tests in order to override any settings provided by `Fog.credentials`
