### PR TITLE
Fix bugs in OpenStack Host

### DIFF
--- a/lib/fog/openstack/models/compute/host.rb
+++ b/lib/fog/openstack/models/compute/host.rb
@@ -20,6 +20,8 @@ module Fog
 
         def details
           service.get_host_details(self.host_name).body['host']
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
         end
 
       end


### PR DESCRIPTION
There are 2 issues here.

The first is that the OpenStack host has an attribute called service. When the model is created, this overrides the parent attribute (formerly "connection") that is used to make all the requests to the OpenStack API. Changed this to service_name to avoid the collision.

The second issue is that for several services, OpenStack returns a NotFound when requesting host details. Added a rescue block to prevent this from raising.
