### PR TITLE
aws/compute: Hotfix, wrong Name argument for copy_image

### DIFF
--- a/lib/fog/aws/requests/compute/copy_image.rb
+++ b/lib/fog/aws/requests/compute/copy_image.rb
@@ -26,7 +26,7 @@ module Fog
             'Action'          => 'CopyImage',
             'SourceImageId'   => source_image_id,
             'SourceRegion'    => source_region,
-            'Name'            => source_region,
+            'Name'            => name,
             'Description'     => description,
             'ClientToken'     => client_token,
             :parser           => Fog::Parsers::Compute::AWS::CopyImage.new


### PR DESCRIPTION
Just a simple fix
