### PR TITLE
[vSphere] Add request to set VM annotations in vSphere

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -80,6 +80,7 @@ module Fog
       request :list_vm_customvalues
       request :list_customfields
       request :get_vm_first_scsi_controller
+      request :set_vm_customvalue
 
       module Shared
 

--- a/lib/fog/vsphere/requests/compute/set_vm_customvalue.rb
+++ b/lib/fog/vsphere/requests/compute/set_vm_customvalue.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def set_vm_customvalue(vm_id, key, value)
+          vm_ref = get_vm_ref(vm_id)
+          vm_ref.setCustomValue(:key => key, :value => value)
+        end
+
+      end
+      class Mock
+        def set_vm_customvalue(vm_id, key, value)
+          nil
+        end
+      end
+    end
+  end
+end
+

--- a/tests/vsphere/requests/compute/set_vm_customvalue_tests.rb
+++ b/tests/vsphere/requests/compute/set_vm_customvalue_tests.rb
@@ -1,0 +1,21 @@
+Shindo.tests('Fog::Compute[:vsphere] | set_vm_customvalue request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+  instance_uuid = '50137835-88a1-436e-768e-9b2677076e67'
+  custom_key = nil
+  custom_value = nil
+
+  tests('The response should') do
+    response = compute.set_vm_customvalue(instance_uuid, custom_key, custom_value)
+    test('be nil') { response.nil? }
+  end
+
+  tests('The expected options') do
+    raises(ArgumentError, 'raises ArgumentError when instance_uuid option is missing') { compute.set_vm_customvalue }
+    raises(ArgumentError, 'raises ArgumentError when custom_key option is missing') { compute.set_vm_customvalue(instance_uuid) }
+    raises(ArgumentError, 'raises ArgumentError when custom_value option is missing') { compute.set_vm_customvalue(instance_uuid, custom_key) }
+  end
+
+end
+


### PR DESCRIPTION
Allow setting vSphere annotations via a request.

Implements the request part of #1755
Replaces #2136 
