### PR TITLE
all? not working in JRuby 1.7.5+. Configure Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ rvm:
   - 2.0.0
   - jruby-18mode
   - jruby-19mode
+  - jruby-head
 
 script: bundle exec rake travis
 
@@ -28,6 +29,14 @@ matrix:
       gemfile: Gemfile
     - rvm: jruby-19mode
       gemfile: Gemfile.1.8.7
+    - rvm: jruby-head
+      gemfile: Gemfile.1.8.7
+
+  # all? tests Failing in 1.7.5+ https://github.com/jruby/jruby/issues/1265
+  allow_failures:
+    - rvm: jruby-18mode
+    - rvm: jruby-19mode
+    - rvm: jruby-head
 
 notifications:
   email: false


### PR DESCRIPTION
That's the reason the travis build is failing on jruby, the override of `each` in Collection stopped working after 1.7.4
https://github.com/jruby/jruby/issues/1265
