### PR TITLE
corrected name of edgegateway generator

### DIFF
--- a/lib/fog/vcloud_director/generators/compute/edge_gateway_service_configuration.rb
+++ b/lib/fog/vcloud_director/generators/compute/edge_gateway_service_configuration.rb
@@ -2,7 +2,7 @@ module Fog
   module Generators
     module Compute
       module VcloudDirector
-        class EdgeGateway
+        class EdgeGatewayServiceConfiguration
           def initialize(configuration={})
             @configuration = configuration
           end

--- a/lib/fog/vcloud_director/requests/compute/post_configure_edge_gateway_services.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_configure_edge_gateway_services.rb
@@ -3,7 +3,7 @@ module Fog
     class VcloudDirector
       class Real
 
-        require 'fog/vcloud_director/generators/compute/edge_gateway'
+        require 'fog/vcloud_director/generators/compute/edge_gateway_service_configuration'
 
         # Configure edge gateway services like firewall, nat and load balancer.
         #
@@ -21,7 +21,7 @@ module Fog
         #   vCloud API Documentaion
         # @since vCloud API version 5.1
         def post_configure_edge_gateway_services(id, configuration)
-          body = Fog::Generators::Compute::VcloudDirector::EdgeGateway.new(configuration).generate_xml
+          body = Fog::Generators::Compute::VcloudDirector::EdgeGatewayServiceConfiguration.new(configuration).generate_xml
 
           request(
               :body => body,


### PR DESCRIPTION
Renamed generator to have name same as the top level xml_node it generates.
