### PR TITLE
Allows custom username for aws spot instances

### DIFF
--- a/lib/fog/aws/models/compute/spot_request.rb
+++ b/lib/fog/aws/models/compute/spot_request.rb
@@ -42,7 +42,7 @@ module Fog
           self.groups ||= ["default"]
           self.flavor_id ||= 't1.micro'
           self.image_id   ||= begin
-            self.username = 'ubuntu'
+            self.username ||= 'ubuntu'
 
             # Old 'connection' is renamed as service and should be used instead
             prepare_service_value(attributes)


### PR DESCRIPTION
Extension of https://github.com/fog/fog/commit/135c30944bf01a8c2a044a1cf3b219d3104ff4d1 for spot instances.
