### PR TITLE
Removed host params for excon connections

### DIFF
--- a/lib/fog/aws/cloud_formation.rb
+++ b/lib/fog/aws/cloud_formation.rb
@@ -103,7 +103,6 @@ module Fog
               :expects    => 200,
               :idempotent => idempotent,
               :headers    => { 'Content-Type' => 'application/x-www-form-urlencoded' },
-              :host       => @host,
               :method     => 'POST',
               :parser     => parser
             })


### PR DESCRIPTION
I am not familiar enough with your code to know if this is the right way to solve this, but I gave it a shot.  We are seeing excon errors in the new 1.16.0 version which is resolved by the following change.  Here is a summary of the error we are seeing:

Invalid Excon request keys: :host
/Users/cheiron/.rvm/gems/ruby-2.0.0-p247@simple_deploy.beta.6/gems/excon-0.27.6/lib/excon/connection.rb:232:in `request'
/Users/cheiron/.rvm/gems/ruby-2.0.0-p247@simple_deploy.beta.6/gems/fog-1.16.0/lib/fog/xml/sax_parser_connection.rb:36:in`request'
/Users/cheiron/.rvm/gems/ruby-2.0.0-p247@simple_deploy.beta.6/gems/fog-1.16.0/lib/fog/core/deprecated/connection.rb:18:in `request'
/Users/cheiron/.rvm/gems/ruby-2.0.0-p247@simple_deploy.beta.6/gems/fog-1.16.0/lib/fog/aws/cloud_formation.rb:101:in`request'
