### PR TITLE
Replaced the 'unicode' gem with 'unf' so it'll work with JRuby.

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -50,7 +50,6 @@ Gem::Specification.new do |s|
   s.add_dependency('net-ssh', '>=2.1.3')
   s.add_dependency('nokogiri', '~>1.5')
   s.add_dependency('ruby-hmac')
-  s.add_dependency('unf')
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development

--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -1,7 +1,12 @@
 require 'fog/core'
 require 'fog/aws/credential_fetcher'
 require 'fog/aws/signaturev4'
-require 'unf/normalizer'
+
+begin
+  require 'unf/normalizer'
+rescue LoadError
+  Fog::Logger.warning("Unable to load the 'unf' gem. Your AWS strings may not be properly encoded.")
+end
 
 module Fog
   module AWS
@@ -87,7 +92,7 @@ module Fog
     end
 
     def self.escape(string)
-      string = ::UNF::Normalizer.normalize(string, :nfc)
+      string = defined?(::UNF::Normalizer) ? ::UNF::Normalizer.normalize(string, :nfc) : string
       string.gsub(/([^a-zA-Z0-9_.\-~]+)/) {
         "%" + $1.unpack("H2" * $1.bytesize).join("%").upcase
       }

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -170,7 +170,7 @@ module Fog
 
         # NOTE: differs from Fog::AWS.escape by NOT escaping `/`
         def escape(string)
-          string = ::UNF::Normalizer.normalize(string, :nfc)
+          string = defined?(::UNF::Normalizer) ? ::UNF::Normalizer.normalize(string, :nfc) : string
           string.gsub(/([^a-zA-Z0-9_.\-~\/]+)/) {
             "%" + $1.unpack("H2" * $1.bytesize).join("%").upcase
           }


### PR DESCRIPTION
Fixes #2279: Remove dependency on "unicode" gem.
