### PR TITLE
Use OpenSSL::Digest instead of deprecated OpenSSL::Digest::Digest

### DIFF
--- a/lib/fog/cloudstack.rb
+++ b/lib/fog/cloudstack.rb
@@ -8,7 +8,7 @@ module Fog
 
     service(:compute, 'cloudstack/compute','Compute')
 
-    @@digest  = OpenSSL::Digest::Digest.new('sha1')
+    @@digest  = OpenSSL::Digest.new('sha1')
 
     def self.escape(string)
       string = CGI::escape(string)

--- a/lib/fog/core/hmac.rb
+++ b/lib/fog/core/hmac.rb
@@ -18,7 +18,7 @@ module Fog
     private
 
     def setup_sha1
-      @digest = OpenSSL::Digest::Digest.new('sha1')
+      @digest = OpenSSL::Digest.new('sha1')
       @signer = lambda do |data|
         OpenSSL::HMAC.digest(@digest, @key, data)
       end
@@ -26,7 +26,7 @@ module Fog
 
     def setup_sha256
       begin
-        @digest = OpenSSL::Digest::Digest.new('sha256')
+        @digest = OpenSSL::Digest.new('sha256')
         @signer = lambda do |data|
           OpenSSL::HMAC.digest(@digest, @key, data)
         end


### PR DESCRIPTION
OpenSSL::Digest::Digest has been discouraged to use from very ancient era such as Ruby 1.8 https://github.com/ruby/ruby/blob/ruby_1_8_7/ext/openssl/lib/openssl/digest.rb#L51
and finally was deprecated recently. https://github.com/ruby/ruby/pull/446
