### PR TITLE
[aws|data_pipeline] don't pass host to request

### DIFF
--- a/lib/fog/aws/data_pipeline.rb
+++ b/lib/fog/aws/data_pipeline.rb
@@ -92,7 +92,6 @@ module Fog
           # Params for all DataPipeline requests
           params.merge!({
             :expects => 200,
-            :host => @host,
             :method => :post,
             :path => '/',
           })


### PR DESCRIPTION
I ran into a similar issue to fog/fog#2248.  Tried the same fix as e57058f.  Verified working.  /cc @kbarrette
