### PR TITLE
[Brightbox] Fix test issue with reusing servers

### DIFF
--- a/tests/brightbox/requests/compute/interface_tests.rb
+++ b/tests/brightbox/requests/compute/interface_tests.rb
@@ -5,28 +5,17 @@ Shindo.tests('Fog::Compute[:brightbox] | interface requests', ['brightbox']) do
   tests('success') do
 
     unless Fog.mocking?
-      server = @test_service.servers.first
+      @test_server = Brightbox::Compute::TestSupport.get_test_server
+      @interface_id = @test_server.interfaces.first["id"]
 
-      # If no server is available, create one just for the test
-      unless server
-        @test_server = Brightbox::Compute::TestSupport.get_test_server
-        server = @test_server
+      tests("#get_interface('#{@interface_id}')") do
+        pending if Fog.mocking?
+        result = @test_service.get_interface(@interface_id)
+        data_matches_schema(Brightbox::Compute::Formats::Full::INTERFACE, {:allow_extra_keys => true}) { result }
       end
 
-      @interface_id = server.interfaces.first["id"]
+      @test_server.destroy
     end
-
-    tests("#get_interface('#{@interface_id}')") do
-      pending if Fog.mocking?
-      result = @test_service.get_interface(@interface_id)
-      data_matches_schema(Brightbox::Compute::Formats::Full::INTERFACE, {:allow_extra_keys => true}) { result }
-    end
-
-    unless Fog.mocking?
-      # If we created a server just for this test, clean it up
-      @test_server.destroy if @test_server
-    end
-
   end
 
   tests('failure') do
@@ -41,5 +30,4 @@ Shindo.tests('Fog::Compute[:brightbox] | interface requests', ['brightbox']) do
       @test_service.get_interface()
     end
   end
-
 end


### PR DESCRIPTION
To save time, we hoped to use an existing server to read the interface
JSON and it did a naive selection of the first server.

Server's that are deleted have two relevant characteristics. 1) They no
longer have interfaces and 2) they are reported in the output in their
deleted state for an hour after being removed.

Since the test was not filtering for active servers, subsequent runs
could pick up a deleted server and fail to find the identifier for it's
missing first interface.

This simplifies matters by creating a new server for the test.
