### PR TITLE
changed shutdown to reboot in reboot server method

### DIFF
--- a/lib/fog/xenserver/requests/compute/reboot_server.rb
+++ b/lib/fog/xenserver/requests/compute/reboot_server.rb
@@ -5,7 +5,7 @@ module Fog
       class Real
         
         def reboot_server( ref, stype = 'clean' )
-          @connection.request({:parser => Fog::Parsers::XenServer::Base.new, :method => "VM.#{stype}_shutdown"}, ref)
+          @connection.request({:parser => Fog::Parsers::XenServer::Base.new, :method => "VM.#{stype}_reboot"}, ref)
         end
         
       end


### PR DESCRIPTION
The command to reboot a xen sever was wrong. Changed to the correct method.
