### PR TITLE
[vcloud_director] fix vms_tests to be pending when run on empty environment

### DIFF
--- a/tests/vcloud_director/models/compute/vms_tests.rb
+++ b/tests/vcloud_director/models/compute/vms_tests.rb
@@ -4,7 +4,8 @@ Shindo.tests("Compute::VcloudDirector | vms", ['vclouddirector', 'all']) do
   pending if Fog.mocking?
   vapp = vapps.detect {|v| v.vms.size >= 1}
 
-  tests("#There is more than one vm").returns(true){ vapp.vms.size >= 1 }
+  # we can't run these tests if there is no vapps with a vm in them
+  pending unless vapp
 
   vms = vapp.vms
   vm = vms.first


### PR DESCRIPTION
If the tests are run on an environment that doesn't have any vms then the test will be pending rather than failing with a nil as the code was doing before
