### PR TITLE
fix Terremark ecloud environments nil reference

### DIFF
--- a/lib/fog/ecloud/models/compute/environments.rb
+++ b/lib/fog/ecloud/models/compute/environments.rb
@@ -15,10 +15,12 @@ module Fog
         def all
           data = []
           service.get_organization(href).body[:Locations][:Location].each do |d|
-            if d[:Environments][:Environment].is_a?(Array)
-              d[:Environments][:Environment].each { |e| data << e }
+            environments = d[:Environments]
+            next unless environments
+            if environments[:Environment].is_a?(Array)
+              environments[:Environment].each { |e| data << e }
             else
-              data << d[:Environments][:Environment]
+              data << environments[:Environment]
             end
           end
           load(data)


### PR DESCRIPTION
This fixes an error I was getting:

> undefined method [] for nil:NilClass
> /Users/sarah/.rvm/gems/ruby-2.0.0-p247/bundler/gems/fog-b7a1f6fc2806/lib/fog/ecloud/models/compute/environments.rb:18:in block in all
