### PR TITLE
[vSphere] Implemented feature to specify a socket cpu layout as specified

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -103,6 +103,7 @@ module Fog
           :tools_version => 'guest.toolsVersionStatus',
           :memory_mb => 'config.hardware.memoryMB',
           :cpus   => 'config.hardware.numCPU',
+          :corespersocket   => 'config.hardware.numCoresPerSocket',
           :overall_status => 'overallStatus',
           :guest_id => 'config.guestId',
         }

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -36,6 +36,7 @@ module Fog
         attribute :relative_path
         attribute :memory_mb
         attribute :cpus
+        attribute :corespersocket
         attribute :interfaces
         attribute :volumes
         attribute :customvalues
@@ -66,12 +67,12 @@ module Fog
 
         def vm_reconfig_memory(options = {})
           requires :instance_uuid, :memory
-          service.vm_reconfig_memory('instance_uuid' => instance_uuid, 'memory' => memory)
+          service.vm_reconfig_memory('instance_uuid' => instance_uuid, 'memory' => memory_mb)
         end
 
         def vm_reconfig_cpus(options = {})
-          requires :instance_uuid, :cpus
-          service.vm_reconfig_cpus('instance_uuid' => instance_uuid, 'cpus' => cpus)
+          requires :instance_uuid, :cpus, :corespersocket
+          service.vm_reconfig_cpus('instance_uuid' => instance_uuid, 'cpus' => cpus, 'corespersocket' => corespersocket)
         end
 
         def vm_reconfig_hardware(hardware_spec, options = {})
@@ -162,6 +163,10 @@ module Fog
           memory_mb * 1024 * 1024
         end
 
+        def sockets
+          cpus / corespersocket
+        end
+        
         def mac
           interfaces.first.mac unless interfaces.empty?
         end
@@ -230,6 +235,7 @@ module Fog
         def defaults
           {
             :cpus      => 1,
+#            :corespersocket => 1,
             :memory_mb => 512,
 #            :guest_id  => 'otherGuest',
             :path      => '/'

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -10,6 +10,7 @@ module Fog
             :guestId      => attributes[:guest_id],
             :files        => { :vmPathName => vm_path_name(attributes) },
             :numCPUs      => attributes[:cpus],
+            :numCoresPerSocket => attributes[:corespersocket],
             :memoryMB     => attributes[:memory_mb],
             :deviceChange => device_change(attributes),
             :extraConfig  => extra_config(attributes),

--- a/lib/fog/vsphere/requests/compute/vm_reconfig_cpus.rb
+++ b/lib/fog/vsphere/requests/compute/vm_reconfig_cpus.rb
@@ -5,7 +5,7 @@ module Fog
         def vm_reconfig_cpus(options = {})
           raise ArgumentError, "cpus is a required parameter" unless options.has_key? 'cpus'
           raise ArgumentError, "instance_uuid is a required parameter" unless options.has_key? 'instance_uuid'
-          hardware_spec={'numCPUs' => options['cpus']}
+          hardware_spec={'numCPUs' => options['cpus'], 'numCoresPerSocket' => options['corespersocket']}
           vm_reconfig_hardware('instance_uuid' => options['instance_uuid'], 'hardware_spec' => hardware_spec )
         end
       end
@@ -14,7 +14,7 @@ module Fog
         def vm_reconfig_cpus(options = {})
           raise ArgumentError, "cpus is a required parameter" unless options.has_key? 'cpus'
           raise ArgumentError, "instance_uuid is a required parameter" unless options.has_key? 'instance_uuid'
-          hardware_spec={'numCPUs' => options['cpus']}
+          hardware_spec={'numCPUs' => options['cpus'], 'numCoresPerSocket' => options['corespersocket']}
           vm_reconfig_hardware('instance_uuid' => options['instance_uuid'], 'hardware_spec' => hardware_spec )
         end
       end


### PR DESCRIPTION
[vSphere] Implemented feature to specify a socket cpu layout as specified in vmware API. If not used numCoresPerSocket is left out and default VMware behaviour is used.

Example for creation of vm:

```
compute.servers.create("name" => "myname", "cluster" => compute.datacenters.first.clusters.first.name, "datacenter" => compute.datacenters.first.name, "memory_mb"=>1024, "cpus"=>2, "corespersocket"=>2,"guest_id"=>"rhel6_64Guest", "interfaces"=>[interface,], "volumes"=>[volume])
```

Will end up with 1 socket with 2 cores instead of 2 sockets with 1 core each. 
This seams to have some performance advantages (might be dependent on guest OS).

[vSphere] also fixed bug in vm_reconfig_memory: wrong memory value passed to reconfig_hardware (memory in bytes instead of memory in MB).
