### PR TITLE
return NS and SOA records - https://github.com/fog/fog/issues/2419

### DIFF
--- a/lib/fog/aws/models/dns/records.rb
+++ b/lib/fog/aws/models/dns/records.rb
@@ -33,8 +33,6 @@ module Fog
           data['NextRecordIdentifier'] = nil unless data.has_key?('NextRecordIdentifier')
 
           merge_attributes(data.reject {|key, value| !['IsTruncated', 'MaxItems', 'NextRecordName', 'NextRecordType', 'NextRecordIdentifier'].include?(key)})
-          # leave out the default, read only records
-          data = data['ResourceRecordSets'].reject {|record| ['NS', 'SOA'].include?(record['Type'])}
           load(data)
         end
 


### PR DESCRIPTION
This allows us to work with NS subdelegations, as well as the NS and SOA records while the type can't be changed, the values and TTLs can be modified.
