### PR TITLE
Invalid Excon request keys: :host, :port

### DIFF
--- a/lib/fog/hp.rb
+++ b/lib/fog/hp.rb
@@ -162,8 +162,6 @@ module Fog
           :headers => {
               'Content-Type' => 'application/json'
           },
-          :host => @host,
-          :port => @port,
           :method => 'POST',
           :body => Fog::JSON.encode(request_body),
           :path => @auth_path


### PR DESCRIPTION
as explained https://github.com/fog/fog/issues/2248 is preventing authentication with hp cloud.
