### PR TITLE
[vcloud_director] Change input options structure.

### DIFF
--- a/lib/fog/vcloud_director/requests/compute/put_guest_customization_section_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_guest_customization_section_vapp.rb
@@ -5,50 +5,127 @@ module Fog
         extend Fog::Deprecation
         deprecate :put_vm_customization, :put_guest_customization_section_vapp
 
-        require 'fog/vcloud_director/generators/compute/customization'
-
         # Updates the guest customization section of a VM.
         #
         # This operation is asynchronous and returns a task that you can
         # monitor to track the progress of the request.
         #
         # @param [String] id Object identifier of the VM.
-        # @param [Hash] customization
-        # @option customization [Boolean] :enabled True if guest customization
-        #   is enabled.
-        # @option customization [Boolean] :change_sid True if customization can
-        #   change the Windows SID of this virtual machine.
-        # @option customization [Boolean] :join_domain_enabled True if this
-        #   virtual machine can join a Windows Domain.
-        # @option customization [Boolean] :use_org_settings True if
-        #   customization should use organization settings
-        #   (OrgGuestPersonalizationSettings) when joining a Windows Domain.
-        # @option customization [String] :domain_name NOT IMPLEMENTED
-        # @option customization [String] :domain_user_name NOT IMPLEMENTED
-        # @option customization [String] :domain_user_password NOT IMPLEMENTED
-        # @option customization [String] :machine_object_ou NOT IMPLEMENTED
-        # @option customization [Boolean] :admin_password_enabled True if guest
+        # @param [Hash] options
+        # @option options [Boolean] :Enabled True if guest customization is
+        #   enabled.
+        # @option options [Boolean] :ChangeSid True if customization can change
+        #   the Windows SID of this virtual machine.
+        # @option options [Boolean] :JoinDomainEnabled True if this virtual
+        #   machine can join a Windows Domain.
+        # @option options [Boolean] :UseOrgSettings True if customization
+        #   should use organization settings (OrgGuestPersonalizationSettings)
+        #   when joining a Windows Domain.
+        # @option options [String] :DomainName The name of the Windows Domain
+        #   to join.
+        # @option options [String] :DomainUserName User name to specify when
+        #   joining a Windows Domain.
+        # @option options [String] :DomainUserPassword Password to use with
+        #   :DomainUserName.
+        # @option options [String] :MachineObjectOU The name of the Windows
+        #   Domain Organizational Unit (OU) in which the computer account for
+        #   this virtual machine will be created.
+        # @option options [Boolean] :AdminPassword_enabled True if guest
         #   customization can modify administrator password settings for this
         #   virtual machine.
-        # @option customization [Boolean] :admin_password_auto NOT IMPLEMENTED
-        # @option customization [String] :admin_password NOT IMPLEMENTED
-        # @option customization [Boolean] :reset_password_required True if the
+        # @option options [Boolean] :AdminPassword_auto True if the
+        #   administrator password for this virtual machine should be
+        #   automatically generated.
+        # @option options [String] :AdminPassword True if the administrator
+        #   password for this virtual machine should be set to this string.
+        #   (:AdminPasswordAuto must be false.)
+        # @option options [Boolean] :ResetPasswordRequired True if the
         #   administrator password for this virtual machine must be reset after
         #   first use.
-        # @option customization [String] :customization_script Script to run on
-        #   guest customization. The entire script must appear in this element.
-        # @option customization [String] :computer_name Computer name to assign
+        # @option customization [String] :CustomizationScript Script to run on
+        #  guest customization. The entire script must appear in this element.
+        # @option customization [String] :ComputerName Computer name to assign
         #   to this virtual machine.
         # @return [Excon::Response]
         #   * body<~Hash>:
+        #     * :Tasks<~Hash>:
+        #       * :Task<~Hash>:
         #
         # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/operations/PUT-GuestCustomizationSection-vApp.html
         # @since vCloud API version 1.0
