### PR TITLE
Allow custom Mock.not_implemented message

### DIFF
--- a/lib/fog/core/mock.rb
+++ b/lib/fog/core/mock.rb
@@ -30,8 +30,8 @@ module Fog
       @delay = new_delay
     end
 
-    def self.not_implemented
-      raise Fog::Errors::MockNotImplemented.new("Contributions welcome!")
+    def self.not_implemented(message = 'Contributions welcome!')
+      raise Fog::Errors::MockNotImplemented.new(message)
     end
 
     def self.random_ip(opts = {:version => :v4})


### PR DESCRIPTION
For Mock mode in vcloud_director/.../get_execute_query.rb (and others), we can only feasibly mock certain operations. This pull req will allow us to communicate to the user what is not implemented and why.
