### PR TITLE
[vcloud_director] improved tests for #ensure_list!

### DIFF
--- a/tests/vcloud_director/ensure_list_tests.rb
+++ b/tests/vcloud_director/ensure_list_tests.rb
@@ -5,7 +5,7 @@ Shindo.tests('Compute::VcloudDirector | ensure_list!', ['vclouddirector']) do
 
     @service = Fog::Compute::VcloudDirector.new
 
-    tests('#ensure_list! for single key') do
+    tests('#ensure_list! for single key ensures our key has an array as a value') do
       tests('for key with a hash').returns(Array) do
         testdata = {:k => {:A => '1'}}
         @service.ensure_list!(testdata, :k)
@@ -31,7 +31,7 @@ Shindo.tests('Compute::VcloudDirector | ensure_list!', ['vclouddirector']) do
       end
     end
 
-    tests ('#ensure_list! for nested keys') do
+    tests('#ensure_list! for nested keys ensures that the child key has an array as a value') do
       tests('with no key').returns(Array) do
         testdata = {}
         @service.ensure_list!(testdata, :keys, :key)
@@ -48,6 +48,34 @@ Shindo.tests('Compute::VcloudDirector | ensure_list!', ['vclouddirector']) do
         testdata = {:keys => {:key => {:a => '1'}}}
         @service.ensure_list!(testdata, :keys, :key)
         testdata[:keys][:key].class
+      end
+    end
+
+    tests('#ensure_list! with parent and child keys does not effect existing data') do
+      tests('for existing array').returns([:one, :two]) do
+        testdata = {:keys => {:key => [:one, :two]}}
+        @service.ensure_list!(testdata, :keys, :key)
+        testdata[:keys][:key]
+      end
+
+      tests('for existing hash').returns([{:one => :two}]) do
+        testdata = {:keys => {:key => {:one => :two}}}
+        @service.ensure_list!(testdata, :keys, :key)
+        testdata[:keys][:key]
+      end
+    end
+
+    tests('#ensure_list! with single key does not effect existing data') do
+      tests('for existing array').returns([:one, :two]) do
+        testdata = {:k => [:one, :two]}
+        @service.ensure_list!(testdata, :k)
+        testdata[:k]
+      end
+
+      tests('for existing hash').returns([{:one => 'two'}]) do
+        testdata = {:k => {:one => 'two'}}
+        @service.ensure_list!(testdata, :k)
+        testdata[:k]
       end
     end
 


### PR DESCRIPTION
Covering required behaviour around the contents of the lists - that they remain intact if data already exists
