### PR TITLE
[vcloud_director] fixing firewall config to follow api documentation

### DIFF
--- a/lib/fog/vcloud_director/generators/compute/edge_gateway_service_configuration.rb
+++ b/lib/fog/vcloud_director/generators/compute/edge_gateway_service_configuration.rb
@@ -128,21 +128,22 @@ module Fog
                   xml.Id rule[:Id]
                   xml.IsEnabled rule[:IsEnabled] if rule.key?(:IsEnabled)
                   xml.MatchOnTranslate rule[:MatchOnTranslate] if rule.key?(:MatchOnTranslate)
-                  xml.Description rule[:Description]
-                  xml.Policy rule[:Policy]
+                  xml.Description rule[:Description] if rule.key?[:Description]
+                  xml.Policy rule[:Policy] if rule.key?[:Policy]
 
                   xml.Protocols {
-                    rule[:Protocols].each do |protocol, is_enabled|
-                      xml.send(protocol.to_s.capitalize, is_enabled)
+                    rule[:Protocols].each do |key, value|
+                      xml.send(key.to_s.capitalize, value)
                     end
                   }
-                  xml.IcmpSubType "any" if (rule[:Protocols].include?(:Icmp)  && rule[:Protocols][:Icmp] == true )
-                  xml.Port rule[:Port] == "Any" ? "-1" : rule[:Port]
+                  xml.IcmpSubType rule[:IcmpSubType] if rule.key?[:IcmpSubType]
+                  xml.Port rule[:Port] if rule.key?[:Port]
                   xml.DestinationPortRange rule[:DestinationPortRange]
                   xml.DestinationIp rule[:DestinationIp]
-                  xml.SourcePort rule[:SourcePort] == "Any" ? "-1" : rule[:SourcePort]
+                  xml.SourcePort rule[:SourcePort] if rule.key?[:SourcePort]
                   xml.SourcePortRange rule[:SourcePortRange]
                   xml.SourceIp rule[:SourceIp]
+                  xml.Direction rule[:Direction] if rule.key?[:Direction] #Firewall rule direction is allowed only in backward compatibility mode.
                   xml.EnableLogging rule[:EnableLogging] if rule.key?(:EnableLogging)
                 }
 


### PR DESCRIPTION
Change include following fixes:
1. policy, description and port fields are not mandatory.
2. Request layer should be dump and should not do smart handling of
data. Accepting data in same format as documented in api doc =>
https://pubs.vmware.com/vcd-51/index.jsp#doc/index.html
3. SourceIp and destinationIp fields are used to control source and destination
for traffic. These fields are included in documentation, but there is
no other field provided to accept ips.
