### PR TITLE
Add exponential backoff to Google Compute Engine's backoff_if_unfound.

### DIFF
--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -99,12 +99,14 @@ module Fog
 
         def backoff_if_unfound(&block)
           retries_remaining = 10
+          sleep_time = 0.1
           begin
             result = block.call
           rescue Exception => msg
             if msg.to_s.include? 'was not found' and retries_remaining > 0
               retries_remaining -= 1
-              sleep 0.1
+              sleep sleep_time
+              sleep_time *= 1.6
               retry
             else
               raise msg


### PR DESCRIPTION
Even with backoff_if_unfound, I frequently see Fog::Errors::NotFound when creating a GCE instance.  For me, this happens most often in europe-west1-b, about 50% of the time; I see the same thing, but less often, in us-central zones.  Adding an exponential backoff factor to backoff_if_unfound resolved this issue for me.

I arrived at a backoff factor of 1.6 by finding the minimum value at which the existing value of up to 10 retries would reliably succeed for me.  It's unclear to me if the Fog::Errors::NotFound errors occur because of (my lack of) physical proximity - I'm on the west coast of the United States - or if there's something unique about europe-west1-b.  As such, the backoff factor and retry count may need adjustment for other users.
