### PR TITLE
[Brightbox] Clean up Cloud IP mapping code

### DIFF
--- a/lib/fog/brightbox/models/compute/cloud_ip.rb
+++ b/lib/fog/brightbox/models/compute/cloud_ip.rb
@@ -26,13 +26,16 @@ module Fog
         attribute :port_translators
         attribute :name
 
+        # Attempt to map or point the Cloud IP to the destination resource.
+        #
+        # @param [Object] destination
+        #
         def map(destination)
           requires :identity
-          case destination
-          when Fog::Compute::Brightbox::Server
-            final_destination = destination.interfaces.first["id"]
-          when Fog::Compute::Brightbox::LoadBalancer
-            final_destination = destination.id
+          if destination.respond_to?(:mapping_identity)
+            final_destination = destination.mapping_identity
+          elsif destination.respond_to?(:identity)
+            final_destination = destination.identity
           else
             final_destination = destination
           end

--- a/lib/fog/brightbox/models/compute/server.rb
+++ b/lib/fog/brightbox/models/compute/server.rb
@@ -180,6 +180,13 @@ module Fog
           true
         end
 
+        # Replaces the server's identifier with it's interface's identifier for Cloud IP mapping
+        #
+        # @return [String] the identifier to pass to a Cloud IP mapping request
+        def mapping_identity
+          interfaces.first["id"]
+        end
+
       private
         # Hard reboots are fast, avoiding the OS by doing a "power off"
         def hard_reboot

--- a/tests/brightbox/models/compute/server_tests.rb
+++ b/tests/brightbox/models/compute/server_tests.rb
@@ -1,21 +1,19 @@
 Shindo.tests("Fog::Compute[:brightbox] | Server model", ["brightbox"]) do
-
   pending if Fog.mocking?
 
   tests("success") do
-
-    unless Fog.mocking?
-      @server = Brightbox::Compute::TestSupport.get_test_server
-      server_id = @server.id
-    end
+    @server = Brightbox::Compute::TestSupport.get_test_server
+    server_id = @server.id
 
     tests("#dns_name") do
-      pending if Fog.mocking?
       returns("public.#{@server.fqdn}") { @server.dns_name }
     end
 
-    unless Fog.mocking?
-      @server.destroy
+    tests("#mapping_identity") do
+      first_interface_id = @server.interfaces.first["id"]
+      returns(first_interface_id) { @server.mapping_identity }
     end
+
+    @server.destroy
   end
 end


### PR DESCRIPTION
When passing an object that responds to `identity` which is all of our
resources, we can pass the resource's identifier in to the API call to
make it easier to use without maintaining a list of classes.

Server's need to use the interface for the destination so they override
a new `mapping_identity` method which is picked up first.

Anything else (such as a String identifier) is passed directly to the
API request as before.
