### PR TITLE
Added content_encoding attribute to Rackspace storage

### DIFF
--- a/lib/fog/rackspace/models/storage/file.rb
+++ b/lib/fog/rackspace/models/storage/file.rb
@@ -42,6 +42,11 @@ module Fog
         # @see http://docs.rackspace.com/files/api/v1/cf-devguide/content/CORS_Container_Header-d1e1300.html
         attribute :origin,          :aliases => ['Origin']
 
+        # @!attribute [rw] content_encoding
+        # @return [String] The content encoding of the file
+        # @see http://docs.rackspace.com/files/api/v1/cf-devguide/content/Enabling_File_Compression_with_the_Content-Encoding_Header-d1e2198.html
+        attribute :content_encoding, :aliases => 'Content-Encoding'
+
         # @!attribute [r] directory
         # @return [Fog::Storage::Rackspace::Directory] directory containing file
         attr_accessor :directory
@@ -87,6 +92,7 @@ module Fog
           options['Content-Type'] ||= content_type if content_type
           options['Access-Control-Allow-Origin'] ||= access_control_allow_origin if access_control_allow_origin
           options['Origin'] ||= origin if origin
+          options['Content-Encoding'] ||= content_encoding if content_encoding
           service.copy_object(directory.key, key, target_directory_key, target_file_key, options)
           target_directory = service.directories.new(:key => target_directory_key)
           target_directory.files.get(target_file_key)
@@ -247,6 +253,7 @@ module Fog
           options['Origin'] = origin if origin
           options['Content-Disposition'] = content_disposition if content_disposition
           options['Etag'] = etag if etag
+          options['Content-Encoding'] = content_encoding if content_encoding
           options.merge!(metadata.to_headers)
 
           data = service.put_object(directory.key, key, body, options)

--- a/tests/rackspace/models/storage/file_tests.rb
+++ b/tests/rackspace/models/storage/file_tests.rb
@@ -314,6 +314,35 @@ Shindo.tests('Fog::Rackspace::Storage | file', ['rackspace']) do
 
     end
 
+    tests("#content_encoding") do
+
+      tests("#content_encoding should default to nil").returns(nil) do
+        @instance.save
+        @instance.content_encoding
+      end
+
+      @instance.content_encoding = 'gzip'
+      @instance.save
+      tests("#content_encoding should return the content encoding").returns('gzip') do
+        @instance.content_encoding
+      end
+      @instance.attributes.delete('content_encoding')
+
+      @instance.content_encoding = 'foo'
+      @instance.save
+      tests("#content_encoding= should update content_encoding").returns('bar') do
+        @instance.content_encoding = 'bar'
+        @instance.save
+        @instance.content_encoding
+      end
+
+      tests("#content_encoding= should not blow up on nil") do
+        @instance.content_encoding = nil
+        @instance.save
+      end
+
+    end
+
   end
 
   @directory.destroy


### PR DESCRIPTION
Added content_encoding attribute to Rackspace storage.

Amazon storage already has it and according to [this](http://docs.rackspace.com/files/api/v1/cf-devguide/content/Enabling_File_Compression_with_the_Content-Encoding_Header-d1e2198.html) Rackspace also allow setting the content-encoding.
