### PR TITLE
[vSphere] Implementation of feature to specify scsi_controller type at create time

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -37,6 +37,7 @@ module Fog
       collection :customvalues
       model :customfield
       collection :customfields
+      model :scsicontroller
 
       request_path 'fog/vsphere/requests/compute'
       request :current_time
@@ -77,6 +78,7 @@ module Fog
       request :get_interface_type
       request :list_vm_customvalues
       request :list_customfields
+      request :get_vm_first_scsi_controller
 
       module Shared
 

--- a/lib/fog/vsphere/models/compute/scsicontroller.rb
+++ b/lib/fog/vsphere/models/compute/scsicontroller.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Vsphere
+
+      class SCSIController < Fog::Model
+
+        attribute :shared_bus
+        attribute :type
+        attribute :unit_number
+        attribute :key
+
+        def to_s
+          "#{type} ##{key}: shared: #{shared_bus}, unit_number: #{unit_number}"
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -46,6 +46,7 @@ module Fog
         attribute :resource_pool
         attribute :instance_uuid # move this --> id
         attribute :guest_id
+        attribute :scsi_controller # this is the first scsi controller. Right now no more of them can be used.
 
         def initialize(attributes={} )
           super defaults.merge(attributes)
@@ -53,6 +54,7 @@ module Fog
           initialize_interfaces
           initialize_volumes
           initialize_customvalues
+          initialize_scsi_controller
         end
 
         # Lazy Loaded Attributes
@@ -202,6 +204,10 @@ module Fog
           attributes[:customvalues] ||= id.nil? ? [] : service.customvalues( :vm => self )
         end
 
+        def scsi_controller
+          self.attributes[:scsi_controller] ||= service.get_vm_first_scsi_controller(id)
+        end
+
         def folder
           return nil unless datacenter and path
           attributes[:folder] ||= service.folders(:datacenter => datacenter, :type => :vm).get(path)
@@ -259,6 +265,13 @@ module Fog
             self.attributes[:customvalues].map { |cfield| cfield.is_a?(Hash) ? service.customvalue.new(cfield) : cfield}
           end
         end
+
+        def initialize_scsi_controller
+          if attributes[:scsi_controller] and attributes[:scsi_controller].is_a?(Hash)
+            Fog::Compute::Vsphere::SCSIController.new(self.attributes[:scsi_controller])
+          end
+        end
+
       end
 
     end

--- a/lib/fog/vsphere/requests/compute/get_vm_first_scsi_controller.rb
+++ b/lib/fog/vsphere/requests/compute/get_vm_first_scsi_controller.rb
@@ -1,0 +1,26 @@
+
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def get_vm_first_scsi_controller(vm_id)
+          Fog::Compute::Vsphere::SCSIController.new(get_vm_first_scsi_controller_raw(vm_id))
+        end
+        def get_vm_first_scsi_controller_raw(vm_id)
+          ctrl=get_vm_ref(vm_id).config.hardware.device.grep(RbVmomi::VIM::VirtualSCSIController).select{ | ctrl | ctrl.key == 1000 }.first
+          {
+            :type    => ctrl.class.to_s,
+            :shared_bus  => ctrl.sharedBus.to_s,
+            :unit_number => ctrl.scsiCtlrUnitNumber,
+            :key => ctrl.key,
+          } 
+        end
+
+      end
+      class Mock
+        def get_vm_first_scsi_controller(vm_id)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This feature is an implementation for creating virtual machines with a userdefined storage controller on bases of the Vsphere VirtualSCSIController.
If you don't pass a userdefined storage controller the VirtualLsiLogicController will be used (as before).
If you want to specify the storage controller by userself do it as follows:

```
vm=compute.servers.create(
   "name" => "..", 
   "cluster" => compute.datacenters.first.clusters.first.name, 
   "datacenter" => compute.datacenters.first.name, 
   "memory_mb"=>1024, 
   "cpus"=>2, 
   "guest_id"=>"rhel6_64Guest", 
   "scsi_controller" => { "type" => "ParaVirtualSCSIController", "shared" => true }, 
   "interfaces"=>[interface,], 
   "volumes"=>[volume]
)
```
