### PR TITLE
[vcloud_director] Manage multiple VM connections

### DIFF
--- a/lib/fog/vcloud_director/README.md
+++ b/lib/fog/vcloud_director/README.md
@@ -426,37 +426,83 @@ vm = vapp.vms.get_by_name("DEVWEB")
 vm.network
 ```
 ```ruby
-    <Fog::Compute::VcloudDirector::VmNetwork
+  <Fog::Compute::VcloudDirector::VmNetwork
     id="vm-2ddeea36-ac71-470f-abc5-c6e3c2aca192",
     type="application/vnd.vmware.vcloud.networkConnectionSection+xml",
     href="https://example.com/api/vApp/vm-2ddeea36-ac71-470f-abc5-c6e3c2aca192/networkConnectionSection/",
     info="Specifies the available VM network connections",
     primary_network_connection_index=0,
-    network="DevOps - Dev Network Connection",
-    needs_customization=true,
-    network_connection_index=0,
-    is_connected=true,
-    mac_address="00:50:56:01:00:ea",
-    ip_address_allocation_mode="POOL"
+    connections=[
+      {:network=>"NET1", :needsCustomization=>false, :network_connection_index=>1, :ip_address=>"10.192.0.102", :is_connected=>true, :mac_address=>"00:50:56:02:02:40", :ip_address_allocation_mode=>"POOL"},
+      {:network=>"NET0", :needsCustomization=>false, :network_connection_index=>0, :ip_address=>"10.192.0.101", :is_connected=>true, :mac_address=>"00:50:56:02:02:3f", :ip_address_allocation_mode=>"POOL"}
+    ]
   >
 ```
 
-### Modify one or more attributes
-
-Network attributes model requires to `save` it after setting the attributes.
+### Add a network to a VM
 
 ```ruby
 org = vcloud.organizations.first
 vdc = org.vdcs.first
 vapp = vdc.vapps.get_by_name("segundo")
 vm = vapp.vms.get_by_name("DEVWEB")
-network = vm.network
-network.is_connected = false
-network.ip_address_allocation_mode = "DHCP"
-network.save
+
+network = org.network.get_by_name('NET2')
+vm.network << network
 ```
-```no-highlight
-true
+```ruby
+  <Fog::Compute::VcloudDirector::VmNetwork
+    id="vm-2ddeea36-ac71-470f-abc5-c6e3c2aca192",
+    type="application/vnd.vmware.vcloud.networkConnectionSection+xml",
+    href="https://example.com/api/vApp/vm-2ddeea36-ac71-470f-abc5-c6e3c2aca192/networkConnectionSection/",
+    info="Specifies the available VM network connections",
+    primary_network_connection_index=0,
+    connections=[
+      {:network=>"NET2", :needsCustomization=>false, :network_connection_index=>2, :ip_address=>"10.192.0.103", :is_connected=>true, :mac_address=>"00:50:56:02:03:f0", :ip_address_allocation_mode=>"POOL"},
+      {:network=>"NET1", :needsCustomization=>false, :network_connection_index=>1, :ip_address=>"10.192.0.102", :is_connected=>true, :mac_address=>"00:50:56:02:02:40", :ip_address_allocation_mode=>"POOL"},
+      {:network=>"NET0", :needsCustomization=>false, :network_connection_index=>0, :ip_address=>"10.192.0.101", :is_connected=>true, :mac_address=>"00:50:56:02:02:3f", :ip_address_allocation_mode=>"POOL"}
+    ]
+  >
+```
+
+### Delete a network to a VM
+
+```ruby
+org = vcloud.organizations.first
+vdc = org.vdcs.first
+vapp = vdc.vapps.get_by_name("segundo")
+vm = vapp.vms.get_by_name("DEVWEB")
+
+vm.network.remove('NET2')
+```
+```ruby
+  <Fog::Compute::VcloudDirector::VmNetwork
+    id="vm-2ddeea36-ac71-470f-abc5-c6e3c2aca192",
+    type="application/vnd.vmware.vcloud.networkConnectionSection+xml",
+    href="https://example.com/api/vApp/vm-2ddeea36-ac71-470f-abc5-c6e3c2aca192/networkConnectionSection/",
+    info="Specifies the available VM network connections",
+    primary_network_connection_index=0,
+    connections=[
+      {:network=>"NET1", :needsCustomization=>false, :network_connection_index=>1, :ip_address=>"10.192.0.102", :is_connected=>true, :mac_address=>"00:50:56:02:02:40", :ip_address_allocation_mode=>"POOL"},
+      {:network=>"NET0", :needsCustomization=>false, :network_connection_index=>0, :ip_address=>"10.192.0.101", :is_connected=>true, :mac_address=>"00:50:56:02:02:3f", :ip_address_allocation_mode=>"POOL"}
+    ]
+  >
+```
+
+### Modify one or more attributes
+
+VM networks can be configured retrieving their attributes and then reassigning them.
+
+```ruby
+org = vcloud.organizations.first
+vdc = org.vdcs.first
+vapp = vdc.vapps.get_by_name("segundo")
+vm = vapp.vms.get_by_name("DEVWEB")
+network = vm.network['NET1']
+
+network[:IsConnected] = false
+network[:IpAllocationMode] = "DHCP"
+vm.network['NET1'] = network
 ```
 
 ## VM Disk

