### PR TITLE
[vcloud_director] fixes so that non configured gateway are supported

### DIFF
--- a/lib/fog/vcloud_director/requests/compute/get_edge_gateway.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_edge_gateway.rb
@@ -23,22 +23,27 @@ module Fog
 
           edge_gateway_service_configuration = response.body[:Configuration][:EdgeGatewayServiceConfiguration]
 
-          ensure_list! edge_gateway_service_configuration[:FirewallService], :FirewallRule
-          ensure_list! edge_gateway_service_configuration[:NatService], :NatRule
-          ensure_list! edge_gateway_service_configuration[:LoadBalancerService], :Pool
-          ensure_list! edge_gateway_service_configuration[:LoadBalancerService], :VirtualServer
+          ensure_list! edge_gateway_service_configuration[:FirewallService], :FirewallRule if edge_gateway_service_configuration[:FirewallService]
+          ensure_list! edge_gateway_service_configuration[:NatService], :NatRule if edge_gateway_service_configuration[:NatService]
 
-          edge_gateway_service_configuration[:LoadBalancerService][:Pool].each do |pool|
-            ensure_list! pool, :ServicePort
-            ensure_list! pool, :Member
-            pool[:Member].each do |member|
-              ensure_list! member, :ServicePort
+          if edge_gateway_service_configuration[:LoadBalancerService]
+
+            ensure_list! edge_gateway_service_configuration[:LoadBalancerService], :Pool
+            edge_gateway_service_configuration[:LoadBalancerService][:Pool].each do |pool|
+              ensure_list! pool, :ServicePort
+              ensure_list! pool, :Member
+              pool[:Member].each do |member|
+                ensure_list! member, :ServicePort
+              end
             end
+
+            ensure_list! edge_gateway_service_configuration[:LoadBalancerService], :VirtualServer
+            edge_gateway_service_configuration[:LoadBalancerService][:VirtualServer].each do |virtual_server|
+              ensure_list! virtual_server, :ServiceProfile
+            end
+
           end
 
-          edge_gateway_service_configuration[:LoadBalancerService][:VirtualServer].each do |virtual_server|
-            ensure_list! virtual_server, :ServiceProfile
-          end
           response
         end
       end


### PR DESCRIPTION
Currently the get_edge_gateway call bombs on non-configured edge gateways as they don't contain all the expected fields and configuration.

This pull request fixes that by checking before traversing the xml. There is a second requirement that fills in the missing parts, but I wanted to submit this as it stops the code breaking on some environments. 

I've tested it on 4 different environments that are in different states, but acknowledge that more automation around this logic is a future requirement, once we can manipulate edge gateway configuration

/cc @nosborn 
