### PR TITLE
[aws|compute]: Add index for describe_images parameters that use them

### DIFF
--- a/lib/fog/aws/requests/compute/describe_images.rb
+++ b/lib/fog/aws/requests/compute/describe_images.rb
@@ -43,7 +43,7 @@ module Fog
           options = {}
           for key in ['ExecutableBy', 'ImageId', 'Owner']
             if filters.is_a?(Hash) && filters.key?(key)
-              options[key] = filters.delete(key)
+              options.merge!(Fog::AWS.indexed_request_param(key, filters.delete(key)))
             end
           end
           params = Fog::AWS.indexed_filters(filters).merge!(options)


### PR DESCRIPTION
The documentation for the [describe_images call](http://docs.amazonwebservices.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeImages.html) notes that the ExecutableBy, Owner, and ImageId parameters must use an index as a suffix. 
