### PR TITLE
AWS IAM userless key management

### DIFF
--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -88,6 +88,10 @@ module Fog
             hash[key] = {
               :owner_id => Fog::AWS::Mock.owner_id,
               :server_certificates => {},
+              :access_keys => [{
+                "Status" => "Active",
+                "AccessKeyId" => key
+              }],
               :users => Hash.new do |uhash, ukey|
                 uhash[ukey] = {
                   :user_id     => Fog::AWS::Mock.key_id,

--- a/lib/fog/aws/models/iam/access_key.rb
+++ b/lib/fog/aws/models/iam/access_key.rb
@@ -14,7 +14,11 @@ module Fog
         def save
           requires :username
 
-          data = service.create_access_key('UserName'=> username).body["AccessKey"]
+          if !persisted?
+            data = service.create_access_key('UserName'=> username).body["AccessKey"]
+          else
+            data = service.update_access_key(id, status, "UserName" => username).body["AccessKey"]
+          end
           merge_attributes(data)
           true
         end

--- a/lib/fog/aws/models/iam/access_keys.rb
+++ b/lib/fog/aws/models/iam/access_keys.rb
@@ -11,7 +11,6 @@ module Fog
 
         def initialize(attributes = {})
           @username = attributes[:username]
-          raise ArgumentError.new("Can't get an access_key's user without a username") unless @username
           super
         end
 

--- a/lib/fog/aws/requests/iam/create_access_key.rb
+++ b/lib/fog/aws/requests/iam/create_access_key.rb
@@ -36,23 +36,30 @@ module Fog
         def create_access_key(options)
           #FIXME: Not 100% correct as AWS will use the signing credentials when there is no 'UserName' in the options hash
           #       Also doesn't raise an error when there are too many keys
-          user_name = options['UserName']
-          if data[:users].has_key? user_name
-            key = { 'SecretAccessKey' => Fog::Mock.random_base64(40),
-                    'Status' => 'Active',
-                    'AccessKeyId' => Fog::AWS::Mock.key_id(20),
-                    'UserName' => user_name
-                  }
-
-            data[:users][user_name][:access_keys] << key
-
-            Excon::Response.new.tap do |response|
-              response.status = 200
-              response.body = { 'AccessKey' => key,
-                                'RequestId' => Fog::AWS::Mock.request_id } 
+          if user = options['UserName']
+            if data[:users].has_key? user
+              access_keys_data = data[:users][user][:access_keys]
+            else
+              raise Fog::AWS::IAM::NotFound.new('The user with name #{user_name} cannot be found.')
             end
           else
-            raise Fog::AWS::IAM::NotFound.new('The user with name booboboboob cannot be found.')
+            access_keys_data = data[:access_keys]
+          end
+
+          key = { 'SecretAccessKey' => Fog::Mock.random_base64(40),
+                  'Status' => 'Active',
+                  'AccessKeyId' => Fog::AWS::Mock.key_id(20),
+                }
+          if user
+            key["UserName"] = user
+          end
+
+          access_keys_data << key
+
+          Excon::Response.new.tap do |response|
+            response.status = 200
+            response.body = { 'AccessKey' => key,
+                              'RequestId' => Fog::AWS::Mock.request_id }
           end
         end
       end

--- a/lib/fog/aws/requests/iam/list_access_keys.rb
+++ b/lib/fog/aws/requests/iam/list_access_keys.rb
@@ -40,19 +40,23 @@ module Fog
 
         def list_access_keys(options = {})
           #FIXME: Doesn't do anything with options, aside from UserName
-          user = options['UserName']
-
-          if data[:users].has_key? user
-            Excon::Response.new.tap do |response|
-              response.body = { 'AccessKeys' => data[:users][user][:access_keys].map do |akey|
-                                                  {'Status' => akey['Status'], 'AccessKeyId' => akey['AccessKeyId']}
-                                                end,
-                                 'IsTruncated' => false,
-                                 'RequestId' => Fog::AWS::Mock.request_id }
-              response.status = 200
+          if user = options['UserName']
+            if data[:users].has_key? user
+              access_keys_data = data[:users][user][:access_keys]
+            else
+              raise Fog::AWS::IAM::NotFound.new("The user with name #{user} cannot be found.")
             end
           else
-            raise Fog::AWS::IAM::NotFound.new("The user with name #{user} cannot be found.")
+            access_keys_data = data[:access_keys]
+          end
+
+          Excon::Response.new.tap do |response|
+            response.body = { 'AccessKeys' => access_keys_data.map do |akey|
+                                                {'Status' => akey['Status'], 'AccessKeyId' => akey['AccessKeyId']}
+                                              end,
+                               'IsTruncated' => false,
+                               'RequestId' => Fog::AWS::Mock.request_id }
+            response.status = 200
           end
         end
       end

--- a/lib/fog/aws/requests/iam/update_access_key.rb
+++ b/lib/fog/aws/requests/iam/update_access_key.rb
@@ -31,6 +31,28 @@ module Fog
         end
 
       end
+
+      class Mock
+        def update_access_key(access_key_id, status, options = {})
+          if user = options['UserName']
+            if data[:users].has_key? user
+              access_keys_data = data[:users][user][:access_keys]
+            else
+              raise Fog::AWS::IAM::NotFound.new('The user with name #{user_name} cannot be found.')
+            end
+          else
+            access_keys_data = data[:access_keys]
+          end
+          key = access_keys_data.detect{|k| k["AccessKeyId"] == access_key_id}
+          key["Status"] = status
+          Excon::Response.new.tap do |response|
+            response.status = 200
+            response.body = { 'AccessKey' => key,
+                              'RequestId' => Fog::AWS::Mock.request_id }
+          end
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
- Implement mocks for create_acces_key, list_access_keys, update_access_keys
- support fog.access_keys without specifying user as amazon does: http://docs.aws.amazon.com/IAM/latest/APIReference/API_ListAccessKeys.html
