### PR TITLE
Disable coveralls on travis with jruby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -55,6 +55,8 @@ Fog::Rake::TestTask.new
 namespace :test do
   mock = 'true' || ENV['FOG_MOCK']
   task :travis do
+      # jruby coveralls causes an OOM in travis
+      ENV['COVERAGE'] = 'false' if RUBY_PLATFORM == 'java'
       sh("export FOG_MOCK=#{mock} && bundle exec shindont")
   end
   task :vsphere do


### PR DESCRIPTION
Causes an error

Coveralls encountered an exception:
Java::JavaLang::OutOfMemoryError
Java heap space
