### PR TITLE
Remove :host key in RDS request method to eliminate excon warning

### DIFF
--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -215,7 +215,6 @@ module Fog
               :expects    => 200,
               :headers    => { 'Content-Type' => 'application/x-www-form-urlencoded' },
               :idempotent => idempotent,
-              :host       => @host,
               :method     => 'POST',
               :parser     => parser
             })


### PR DESCRIPTION
Same as #2265.  Gets rid of warning:

```
[excon][WARNING] Invalid Excon request keys: :host
```

for RDS requests.
