### PR TITLE
[vsphere|compute] restore default guest_id so setting it is optional

### DIFF
--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -255,7 +255,7 @@ module Fog
             :cpus      => 1,
 #            :corespersocket => 1,
             :memory_mb => 512,
-#            :guest_id  => 'otherGuest',
+            :guest_id  => 'otherGuest',
             :path      => '/'
           }
         end


### PR DESCRIPTION
cc @MarcGrimme, @ekohl

I suspect this wasn't intentional, as it now means the guest_id has to be set: http://projects.theforeman.org/issues/3653
