### PR TITLE
Update S3 ACL whitelist

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -33,13 +33,13 @@ module Fog
 
         # Set file's access control list (ACL).
         # 
-        #     valid acls: private, public-read, public-read-write, authenticated-read
+        #     valid acls: private, public-read, public-read-write, authenticated-read, bucket-owner-read, bucket-owner-full-control
         # 
         # @param [String] new_acl one of valid options
         # @return [String] @acl
         # 
         def acl=(new_acl)
-          valid_acls = ['private', 'public-read', 'public-read-write', 'authenticated-read']
+          valid_acls = ['private', 'public-read', 'public-read-write', 'authenticated-read', 'bucket-owner-read', 'bucket-owner-full-control']
           unless valid_acls.include?(new_acl)
             raise ArgumentError.new("acl must be one of [#{valid_acls.join(', ')}]")
           end


### PR DESCRIPTION
@geemus

Updates the S3 ACL whitelist to include all values documented here: http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html
