### PR TITLE
[google|compute] natIP is set to true when it must be an ip

### DIFF
--- a/lib/fog/google/requests/compute/insert_server.rb
+++ b/lib/fog/google/requests/compute/insert_server.rb
@@ -115,18 +115,16 @@ module Fog
           end
 
           # ExternalIP is default value for server creation
+          access_config = {'type' => 'ONE_TO_ONE_NAT', 'name' => 'External NAT'}
+          # leave natIP undefined to use an IP from a shared ephemeral IP address pool
           if options.has_key? 'externalIp'
-            external_ip = options.delete 'externalIp'
-          else
-             external_ip = true
+            access_config['natIP'] = options.delete 'externalIp'
           end
 
           networkInterfaces = []
           if ! network.nil?
             networkInterface = { 'network' => @api_url + @project + "/global/networks/#{network}" }
-            if external_ip
-              networkInterface['accessConfigs'] = [{'type' => 'ONE_TO_ONE_NAT', 'name' => 'External NAT', 'natIP' => external_ip}]
-            end
+            networkInterface['accessConfigs'] = [access_config]
             networkInterfaces <<  networkInterface
           end
 


### PR DESCRIPTION
As described in https://developers.google.com/compute/docs/reference/latest/instances networkInterfaces[].accessConfigs[].natIP
Fixes Fog::Errors::Error: Invalid value for field 'resource.networkInterfaces[0].accessConfigs[0].natIP': 'true'.  Must be an IP address
