### PR TITLE
Improve support for VPC Security Groups in RDS

### DIFF
--- a/lib/fog/aws/models/rds/server.rb
+++ b/lib/fog/aws/models/rds/server.rb
@@ -31,7 +31,7 @@ module Fog
         attribute :license_model, :aliases => 'LicenseModel'
         attribute :db_subnet_group_name, :aliases => 'DBSubnetGroupName'
         attribute :publicly_accessible, :aliases => 'PubliclyAccessible'
-        attribute :vpc_security_groups, :aliases => 'VpcSecurityGroups'
+        attribute :vpc_security_groups, :aliases => 'VpcSecurityGroups', :type => :array
 
         attr_accessor :password, :parameter_group_name, :security_group_names, :port
 
@@ -123,7 +123,8 @@ module Fog
             'MultiAZ'                       => multi_az,
             'LicenseModel'                  => license_model,
             'DBSubnetGroupName'             => db_subnet_group_name,
-            'PubliclyAccessible'            => publicly_accessible
+            'PubliclyAccessible'            => publicly_accessible,
+            'VpcSecurityGroups'             => vpc_security_groups,
           }
 
           options.delete_if {|key, value| value.nil?}

--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -168,7 +168,7 @@ module Fog
           @port       = options[:port]        || 443
           @scheme     = options[:scheme]      || 'https'
           @connection = Fog::Connection.new("#{@scheme}://#{@host}:#{@port}#{@path}", @persistent, @connection_options)
-          @version    = options[:version] || '2012-09-17' #'2011-04-01'
+          @version    = options[:version] || '2013-05-15'
         end
 
         def owner_id

--- a/lib/fog/aws/requests/rds/create_db_instance.rb
+++ b/lib/fog/aws/requests/rds/create_db_instance.rb
@@ -26,6 +26,7 @@ module Fog
         # @param PreferredMaintenanceWindow [String] The weekly time range (in UTC) during which system maintenance can occur, which may result in an outage
         # @param DBSubnetGroupName [String] The name, if any, of the VPC subnet for this RDS instance
         # @param PubliclyAcccesible [Boolean] Whether an RDS instance inside of the VPC subnet should have a public-facing endpoint
+        # @param VpcSecurityGroups [Array] A list of VPC Security Groups to authorize on this DB instance
         # 
         # @return [Excon::Response]:
         #   * body [Hash]:
@@ -35,6 +36,10 @@ module Fog
 
           if security_groups = options.delete('DBSecurityGroups')
             options.merge!(Fog::AWS.indexed_param('DBSecurityGroups.member.%d', [*security_groups]))
+          end
+
+          if vpc_security_groups = options.delete('VpcSecurityGroups')
+            options.merge!(Fog::AWS.indexed_param('VpcSecurityGroupIds.member.%d', [*vpc_security_groups]))
           end
 
           request({
@@ -105,7 +110,8 @@ module Fog
 #                 "LatestRestorableTime" => nil,
                  "AvailabilityZone" => options["AvailabilityZone"],
                  "DBSubnetGroupName" => options["DBSubnetGroupName"],
-                 "PubliclyAccessible" => options["PubliclyAccessible"]
+                 "PubliclyAccessible" => options["PubliclyAccessible"],
+                 "VpcSecurityGroups" => options["VpcSecurityGroups"],
              }
 
 


### PR DESCRIPTION
- Ensures create_db_instance passes VPC args onwards
- Bumps API version so that VPC results are returned in describe calls

When merged, should close #2379 