--- a/lib/fog/vcloud_director/generators/compute/vm_network.rb
+++ b/lib/fog/vcloud_director/generators/compute/vm_network.rb
@@ -49,36 +49,12 @@ module Fog
             output
           end
 
-          def network
-            @attrs[:network]
+          def connections
+            @attrs[:connections]
           end
 
-          def network=(new_network_name)
-            @attrs[:network] = new_network_name
-          end
-
-          def ip_address
-            @attrs[:ip_address]
-          end
-
-          def ip_address=(new_ip_address)
-            @attrs[:ip_address] = new_ip_address
-          end
-
-          def is_connected
-            @attrs[:is_connected]
-          end
-
-          def is_connected=(new_is_connected)
-            @attrs[:is_connected] = new_is_connected
-          end
-
-          def ip_address_allocation_mode
-            @attrs[:ip_address_allocation_mode]
-          end
-
-          def ip_address_allocation_mode=(new_ip_address_allocation_mode)
-            @attrs[:ip_address_allocation_mode] = new_ip_address_allocation_mode
+          def connections=(new_connections)
+            @attrs[:connections] = new_connections
           end
 
           private
@@ -92,19 +68,25 @@ module Fog
           end
 
           def body(opts={})
-            <<-END
+            connections = <<-END
               <ovf:Info>#{opts[:info]}</ovf:Info>
               <PrimaryNetworkConnectionIndex>#{opts[:primary_network_connection_index]}</PrimaryNetworkConnectionIndex>
-              <NetworkConnection
-                network="#{opts[:network]}"
-                needsCustomization="#{opts[:needs_customization]}">
-                <NetworkConnectionIndex>#{opts[:network_connection_index]}</NetworkConnectionIndex>
-                <IpAddress>#{opts[:ip_address]}</IpAddress>
-                <IsConnected>#{opts[:is_connected]}</IsConnected>
-                <MACAddress>#{opts[:mac_address]}</MACAddress>
-                <IpAddressAllocationMode>#{opts[:ip_address_allocation_mode]}</IpAddressAllocationMode>
-              </NetworkConnection>
             END
+
+            opts[:connections].each do |connection|
+              connections << <<-END
+                <NetworkConnection
+                  network="#{connection[:network]}"
+                  needsCustomization="#{connection[:needs_customization]}">
+                  <NetworkConnectionIndex>#{connection[:network_connection_index]}</NetworkConnectionIndex>
+                  <IpAddress>#{connection[:ip_address]}</IpAddress>
+                  <IsConnected>#{connection[:is_connected]}</IsConnected>
+                  <MACAddress>#{connection[:mac_address]}</MACAddress>
+                  <IpAddressAllocationMode>#{connection[:ip_address_allocation_mode]}</IpAddressAllocationMode>
+                </NetworkConnection>
+              END
+            end
+            connections
           end
 
           def tail

--- a/lib/fog/vcloud_director/models/compute/vm_network.rb
+++ b/lib/fog/vcloud_director/models/compute/vm_network.rb
@@ -12,18 +12,47 @@ module Fog
         attribute :href
         attribute :info
         attribute :primary_network_connection_index
