### PR TITLE
AWS AutoScalying/adding spot price to launch configurations

### DIFF
--- a/lib/fog/aws/models/auto_scaling/configuration.rb
+++ b/lib/fog/aws/models/auto_scaling/configuration.rb
@@ -18,6 +18,8 @@ module Fog
         attribute :ramdisk_id,            :aliases => 'RamdiskId'
         attribute :security_groups,       :aliases => 'SecurityGroups'
         attribute :user_data,             :aliases => 'UserData'
+        attribute :spot_price,            :aliases => 'SpotPrice'
+        
 
         def initialize(attributes={})
           #attributes[:availability_zones] ||= %w(us-east-1a us-east-1b us-east-1c us-east-1d)

--- a/lib/fog/aws/parsers/auto_scaling/describe_launch_configurations.rb
+++ b/lib/fog/aws/parsers/auto_scaling/describe_launch_configurations.rb
@@ -68,6 +68,8 @@ module Fog
               @launch_configuration[name] = value
             when 'KernelId', 'RamdiskId', 'UserData'
               @launch_configuration[name] = value
+            when 'SpotPrice'
+              @launch_configuration[name] = value.to_f
 
             when 'BlockDeviceMappings'
               @in_block_device_mappings = false


### PR DESCRIPTION
Hi!

This PR adds the possibility of adding a spot price to a launch configuration. The Price is a float.

Thanks,

Rodrigo
