### PR TITLE
Write logger output to stderr to conform to convention

### DIFF
--- a/lib/fog/core/logger.rb
+++ b/lib/fog/core/logger.rb
@@ -2,11 +2,11 @@ module Fog
   class Logger
 
     @channels = {
-      :deprecation  => ::STDOUT,
-      :warning      => ::STDOUT
+      :deprecation  => ::STDERR,
+      :warning      => ::STDERR
     }
 
-    @channels[:debug] = ::STDOUT if ENV['DEBUG']
+    @channels[:debug] = ::STDERR if ENV['DEBUG']
 
     def self.[](channel)
       @channels[channel]


### PR DESCRIPTION
Writing log to stdout causes issues when piping.