-        attribute :network
-        attribute :needs_customization
-        attribute :network_connection_index
-        attribute :is_connected
-        attribute :mac_address
-        attribute :ip_address_allocation_mode
+        attribute :connections
+
+        def <<(new_connection)
+          self.primary_network_connection_index = 0 if connections.empty?
+          if new_connection.is_a?(Fog::Compute::VcloudDirector::Network)
+            connections << convert_to_connection(new_connection)
+          else
+            connections << new_connection
+          end
+          save
+        end
+
+        def [](connection_name)
+          connections.select do |connection|
+            connection[:network] == connection_name
+          end.first
+        end
+
+        def []=(connection_name, attributes)
+          connections.delete(self[connection_name])
+          connections << attributes
+          save
+        end
+
+        def remove(connection_name)
+          connections.delete(self[connection_name])
+          save
+        end
 
         def save
           response = service.put_network_connection_system_section_vapp(id, attributes)
           service.process_task(response.body)
         end
 
+        private
+        def convert_to_connection(network)
+          connection = {}
+          connection[:network] = network.name
+          connection[:network_connection_index] = connections.count
+          connection
+        end
       end
     end
   end

--- a/lib/fog/vcloud_director/parsers/compute/vm_network.rb
+++ b/lib/fog/vcloud_director/parsers/compute/vm_network.rb
@@ -3,69 +3,55 @@ module Fog
     module Compute
       module VcloudDirector
         #
-        #{:xmlns=>"http://www.vmware.com/vcloud/v1.5",
-        # :xmlns_xsi=>"http://www.w3.org/2001/XMLSchema-instance",
-        # :name=>"DevOps - Dev Network Connection",
-        # :id=>"urn:vcloud:network:d5f47bbf-de27-4cf5-aaaa-56772f2ccd17",
-        # :type=>"application/vnd.vmware.vcloud.orgNetwork+xml",
-        # :href=>
-        #  "https://example.com/api/network/d5f47bbf-de27-4cf5-aaaa-56772f2ccd17",
-        # :xsi_schemaLocation=>
-        #  "http://www.vmware.com/vcloud/v1.5 http://10.194.1.65/api/v1.5/schema/master.xsd",
-        # :Link=>
-        #  [{:rel=>"up",
-        #    :type=>"application/vnd.vmware.vcloud.org+xml",
-        #    :name=>"DevOps",
-        #    :href=>
-        #     "https://example.com/api/org/c6a4c623-c158-41cf-a87a-dbc1637ad55a"},
-        #   {:rel=>"down",
-        #    :type=>"application/vnd.vmware.vcloud.metadata+xml",
-        #    :href=>
-        #     "https://example.com/api/network/d5f47bbf-de27-4cf5-aaaa-56772f2ccd17/metadata"}],
-        # :Description=>"",
-        # :Configuration=>
-        #  {:IpScope=>
-        #    {:IsInherited=>"true",
-        #     :Gateway=>"10.192.0.1",
-        #     :Netmask=>"255.255.252.0",
-        #     :Dns1=>"10.192.0.11",
-        #     :Dns2=>"10.192.0.12",
-        #     :DnsSuffix=>"dev.ad.mdsol.com",
-        #     :IpRanges=>
-        #      {:IpRange=>
-        #        {:StartAddress=>"10.192.0.100", :EndAddress=>"10.192.3.254"}}},
-        #   :FenceMode=>"bridged",
-        #   :RetainNetInfoAcrossDeployments=>"false"}}
-        #
         #<?xml version="1.0" encoding="UTF-8"?>