-        def put_guest_customization_section_vapp(id, customization={})
-          data = Fog::Generators::Compute::VcloudDirector::Customization.new(customization)
+        def put_guest_customization_section_vapp(id, options={})
+          options = options.dup
+
+          # Mutate options to new format.
+          deprecated = {
+            :enabled => :Enabled,
+            :change_sid => :ChangeSid,
+            :join_domain_enabled => :JoinDomainEnabled,
+            :use_org_settings => :UseOrgSettings,
+            :admin_password_enabled => :AdminPasswordEnabled,
+            :admin_password_auto => :AdminPasswordAuto,
+            :reset_password_required => :ResetPasswordRequired,
+            :customization_script => :CustomizationScript,
+            :computer_name => :ComputerName
+          }
+          deprecated.each do |from, to|
+            options[to] = options.delete(from) if options.key?(from)
+          end
+
+          body = Nokogiri::XML::Builder.new do
+            attrs = {
+              :xmlns => 'http://www.vmware.com/vcloud/v1.5',
+              'xmlns:ovf' => 'http://schemas.dmtf.org/ovf/envelope/1'
+            }
+            GuestCustomizationSection(attrs) {
+              self['ovf'].Info 'Specifies Guest OS Customization Settings'
+              if options.key?(:Enabled)
+                Enabled options[:Enabled]
+              end
+              if options.key?(:ChangeSid)
+                ChangeSid options[:ChangeSid]
+              end
+              if options.key?(:JoinDomainEnabled)
+                JoinDomainEnabled options[:JoinDomainEnabled]
+              end
+              if options.key?(:UseOrgSettings)
+                UseOrgSettings options[:UseOrgSettings]
+              end
+              if options.key?(:DomainName)
+                DomainName options[:DomainName]
+              end
+              if options.key?(:DomainUser)
+                DomainUser options[:DomainUser]
+              end
+              if options.key?(:DomainUserPassword)
+                DomainUserPassword options[:DomainUserPassword]
+              end
+              if options.key?(:MachineObjectOU)
+                MachineObjectOU options[:MachineObjectOU]
+              end
+              if options.key?(:AdminPasswordEnabled)
+                AdminPasswordEnabled options[:AdminPasswordEnabled]
+              end
+              if options.key?(:AdminPasswordAuto)
+                AdminPasswordAuto options[:AdminPasswordAuto]
+              end
+              if options.key?(:AdminPassword)
+                AdminPassword options[:AdminPassword]
+              end
+              if options.key?(:ResetPasswordRequired)
+                ResetPasswordRequired options[:ResetPasswordRequired]
+              end
+              if options.key?(:CustomizationScript)
+                CustomizationScript options[:CustomizationScript]
+              end
+              if options.key?(:ComputerName)
+                ComputerName options[:ComputerName]
+              end
+            }
+          end.to_xml
 
           request(
-            :body    => data.generate_xml,
+            :body    => body,
             :expects => 202,
             :headers => {'Content-Type' => 'application/vnd.vmware.vcloud.guestCustomizationSection+xml'},
             :method  => 'PUT',

--- a/lib/fog/vcloud_director/requests/compute/put_network_connection_system_section_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_network_connection_system_section_vapp.rb
@@ -5,51 +5,109 @@ module Fog
         extend Fog::Deprecation
         deprecate :put_vm_network, :put_network_connection_system_section_vapp
 
-        require 'fog/vcloud_director/generators/compute/vm_network'
-
         # Update the network connection section of a VM.
         #
         # This operation is asynchronous and returns a task that you can
         # monitor to track the progress of the request.
         #
         # @param [String] id Object identifier of the VM.
-        # @param [Hash] network
-        # @option network [String] :info
-        # @option network [Integer] :primary_network_connection_index Virtual
-        #   slot number associated with the NIC that should be considered this
-        #   virtual machine's primary network connection. Defaults to slot 0.
-        # @option network [Boolean] :needs_customization True if this NIC needs
-        #   customization.
-        # @option network [String] :network Name of the network to which this
-        #   NIC is connected.
-        # @option network [Integer] :network_connection_index Virtual slot
-        #   number associated with this NIC.  First slot number is 0.
-        # @option network [String] :ip_address IP address assigned to this NIC.
-        # @option network [Boolean] :is_connected<~Boolean> If the virtual
-        #   machine is undeployed, this value specifies whether the NIC should
-        #   be connected upon deployment. If the virtual machine is deployed,
-        #   this value reports the current status of this NIC's connection, and
-        #   can be updated to change that connection status.
-        # @option network [String] :mac_address MAC address associated with the
-        #   NIC.
-        # @option network [String] :ip_address_allocation_mode IP address
-        #   allocation mode for this connection. One of:
-        #   * POOL (A static IP address is allocated automatically from a pool
-        #     of addresses.)
-        #   * DHCP (The IP address is obtained from a DHCP service.)
-        #   * MANUAL (The IP address is assigned manually in the :ip_address
-        #     element.)
-        #   * NONE (No IP addressing mode specified.)
+        # @param [Hash] options Container for the network connections of this
+        #   virtual machine.
+        # @option options [Integer] :PrimaryNetworkConnectionIndex (0)
+        #   Virtual slot number associated with the NIC that should be
+        #   considered this virtual machine's primary network connection.
+        #   Defaults to slot 0.
+        # @option options [Array<Hash>] :NetworkConnection
+        #   * :needsCustomization<~Boolean> - True if this NIC needs
+        #     customization.
+        #   * :network<~String> - Name of the network to which this NIC is
+        #     connected.
+        #   * :NetworkConnectionIndex<~Integer> - Virtual slot number
+        #     associated with this NIC. First slot number is 0.
+        #   * :IpAddress<~String> - IP address assigned to this NIC.
+        #   * :IsConnected<~Boolean> - If the virtual machine is undeployed,
+        #     this value specifies whether the NIC should be connected upon
+        #     deployment. If the virtual machine is deployed, this value
+        #     reports the current status of this NIC's connection, and can be
+        #     updated to change that connection status.
+        #   * :MACAddress<~String> - MAC address associated with the NIC.
+        #   * :IpAddressAllocationMode<~String> - IP address allocation mode
+        #     for this connection. One of:
+        #     - POOL (A static IP address is allocated automatically from a
+        #       pool of addresses.)
+        #     - DHCP (The IP address is obtained from a DHCP service.)
+        #     - MANUAL (The IP address is assigned manually in the :IpAddress
+        #       element.)
+        #     - NONE (No IP addressing mode specified.)
         # @return [Excon::Response]
         #   * body<~Hash>:
+        #     * :Tasks<~Hash>:
+        #       * :Task<~Hash>:
         #
         # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/operations/PUT-NetworkConnectionSystemSection-vApp.html
         # @since vCloud API version 0.9
-        def put_network_connection_system_section_vapp(id, network={})
-          data = Fog::Generators::Compute::VcloudDirector::VmNetwork.new(network)
+        def put_network_connection_system_section_vapp(id, options={})
+          options = options.dup
+
+          # Mutate options to new format.
+          deprecated = {
+            :needs_customization => :needsCustomization,
+            :network => :network,
+            :network_connection_index => :NetworkConnectionIndex,
+            :ip_address => :IpAddress,
+            :is_connected => :IsConnected,
+            :mac_address => :MACAddress,
+            :ip_address_allocation_mode => :IpAddressAllocationMode
+          }
+          option = options.delete(:primary_network_connection_index)
+          options[:PrimaryNetworkConnectionIndex] ||= option unless option.nil?
+          unless options.key?(:NetworkConnection)
+            deprecated.each do |from, to|
+              if options.key?(from)
+                options[:NetworkConnection] ||= [{}]
+                options[:NetworkConnection].first[to] = options.delete(from)
+              end
+            end
+          end
+
+          options[:NetworkConnection] = [options[:NetworkConnection]] if options[:NetworkConnection].is_a?(Hash)
+
+          body = Nokogiri::XML::Builder.new do
+            attrs = {
+              :xmlns => 'http://www.vmware.com/vcloud/v1.5',
+              'xmlns:ovf' => 'http://schemas.dmtf.org/ovf/envelope/1'
+            }
+            NetworkConnectionSection(attrs) {
+              self[:ovf].Info 'Specifies the available VM network connections'
+              if options.key?(:PrimaryNetworkConnectionIndex)
+                PrimaryNetworkConnectionIndex options[:PrimaryNetworkConnectionIndex]
+              end
+              if network_connection = options[:NetworkConnection]
+               network_connection.each do |nic|
+                  attrs = {
+                    :network => nic[:network]
+                  }
+                  if nic.key?(:needsCustomization)
+                    attrs[:needsCustomization] = nic[:needsCustomization]
+                  end
+                  NetworkConnection(attrs) {
+                    NetworkConnectionIndex nic[:NetworkConnectionIndex]
+                    if nic.key?(:IpAddress)
+                      IpAddress nic[:IpAddress]
+                    end
+                    IsConnected nic[:IsConnected]
+                    if nic.key?(:MACAddress)
+                      MACAddress nic[:MACAddress]
+                    end
+                    IpAddressAllocationMode nic[:IpAddressAllocationMode]
+                  }
+                end
+              end
+            }
+          end.to_xml
 
           request(
-            :body    => data.generate_xml,
+            :body    => body,
             :expects => 202,
             :headers => {'Content-Type' => 'application/vnd.vmware.vcloud.networkConnectionSection+xml'},
             :method  => 'PUT',


### PR DESCRIPTION
  #put_guest_customization_section_vapp
  #put_network_connection_system_section_vapp

Although no longer documented, the previous options structure is still
accepted and is mutated into the new structure. This behaviour is likely
to be deprecated at some point.
