### PR TITLE
Username being overrided

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -65,7 +65,7 @@ module Fog
           prepare_service_value(attributes)
 
           self.image_id   ||= begin
-            self.username = 'ubuntu'
+            self.username ||= 'ubuntu'
             case @service.instance_variable_get(:@region) # Ubuntu 10.04 LTS 64bit (EBS)
             when 'ap-northeast-1'
               'ami-5e0fa45f'


### PR DESCRIPTION
When trying to launch a spot instance with AWS the username that I defined during the setup of the server is being overridden.

I added a || so that if the username is already manually defined by the user, it won't get  overridden.
