### PR TITLE
Disable specific tests that don't pass on jruby 1.7.5+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,10 +32,7 @@ matrix:
     - rvm: jruby-head
       gemfile: Gemfile.1.8.7
 
-  # all? tests Failing in 1.7.5+ https://github.com/jruby/jruby/issues/1265
   allow_failures:
-    - rvm: jruby-18mode
-    - rvm: jruby-19mode
     - rvm: jruby-head
 
 notifications:

--- a/tests/aws/models/storage/file_tests.rb
+++ b/tests/aws/models/storage/file_tests.rb
@@ -44,6 +44,10 @@ Shindo.tests("Storage[:aws] | file", ["aws"]) do
       end
 
       tests('#versions are all for the correct key').returns(true) do
+        # JRuby 1.7.5+ issue causes a SystemStackError: stack level too deep
+        # https://github.com/jruby/jruby/issues/1265
+        pending if RUBY_PLATFORM == "java" and JRUBY_VERSION =~ /1\.7\.[5-8]/
+
         @instance.versions.all? { |v| v.key == @instance.key }
       end
     end

--- a/tests/helpers/collection_helper.rb
+++ b/tests/helpers/collection_helper.rb
@@ -36,11 +36,19 @@ def collection_tests(collection, params = {}, mocks_implemented = true)
     tests('Enumerable') do
       pending if Fog.mocking? && !mocks_implemented
 
-      [
+      methods = [
         'all?', 'any?', 'find',  'detect', 'collect', 'map',
         'find_index', 'flat_map', 'collect_concat', 'group_by',
         'none?', 'one?'
-      ].each do |enum_method|
+      ]
+
+      # JRuby 1.7.5+ issue causes a SystemStackError: stack level too deep
+      # https://github.com/jruby/jruby/issues/1265
+      if RUBY_PLATFORM == "java" and JRUBY_VERSION =~ /1\.7\.[5-8]/
+        methods.delete('all?')
+      end
+
+      methods.each do |enum_method|
         if collection.respond_to?(enum_method)
           tests("##{enum_method}").succeeds do
             block_called = false


### PR DESCRIPTION
Due to https://github.com/jruby/jruby/issues/1265

@geemus Thanks for applying #2429, this is probably a better solution that won't hide other errors on jruby builds
