### PR TITLE
[Brightbox] Add SSL settings to load balancer

### DIFF
--- a/lib/fog/brightbox/models/compute/load_balancer.rb
+++ b/lib/fog/brightbox/models/compute/load_balancer.rb
@@ -18,6 +18,14 @@ module Fog
         attribute :healthcheck
         attribute :listeners
 
+        # These SSL attributes act only as setters. You can not read certs or keys via the API
+        attribute :certificate_pem
+        attribute :certificate_private_key
+
+        # These SSL attributes act only as getters for metadata
+        attribute :certificate_expires_at
+        attribute :certificate_subject
+
         # Times
         attribute :created_at, :type => :time
         attribute :deleted_at, :type => :time
@@ -39,7 +47,9 @@ module Fog
             :listeners => listeners,
             :healthcheck => healthcheck,
             :policy => policy,
-            :name => name
+            :name => name,
+            :certificate_pem => certificate_pem,
+            :certificate_private_key => certificate_private_key
           }.delete_if {|k,v| v.nil? || v == "" }
           data = service.create_load_balancer(options)
           merge_attributes(data)
@@ -52,8 +62,43 @@ module Fog
           true
         end
 
-      end
+        # SSL cert metadata for expiration of certificate
+        def certificate_expires_at
+          attributes[:certificate_expires_at]
+        end
 
+        # SSL cert metadata for subject
+        def certificate_subject
+          attributes[:certificate_subject]
+        end
+
+        # Sets the certificate metadata from the JSON object that contains it.
+        #
+        # It is used by fog's attribute setting and should not be used for attempting to set a
+        # certificate on a load balancer.
+        #
+        # @private
+        def certificate=(cert_metadata)
+          if cert_metadata
+            attributes[:certificate_expires_at] = time_or_original(cert_metadata["expires_at"])
+            attributes[:certificate_subject] = cert_metadata["subject"]
+          else
+            attributes[:certificate_expires_at] = nil
+            attributes[:certificate_subject] = nil
+          end
+        end
+
+      private
+
+        def time_or_original(value)
+          begin
+            Time.parse(value)
+          rescue TypeError, ArgumentError
+            value
+          end
+        end
+
+      end
     end
   end
 end

--- a/tests/brightbox/compute/schema.rb
+++ b/tests/brightbox/compute/schema.rb
@@ -581,6 +581,7 @@ class Brightbox
           "listeners"       => [Brightbox::Compute::Formats::Struct::LB_LISTENER],
           "policy"          => String,
           "healthcheck"     => Brightbox::Compute::Formats::Struct::LB_HEALTHCHECK,
+          "certificate"     => Fog::Nullable::Hash,
           "created_at"      => String,
           "deleted_at"      => Fog::Nullable::String,
           "account"         => Brightbox::Compute::Formats::Nested::ACCOUNT,


### PR DESCRIPTION
This allows passing a SSL cert and key to a load balancer to use SSL.

If a certificate is present, the expiry time and certificate subject are
available.
