### PR TITLE
[AWS|Storage] fixed signed urls when using session tokens

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -140,6 +140,10 @@ module Fog
 
         def signed_url(params, expires)
           expires = expires.to_i
+          if @aws_session_token
+            params[:headers]||= {}
+            params[:headers]['x-amz-security-token'] = @aws_session_token
+          end
           signature = signature(params, expires)
           params = request_params(params)
 


### PR DESCRIPTION
the session token needs to be added to the signature as a header
(as well as being included in the query string)
