### PR TITLE
[aws|iam] Don't pass :host to Excon request

### DIFF
--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -209,7 +209,6 @@ module Fog
             :expects    => 200,
             :idempotent => idempotent,
             :headers    => { 'Content-Type' => 'application/x-www-form-urlencoded' },
-            :host       => @host,
             :method     => 'POST',
             :parser     => parser
           })


### PR DESCRIPTION
Related issues: #2262, #2265 & #2284.  Tested on my AWS account scripts.
