### PR TITLE
[aws|elb] support for cross zone load balancing

### DIFF
--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -31,10 +31,12 @@ module Fog
       request :deregister_instances_from_load_balancer
       request :describe_instance_health
       request :describe_load_balancers
+      request :describe_load_balancer_attributes
       request :describe_load_balancer_policies
       request :describe_load_balancer_policy_types
       request :disable_availability_zones_for_load_balancer
       request :enable_availability_zones_for_load_balancer
+      request :modify_load_balancer_attributes
       request :register_instances_with_load_balancer
       request :set_load_balancer_listener_ssl_certificate
       request :set_load_balancer_policies_of_listener

--- a/lib/fog/aws/models/elb/load_balancer.rb
+++ b/lib/fog/aws/models/elb/load_balancer.rb
@@ -35,6 +35,16 @@ module Fog
           super
         end
 
+        def cross_zone_load_balancing?
+          requires :id
+          service.describe_load_balancer_attributes(id).body['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['CrossZoneLoadBalancing']['Enabled']
+        end
+
+        def cross_zone_load_balancing= value
+          requires :id
+          service.modify_load_balancer_attributes(id, 'CrossZoneLoadBalancing' => {'Enabled' => value})
+        end
+
         def register_instances(instances)
           requires :id
           data = service.register_instances_with_load_balancer(instances, id).body['RegisterInstancesWithLoadBalancerResult']

--- a/lib/fog/aws/parsers/elb/describe_load_balancer_attributes.rb
+++ b/lib/fog/aws/parsers/elb/describe_load_balancer_attributes.rb
@@ -1,0 +1,40 @@
+module Fog
+  module Parsers
+    module AWS
+      module ELB
+
+        class DescribeLoadBalancerAttributes < Fog::Parsers::Base
+
+          def reset
+            @response = { 'DescribeLoadBalancerAttributesResult' => { 'LoadBalancerAttributes' => {} }, 'ResponseMetadata' => {} }
+            @stack = []
+          end
+
+          def start_element(name, attrs = [])
+            super
+            case name 
+            when 'CrossZoneLoadBalancing'
+              @cross_zone_load_balancing = {}
+            end
+          end
+
+          def end_element(name)
+            case name
+            when 'Enabled'
+              if @cross_zone_load_balancing
+                @cross_zone_load_balancing['Enabled'] = value == 'true' ? true : false
+              end
+            when 'CrossZoneLoadBalancing'
+              @response['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['CrossZoneLoadBalancing'] = @cross_zone_load_balancing
+              @cross_zone_load_balancing = nil
+            when 'RequestId'
+              @response['ResponseMetadata'][name] = value
+            end
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/elb/create_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer.rb
@@ -121,6 +121,7 @@ module Fog
             },
             'Instances' => [],
             'ListenerDescriptions' => listeners,
+            'LoadBalancerAttributes' => {'CrossZoneLoadBalancing' => {'Enabled' => false}},
             'LoadBalancerName' => lb_name,
             'Policies' => {
               'AppCookieStickinessPolicies' => [],

--- a/lib/fog/aws/requests/elb/describe_load_balancer_attributes.rb
+++ b/lib/fog/aws/requests/elb/describe_load_balancer_attributes.rb
@@ -1,0 +1,54 @@
+module Fog
+  module AWS
+    class ELB
+      class Real
+
+        require 'fog/aws/parsers/elb/describe_load_balancer_attributes'
+
+        # Describe the load balancer attributes
+        # http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_DescribeLoadBalancerAttributes.html
+        # ==== Parameters
+        # * lb_name<~String> - The mnemonic name associated with the LoadBalancer. 
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'ResponseMetadata'<~Hash>:
+        #       * 'RequestId'<~String> - Id of request
+        #     * 'DescribeLoadBalancerAttributesResult'<~Hash>:
+        #       * 'LoadBalancerAttributes'<~Hash>
+        #         * 'CrossZoneLoadBalancing'<~Hash>
+        #           * 'Enabled'<~Boolean> - whether crosszone load balancing is enabled
+        def describe_load_balancer_attributes(lb_name)
+          request({
+            'Action'  => 'DescribeLoadBalancerAttributes',
+            'LoadBalancerName' => lb_name,
+            :parser   => Fog::Parsers::AWS::ELB::DescribeLoadBalancerAttributes.new
+          })
+        end
+
+      end
+
+      class Mock
+        def describe_load_balancer_attributes(lb_name = nil, names = [])
+          raise Fog::AWS::ELB::NotFound unless load_balancer = self.data[:load_balancers][lb_name]
+          attributes = load_balancer['LoadBalancerAttributes']
+
+          response = Excon::Response.new
+          response.status = 200
+
+          response.body = {
+            'ResponseMetadata' => {
+              'RequestId' => Fog::AWS::Mock.request_id
+            },
+            'DescribeLoadBalancerAttributesResult' => {
+              'LoadBalancerAttributes' => attributes
+            }
+          }
+
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/elb/modify_load_balancer_attributes.rb
+++ b/lib/fog/aws/requests/elb/modify_load_balancer_attributes.rb
@@ -1,0 +1,59 @@
+module Fog
+  module AWS
+    class ELB
+      class Real
+
+        require 'fog/aws/parsers/elb/empty'
+
+
+        # Sets attributes of the load balancer
+        #
+        # Currently the only attribute that can be set is whether CrossZoneLoadBalancing
+        # is enabled
+        #
+        # http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_ModifyLoadBalancerAttributes.html
+        # ==== Parameters
+        # * lb_name<~String> - Name of the ELB
+        # * options<~Hash>
+        #   * 'CrossZoneLoadBalancing'<~Hash>:
+        #     * 'Enabled'<~Boolean> whether to enable cross zone load balancing
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'ResponseMetadata'<~Hash>:
+        #       * 'RequestId'<~String> - Id of request
+        def modify_load_balancer_attributes(lb_name, options)
+          attributes = Fog::AWS.serialize_keys 'LoadBalancerAttributes', options
+          request(attributes.merge(
+            'Action'           => 'ModifyLoadBalancerAttributes',
+            'LoadBalancerName' => lb_name,
+            :parser            => Fog::Parsers::AWS::ELB::Empty.new
+          ))
+        end
+
+      end
+
+      class Mock
+        def modify_load_balancer_attributes(lb_name, attributes)
+          raise Fog::AWS::ELB::NotFound unless load_balancer = self.data[:load_balancers][lb_name]
+
+          if attributes['CrossZoneLoadBalancing']
+            load_balancer['LoadBalancerAttributes'].merge! attributes
+          end
+          
+          response = Excon::Response.new
+
+          response.status = 200
+          response.body = {
+            "ResponseMetadata" => {
+              "RequestId" => Fog::AWS::Mock.request_id
+            }
+          }
+
+          response
+        end
+      end
+    end
+  end
+end

--- a/tests/aws/models/elb/model_tests.rb
+++ b/tests/aws/models/elb/model_tests.rb
@@ -193,6 +193,12 @@ Shindo.tests('AWS::ELB | models', ['aws', 'elb']) do
       returns(@availability_zones) { elb.availability_zones.sort }
     end
 
+    tests('cross_zone_load_balancing') do
+      returns(false) {elb.cross_zone_load_balancing?}
+      elb.cross_zone_load_balancing = true
+      returns(true) {elb.cross_zone_load_balancing?}
+    end
+
     tests('default health check') do
       default_health_check = {
         "HealthyThreshold"=>10,

--- a/tests/aws/requests/elb/load_balancer_tests.rb
+++ b/tests/aws/requests/elb/load_balancer_tests.rb
@@ -36,6 +36,12 @@ Shindo.tests('AWS::ELB | load_balancer_tests', ['aws', 'elb']) do
       end
     end
 
+    tests("modify_load_balancer_attributes") do
+      Fog::AWS[:elb].modify_load_balancer_attributes(@load_balancer_id, 'CrossZoneLoadBalancing' => {'Enabled' => true}).body
+      response = Fog::AWS[:elb].describe_load_balancer_attributes(@load_balancer_id).body
+      response['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['CrossZoneLoadBalancing']['Enabled'] == true
+    end
+
     tests("#configure_health_check").formats(AWS::ELB::Formats::CONFIGURE_HEALTH_CHECK) do
       health_check = {
         'Target' => 'HTTP:80/index.html',


### PR DESCRIPTION
Support for cross zone load balancing, as described here: http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/TerminologyandKeyConcepts.html#AZ-Region

I'm a little uncertain about the model side of things - should I be caching the value? It's a slightly odd value in that it feels like an attribute of the load balancer, but as far as I can tell it is only returned by describe_load_balancer_attributes, not by describe_load_balancers