-        #<OrgNetwork xmlns="http://www.vmware.com/vcloud/v1.5" name="DevOps - Dev Network Connection" id="urn:vcloud:network:d5f47bbf-de27-4cf5-aaaa-56772f2ccd17" type="application/vnd.vmware.vcloud.orgNetwork+xml" href="https://example.com/api/network/d5f47bbf-de27-4cf5-aaaa-56772f2ccd17" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.194.1.65/api/v1.5/schema/master.xsd">
-        #    <Link rel="up" type="application/vnd.vmware.vcloud.org+xml" name="DevOps" href="https://example.com/api/org/c6a4c623-c158-41cf-a87a-dbc1637ad55a"/>
-        #    <Link rel="down" type="application/vnd.vmware.vcloud.metadata+xml" href="https://example.com/api/network/d5f47bbf-de27-4cf5-aaaa-56772f2ccd17/metadata"/>
-        #    <Description/>
-        #    <Configuration>
-        #        <IpScope>
-        #            <IsInherited>true</IsInherited>
-        #            <Gateway>10.192.0.1</Gateway>
-        #            <Netmask>255.255.252.0</Netmask>
-        #            <Dns1>10.192.0.11</Dns1>
-        #            <Dns2>10.192.0.12</Dns2>
-        #            <DnsSuffix>dev.ad.mdsol.com</DnsSuffix>
-        #            <IpRanges>
-        #                <IpRange>
-        #                    <StartAddress>10.192.0.100</StartAddress>
-        #                    <EndAddress>10.192.3.254</EndAddress>
-        #                </IpRange>
-        #            </IpRanges>
-        #        </IpScope>
-        #        <FenceMode>bridged</FenceMode>
-        #        <RetainNetInfoAcrossDeployments>false</RetainNetInfoAcrossDeployments>
-        #    </Configuration>
-        #</OrgNetwork>
+        #<NetworkConnectionSection xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" href="https://example.com/api/vApp/vm-7b2c35c2-18a6-44b6-ba59-35f2c7e1644e/networkConnectionSection/" ovf:required="false" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://schemas.dmtf.org/ovf/envelope/1 http://schemas.dmtf.org/ovf/envelope/1/dsp8023_1.1.0.xsd http://www.vmware.com/vcloud/v1.5 http://csicloud.csi.it/api/v1.5/schema/master.xsd">
+        #    <ovf:Info>Specifies the available VM network connections</ovf:Info>
+        #    <PrimaryNetworkConnectionIndex>0</PrimaryNetworkConnectionIndex>
+        #    <NetworkConnection network="NET1" needsCustomization="false">
+        #        <NetworkConnectionIndex>1</NetworkConnectionIndex>
+        #        <IpAddress>10.192.0.102</IpAddress>
+        #        <IsConnected>true</IsConnected>
+        #        <MACAddress>00:50:56:02:02:40</MACAddress>
+        #        <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+        #    </NetworkConnection>
+        #    <NetworkConnection network="NET0" needsCustomization="false">
+        #        <NetworkConnectionIndex>0</NetworkConnectionIndex>
+        #        <IpAddress>10.192.0.101</IpAddress>
+        #        <IsConnected>true</IsConnected>
+        #        <MACAddress>00:50:56:02:02:3f</MACAddress>
+        #        <IpAddressAllocationMode>POOL</IpAddressAllocationMode>
+        #    </NetworkConnection>
+        #    <Link rel="edit" type="application/vnd.vmware.vcloud.networkConnectionSection+xml" href="https://example.com/api/vApp/vm-7b2c35c2-18a6-44b6-ba59-35f2c7e1644e/networkConnectionSection/"/>
+        #</NetworkConnectionSection>
+        #
+        #{:type=>"application/vnd.vmware.vcloud.networkConnectionSection+xml",
+        # :href=>
+        #  "https://example.com/api/vApp/vm-7b2c35c2-18a6-44b6-ba59-35f2c7e1644e/networkConnectionSection/",
+        # :id=>"vm-7b2c35c2-18a6-44b6-ba59-35f2c7e1644e",
+        # :info=>"Specifies the available VM network connections",
+        # :primary_network_connection_index=>0,
+        # :connections=>
+        #  [{:network=>"NET1",
+        #    :needsCustomization=>false,
+        #    :network_connection_index=>1,
+        #    :ip_address=>"10.192.0.102",
+        #    :is_connected=>true,
+        #    :mac_address=>"00:50:56:02:02:40",
+        #    :ip_address_allocation_mode=>"POOL"},
+        #   {:network=>"NET0",
+        #    :needsCustomization=>false,
+        #    :network_connection_index=>0,
+        #    :ip_address=>"10.192.0.101",
+        #    :is_connected=>true,
+        #    :mac_address=>"00:50:56:02:02:3f",
+        #    :ip_address_allocation_mode=>"POOL"}]
+        # }
         #
         class VmNetwork < VcloudDirectorParser
 
           def reset
-            @response = { }
+            @response = { :connections => [] }
+            @network_connection = {}
           end
 
           def start_element(name, attributes)
@@ -77,9 +63,8 @@ module Fog
               @response[:href] = network_connection_section[:href]
               @response[:id] = @response[:href].split('/')[-2]
             when 'NetworkConnection'
-              network_connection = extract_attributes(attributes)
-              @response[:network] = network_connection[:network]
-              @response[:needs_customization] = ( network_connection[:needsCustomization] == "true" )
+              @network_connection = extract_attributes(attributes)
+              @network_connection[:needsCustomization] = ( @network_connection[:needsCustomization] == "true" )
             end
           end
 
@@ -90,18 +75,20 @@ module Fog
             when 'PrimaryNetworkConnectionIndex'
               @response[:primary_network_connection_index] = value.to_i
             when 'NetworkConnectionIndex'
