### PR TITLE
[vcloud_director] Add EnableLogging field to FirewallService XML

### DIFF
--- a/lib/fog/vcloud_director/generators/compute/edge_gateway_service_configuration.rb
+++ b/lib/fog/vcloud_director/generators/compute/edge_gateway_service_configuration.rb
@@ -143,6 +143,7 @@ module Fog
                   xml.SourcePort rule[:SourcePort] == "Any" ? "-1" : rule[:SourcePort]
                   xml.SourcePortRange rule[:SourcePortRange]
                   xml.SourceIp rule[:SourceIp]
+                  xml.EnableLogging rule[:EnableLogging] if rule.key?(:EnableLogging)
                 }
 
               end


### PR DESCRIPTION
This field controls the "log network traffice for firewall rule" option.

Manually tested against a vcloud director instance.
