### PR TITLE
rake mock[<provider>] and live[<provider] tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -68,7 +68,7 @@ end
 desc 'Run mocked tests for a specific provider'
 task :mock, :provider do |t, args|
   if args.to_a.size != 1
-    fail 'USAGE: rake live[<provider>]'
+    fail 'USAGE: rake mock[<provider>]'
   end
   provider = args[:provider]
   sh("export FOG_MOCK=true && bundle exec shindont tests/#{provider}")


### PR DESCRIPTION
In a case of inspired laziness, I decided I'd rather implement this:

``` sh
$ rake -vT
...
rake live[provider]  # Run live tests against a specific provider
rake mock[provider]  # Run mocked tests for a specific provider
...
```

``` sh
$ rake mock['rackspace']
# runs rackspace tests using mocks...
```

then send someone instructions to run `export FOG_MOCK=false && bundle exec shindont tests/rackspace` or `export FOG_MOCK=false && bundle exec shindont tests/rackspace`.  Less typing.

Note: the provider names are from the tests folder instead of the keys for Fog.providers.  It's the same for most, but there is are discrepencies for multi-word providers (gogrid, internetarchive, baremetalcloud, stormondemand, vclouddirector and vmfusion).
