### PR TITLE
[vcloud_director] Fix Guest admin password settings

### DIFF
--- a/lib/fog/vcloud_director/README.md
+++ b/lib/fog/vcloud_director/README.md
@@ -387,6 +387,7 @@ vm.customization
     join_domain_enabled=false,
     use_org_settings=false,
     admin_password_auto=false,
+    admin_password='',
     admin_password_enabled=false,
     reset_password_required=false,
     virtual_machine_id="2ddeea36-ac71-470f-abc5-c6e3c2aca192",

--- a/lib/fog/vcloud_director/models/compute/vm_customization.rb
+++ b/lib/fog/vcloud_director/models/compute/vm_customization.rb
@@ -15,6 +15,7 @@ module Fog
         attribute :join_domain_enabled
         attribute :use_org_settings
         attribute :admin_password_auto
+        attribute :admin_password
         attribute :admin_password_enabled
         attribute :reset_password_required
         attribute :virtual_machine_id

--- a/lib/fog/vcloud_director/parsers/compute/vm_customization.rb
+++ b/lib/fog/vcloud_director/parsers/compute/vm_customization.rb
@@ -32,6 +32,8 @@ module Fog
               @response[:join_domain_enabled] = (value == "true")
             when 'UseOrgSettings'
               @response[:use_org_settings] = (value == "true")
+            when 'AdminPassword'
+              @response[:admin_password] = value
             when 'AdminPasswordEnabled'
               @response[:admin_password_enabled] = (value == "true")
             when 'AdminPasswordAuto'

--- a/lib/fog/vcloud_director/requests/compute/put_guest_customization_section_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_guest_customization_section_vapp.rb
@@ -62,6 +62,7 @@ module Fog
             :change_sid => :ChangeSid,
             :join_domain_enabled => :JoinDomainEnabled,
             :use_org_settings => :UseOrgSettings,
+            :admin_password => :AdminPassword,
             :admin_password_enabled => :AdminPasswordEnabled,
             :admin_password_auto => :AdminPasswordAuto,
             :reset_password_required => :ResetPasswordRequired,


### PR DESCRIPTION
These patches fix some missing points in the way guest customizations are handled.
Commit messages should be quite clear, but to sum up:
- setting "admin password auto" was retrieved but not shown
- "admin password" handling was partially implemented (i.e., was not retrieved and never set in .save)

With these fixes is now possible to do with fog the same operations allowed by the VMWare console.