-              @response[:network_connection_index] = value.to_i
+              @network_connection[:network_connection_index] = value.to_i
             when 'IpAddress'
-              @response[:ip_address] = value
+              @network_connection[:ip_address] = value
             when 'IsConnected'
-              @response[:is_connected] = (value == "true")
+              @network_connection[:is_connected] = (value == "true")
             when 'MACAddress'
-              @response[:mac_address] = value
+              @network_connection[:mac_address] = value
             when 'IpAddressAllocationMode'
-              @response[:ip_address_allocation_mode] = value
+              @network_connection[:ip_address_allocation_mode] = value
+            when 'NetworkConnection'
+              @response[:connections] << @network_connection
+              @network_connection = {}
             end
           end
-
         end
       end
     end

--- a/lib/fog/vcloud_director/requests/compute/put_network_connection_system_section_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_network_connection_system_section_vapp.rb
@@ -61,12 +61,16 @@ module Fog
           }
           option = options.delete(:primary_network_connection_index)
           options[:PrimaryNetworkConnectionIndex] ||= option unless option.nil?
-          unless options.key?(:NetworkConnection)
-            deprecated.each do |from, to|
-              if options.key?(from)
-                options[:NetworkConnection] ||= [{}]
-                options[:NetworkConnection].first[to] = options.delete(from)
+          if !options.key?(:NetworkConnection) && options.key?(:connections)
+            connections = options[:connections]
+            options[:NetworkConnection] = []
+            connections.each do |connection|
+              deprecated.each do |from, to|
+                if connection.key?(from)
+                  connection[to] = connection.delete(from)
+                end
               end
+              options[:NetworkConnection] << connection
             end
           end
 
@@ -95,11 +99,11 @@ module Fog
                     if nic.key?(:IpAddress)
                       IpAddress nic[:IpAddress]
                     end
-                    IsConnected nic[:IsConnected]
+                    IsConnected nic[:IsConnected] || 'true'
                     if nic.key?(:MACAddress)
                       MACAddress nic[:MACAddress]
                     end
-                    IpAddressAllocationMode nic[:IpAddressAllocationMode]
+                    IpAddressAllocationMode nic[:IpAddressAllocationMode] || 'POOL'
                   }
                 end
               end

--- a/tests/vcloud_director/models/compute/vms_tests.rb
+++ b/tests/vcloud_director/models/compute/vms_tests.rb
@@ -70,12 +70,17 @@ Shindo.tests("Compute::VcloudDirector | vms", ['vclouddirector', 'all']) do
     tests("#type").returns("application/vnd.vmware.vcloud.networkConnectionSection+xml"){ network.type }
     tests("#info").returns(String){ network.info.class }
     tests("#primary_network_connection_index").returns(Fixnum){ network.primary_network_connection_index.class }
-    tests("#network").returns(String){ network.network.class }
-    tests("#network_connection_index").returns(Fixnum){ network.network_connection_index.class }
-    tests("#mac_address").returns(String){ network.mac_address.class }
-    tests("#ip_address_allocation_mode").returns(String){ network.ip_address_allocation_mode.class }
-    tests("#needs_customization").returns(true){ boolean? network.needs_customization }
-    tests("#is_connected").returns(true){ boolean? network.is_connected }
+    tests("#connections").returns(Array){ network.connections.class }
+    unless network.connections.empty?
+      connection = network.connections.first
+      tests("#connections.first").returns(Hash){ connection.class }
+      tests("#connections.first contains network").returns(true) { boolean? connection.has_key?('network')}
+      tests("#connections.first contains network_connection_index").returns(true) { boolean? connection.has_key?('network_connection_index')}
+      tests("#connections.first contains mac_address").returns(true) { boolean? connection.has_key?('mac_address')}
+      tests("#connections.first contains ip_address_allocation_mode").returns(true) { boolean? connection.has_key?('ip_address_allocation_mode')}
+      tests("#connections.first contains needs_customization").returns(true) { boolean? connection.has_key?('needs_customization')}
+      tests("#connections.first contains is_connected").returns(true) { boolean? connection.has_key?('is_connected')}
+    end
   end
 
   tests("Compute::VcloudDirector | vm | tags") do


### PR DESCRIPTION
VMs can have multiple connections, but vm.network retrieved only the first one.

Details about a real response and a correct output are documented in `lib/fog/vcloud_director/parsers/compute/vm_network.rb`

This patch adds options to add, remove and edit VM networks.
