### PR TITLE
Need to list block in the argument list to access the variable

### DIFF
--- a/lib/fog/core/scp.rb
+++ b/lib/fog/core/scp.rb
@@ -78,7 +78,7 @@ module Fog
         end
       end
 
-      def download(remote_path, local_path, download_options = {})
+      def download(remote_path, local_path, download_options = {}, &block)
         begin
           Net::SCP.start(@address, @username, @options) do |scp|
             scp.download!(remote_path, local_path, download_options) do |ch, name, sent, total|


### PR DESCRIPTION
This caused our scp_download call to give us the following error:

`Net::SCP::Error: SCP did not finish successfully (1)`
