### PR TITLE
[aws|dns] Don't set mock changes to INSYNC immediately, only after some timeout

### DIFF
--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -180,7 +180,7 @@ module Fog
             if errors.empty?
               change = {
                 :id => change_id,
-                :status => 'INSYNC',
+                :status => 'PENDING',
                 :submitted_at => Time.now.utc.iso8601
               }
               self.data[:changes][change[:id]] = change

--- a/lib/fog/aws/requests/dns/create_hosted_zone.rb
+++ b/lib/fog/aws/requests/dns/create_hosted_zone.rb
@@ -82,7 +82,7 @@ module Fog
             }
             change = {
               :id => Fog::AWS::Mock.change_id,
-              :status => 'INSYNC',
+              :status => 'PENDING',
               :submitted_at => Time.now.utc.iso8601
             }
             self.data[:changes][change[:id]] = change

--- a/lib/fog/aws/requests/dns/get_change.rb
+++ b/lib/fog/aws/requests/dns/get_change.rb
@@ -43,9 +43,11 @@ module Fog
 
           if change
             response.status = 200
+            submitted_at = Time.parse(change[:submitted_at])
             response.body = {
               'Id' => change[:id],
-              'Status' => 'INSYNC', # TODO do some logic here
+              # set as insync after some time
+              'Status' => (submitted_at + (Fog.timeout/4).to_i) < Time.now ? 'INSYNC' : change[:status],
               'SubmittedAt' => change[:submitted_at]
             }
             response


### PR DESCRIPTION
Allows more real testing with mocks
