### PR TITLE
Added parameter to force request timeout on xen

### DIFF
--- a/lib/fog/xenserver.rb
+++ b/lib/fog/xenserver.rb
@@ -14,9 +14,10 @@ module Fog
     class Connection
       require 'xmlrpc/client'
     
-      def initialize(host)
+      def initialize(host, timeout)
         @factory = XMLRPC::Client.new(host, '/')
         @factory.set_parser(NokogiriStreamParser.new)
+        @factory.timeout = timeout
       end
     
       def authenticate( username, password )

--- a/lib/fog/xenserver/compute.rb
+++ b/lib/fog/xenserver/compute.rb
@@ -86,7 +86,8 @@ module Fog
           @username    = options[:xenserver_username]
           @password    = options[:xenserver_password]
           @defaults    = options[:xenserver_defaults] || {}
-          @connection  = Fog::XenServer::Connection.new(@host)
+          @timeout     = options[:xenserver_timeout] || 30
+          @connection  = Fog::XenServer::Connection.new(@host, @timeout)
           @connection.authenticate(@username, @password)
         end
 


### PR DESCRIPTION
Now, its possible to force request timeout by setting the parameter `xenserver_timeout` when openning connection

closes #1866

``` ruby
@connection = Fog::Compute.new({
    :provider => 'XenServer',
    :xenserver_url => @host,
    :xenserver_username => @user,
    :xenserver_password => @pass,
    :xenserver_timeout => 300
})
```
