### PR TITLE
Ensure vpc created in a test doesn't affect another

### DIFF
--- a/tests/aws/models/elb/model_tests.rb
+++ b/tests/aws/models/elb/model_tests.rb
@@ -330,5 +330,9 @@ Shindo.tests('AWS::ELB | models', ['aws', 'elb']) do
     end
 
     Fog::AWS[:iam].delete_server_certificate(@key_name)
+
+    @igw.destroy
+    @subnet.destroy
+    @vpc.destroy
   end
 end


### PR DESCRIPTION
Running tests in a specific order that sometimes happens causes subnet_groups_tests to fail. Delete the vpc created in another test when done

```
shindo tests/aws/models/elb/model_tests.rb tests/aws/requests/compute/dhcp_options_tests.rb   tests/aws/requests/rds/subnet_groups_tests.rb

...

  AWS::RDS | subnet group requests (aws, rds)
    success
      #create_db_subnet_group + returns "fog-test-537c"
+ returns "A subnet group"
- returns "0c805332-da26-1ccd-6160-ddcc98c977c5"
        expected => "0c805332-da26-1ccd-6160-ddcc98c977c5"
        returned => "e15217ad-4225-3a2c-0848-c50b98c0f15f"
```
