### PR TITLE
[dnsimple] remove host from request

### DIFF
--- a/lib/fog/dnsimple/dns.rb
+++ b/lib/fog/dnsimple/dns.rb
@@ -85,7 +85,7 @@ module Fog
                                     "Accept" => "application/json",
                                     "Content-Type" => "application/json" })
 
-          response = @connection.request(params.merge!({:host => @host}))
+          response = @connection.request(params)
 
           unless response.body.empty?
             response.body = Fog::JSON.decode(response.body)


### PR DESCRIPTION
Remove host from request  in `dns/dnsimple` to avoid `excon` warnings:

```
[excon][WARNING] Invalid Excon request keys: :host
/home/selu/.rbenv/versions/2.0.0-p195/lib/ruby/gems/2.0.0/gems/excon-0.28.0/lib/excon/connection.rb:217:in `request'
/home/selu/git/fog/lib/fog/core/connection.rb:57:in `request'
/home/selu/git/fog/lib/fog/core/deprecated/connection.rb:20:in `request'
/home/selu/git/fog/lib/fog/dnsimple/dns.rb:88:in `request'
/home/selu/git/fog/lib/fog/dnsimple/requests/dns/get_domain.rb:27:in `get_domain'
/home/selu/git/fog/lib/fog/dnsimple/models/dns/zones.rb:19:in `get'
```
