### PR TITLE
[linode|compute] Avoid passing host to request.

### DIFF
--- a/lib/fog/linode/compute.rb
+++ b/lib/fog/linode/compute.rb
@@ -95,7 +95,7 @@ module Fog
           params[:query] ||= {}
           params[:query].merge!(:api_key => @linode_api_key)
 
-          response = @connection.request(params.merge!({:host => @host}))
+          response = @connection.request(params)
 
           unless response.body.empty?
             response.body = Fog::JSON.decode(response.body)


### PR DESCRIPTION
One more instance of a `:host` key creeping into the Excon request params. That should clear the remainder of Linode issues.

References #2248

Thanks for the prompt fix on [linode|dns]!
