### PR TITLE
Modified AWS S3 mock, so that it errors when creating an existing bucket

### DIFF
--- a/lib/fog/aws/requests/storage/put_bucket.rb
+++ b/lib/fog/aws/requests/storage/put_bucket.rb
@@ -62,8 +62,11 @@ DATA
           else
             bucket['LocationConstraint'] = nil
           end
-          unless self.data[:buckets][bucket_name]
+          if !self.data[:buckets][bucket_name] || self.region == 'us-east-1'
             self.data[:buckets][bucket_name] = bucket
+          else
+            response.status = 409
+            raise(Excon::Errors.status_error({:expects => 200}, response))
           end
           response
         end

--- a/tests/aws/requests/storage/bucket_tests.rb
+++ b/tests/aws/requests/storage/bucket_tests.rb
@@ -48,6 +48,14 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
       @aws_owner = Fog::Storage[:aws].get_bucket_acl(Fog::Storage[:aws].directories.first.key).body['Owner']
     end
 
+    tests('put existing bucket - default region') do
+      Fog::Storage[:aws].put_bucket(@aws_bucket_name)
+
+      tests("#put_bucket('#{@aws_bucket_name}') existing").succeeds do
+        Fog::Storage[:aws].put_bucket(@aws_bucket_name)
+      end
+    end    
+
     tests("#get_service").formats(@service_format) do
       Fog::Storage[:aws].get_service.body
     end
@@ -337,6 +345,15 @@ Shindo.tests('Fog::Storage[:aws] | bucket requests', ["aws"]) do
       Fog::Storage[:aws].put_bucket_website('fognonbucket', 'index.html')
     end
 
+    tests('put existing bucket - non-default region') do
+      storage_eu_endpoint = Fog::Storage[:aws]
+      storage_eu_endpoint.region = "eu-west-1"
+      storage_eu_endpoint.put_bucket(@aws_bucket_name)
+
+      tests("#put_bucket('#{@aws_bucket_name}') existing").raises(Excon::Errors::Conflict) do
+        storage_eu_endpoint.put_bucket(@aws_bucket_name)
+      end
+    end
   end
 
   # don't keep the bucket around


### PR DESCRIPTION
AWS S3 returns a BucketAlreadyOwnedByYou error when attempting to create a bucket that already exists, in a region other than the default. This commit modifies the mocked object to reflect this. See the issue in more detail here: https://github.com/fog/fog/issues/2446
