### PR TITLE
[vcloud_director] post_create_org_vdc_network

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -202,6 +202,7 @@ module Fog
       request :post_configure_edge_gateway_services
       request :post_consolidate_vm_vapp
       request :post_consolidate_vm_vapp_template
+      request :post_create_org_vdc_network
       request :post_deploy_vapp
       request :post_detach_disk
       request :post_disable_nested_hv

--- a/lib/fog/vcloud_director/generators/compute/org_vdc_network.rb
+++ b/lib/fog/vcloud_director/generators/compute/org_vdc_network.rb
@@ -1,0 +1,89 @@
+module Fog
+  module Generators
+    module Compute
+      module VcloudDirector
+
+        # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/types/OrgVdcNetworkType.html
+        class OrgVdcNetwork
+          attr_reader :options
+
+          def initialize(options={})
+            @options = options
+          end
+
+          def generate_xml
+
+            body = Nokogiri::XML::Builder.new do
+              attrs = {
+                :xmlns => 'http://www.vmware.com/vcloud/v1.5',
+                :name  => options[:name]
+              }
+              OrgVdcNetwork(attrs) {
+                Description options[:Description] if options.key?(:Description)
+                if configuration = options[:Configuration]
+                  Configuration {
+                    if ip_scopes = configuration[:IpScopes]
+                      IpScopes {
+                        if ip_scope = ip_scopes[:IpScope]
+                          IpScope {
+                            IsInherited  ip_scope[:IsInherited] if ip_scope.key?(:IsInherited)
+                            Gateway      ip_scope[:Gateway]     if ip_scope.key?(:Gateway)
+                            Netmask      ip_scope[:Netmask]     if ip_scope.key?(:Netmask)
+                            Dns1         ip_scope[:Dns1]        if ip_scope.key?(:Dns1)
+                            Dns2         ip_scope[:Dns2]        if ip_scope.key?(:Dns2)
+                            DnsSuffix    ip_scope[:DnsSuffix]   if ip_scope.key?(:DnsSuffix)
+                            IsEnabled    ip_scope[:IsEnabled]   if ip_scope.key?(:IsEnabled)
+                            if ip_ranges = ip_scope[:IpRanges]
+                              IpRanges {
+                                ip_ranges.each do |ip_range|
+                                  IpRange {
+                                    StartAddress ip_range[:StartAddress]
+                                    EndAddress   ip_range[:EndAddress]
+                                  }
+                                end
+                              }
+                            end
+                          }
+                        end
+                      }
+                    end
+                    FenceMode    configuration[:FenceMode]
+                    if router_info = configuration[:RouterInfo]
+                      RouterInfoType {
+                        ExternalIp router_info[:ExternalIp]
+                      }
+                    end
+                  }
+                end # Configuration
+
+                if edgegw = options[:EdgeGateway] and configuration[:FenceMode] != 'isolated'
+                  EdgeGateway(edgegw)
+                elsif options[:Configuration] && options[:Configuration][:FenceMode] == 'isolated'
+                  # isolated networks can specify ServiceConfig
+                  if sc = options[:ServiceConfig]
+                    ServiceConfig {
+                      if dhcp = sc[:GatewayDhcpService]
+                        IsEnabled dhcp[:IsEnabled] if dhcp[:IsEnabled]
+                        if pool = dhcp[:Pool]
+                          IsEnabled        pool[:IsEnabled]
+                          DefaultLeaseTime pool[:DefaultLeaseTime]
+                          MaxLeaseTime     pool[:MaxLeaseTime]
+                          LowIpAddress     pool[:LowIpAddress]
+                          HighIpAddress    pool[:HighIpAddress]
+                        end
+                      end
+                    }
+                  end
+                end
+
+                IsShared       options[:IsShared] if options.key?(:IsShared)
+
+              }
+            end.to_xml
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vcloud_director/requests/compute/post_create_org_vdc_network.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_create_org_vdc_network.rb
@@ -1,0 +1,83 @@
+module Fog
+  module Compute
+    class VcloudDirector
+      class Real
+
+        require 'fog/vcloud_director/generators/compute/org_vdc_network'
+
+        # Create an Org vDC network.
+        #
+        # This operation is asynchronous and returns a task that you can
+        # monitor to track the progress of the request.
+        #
+        # Produce media type(s):
+        # application/vnd.vmware.vcloud.orgVdcNetwork+xml
+        # Output type:
+        # OrgVdcNetworkType
+        #
+        # @param [String] vdc_id Object identifier of the vDC
+        # @param [String] name   The name of the entity.
+        # @param [Hash] options
+        # @option options [String] :Description Optional description.
+        # @option options [Hash] :Configuration Network configuration.
+        # @option options [Hash] :EdgeGateway  EdgeGateway that connects this 
+        #   Org vDC network. Applicable only for routed networks.
+        # @option options [Hash] :ServiceConfig Specifies the service 
+        #   configuration for an isolated Org vDC networks.
+        # @option options [Boolean] :IsShared True if this network is shared 
+        #   to multiple Org vDCs.
+        #   * :Configuration<~Hash>: NetworkConfigurationType
+        #     * :IpScopes<~Hash>:
+        #       * :IpScope<~Hash>:
+        #         * :IsInherited<~Boolean>: ?
+        #         * :Gateway<~String>: IP address of gw
+        #         * :Netmask<~String>: Subnet mask of network
+        #         * :Dns1<~String>: Primary DNS server.
+        #         * :Dns2<~String>: Secondary DNS server.
+        #         * :DnsSuffix<~String>: DNS suffix.
+        #         * :IsEnabled<~String>: Indicates if subnet is enabled or not.
+        #                                Default value is True.
+        #         * :IpRanges<~Array>: IP ranges used for static pool allocation
+        #                             in the network. Array of Hashes of:
+        #                               * :StartAddress - start IP in range
+        #                               * :EndAddress - end IP in range
+        #   * :EdgeGateway<~Hash>: EdgeGateway that connects this Org vDC
+        #                          network. Applicable only for routed networks.
+        #   * :ServiceConfig<~Hash>: Specifies the service configuration for an
+        #                            isolated network
+        #
+        # @return [Excon::Response]
+        #   * body<~Hash>:
+        #
+        # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/operations/POST-CreateOrgVdcNetwork.html
+        # @since vCloud API version 5.1
+        def post_create_org_vdc_network(vdc_id, name, options={})
+
+          body = Fog::Generators::Compute::VcloudDirector::OrgVdcNetwork.new(options.merge(:name => name)).generate_xml
+
+          request(
+            :body    => body,
+            :expects => 201,
+            :headers => {'Content-Type' => 'application/vnd.vmware.vcloud.orgVdcNetwork+xml'},
+            :method  => 'POST',
+            :parser  => Fog::ToHashDocument.new,
+            :path    => "admin/vdc/#{vdc_id}/networks"
+          )
+
+        end
+      end
+
+      class Mock
+
+        def post_create_org_vdc_network(vdc_id, name, options={})
+          unless data[:vdcs][vdc_id]
+            raise Fog::Compute::VcloudDirector::Forbidden.new(
+              "No access to entity \"(com.vmware.vcloud.entity.vdc:#{vdc_id})\"."
+            )
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/tests/vcloud_director/requests/compute/network_tests.rb
+++ b/tests/vcloud_director/requests/compute/network_tests.rb
@@ -21,6 +21,10 @@ Shindo.tests('Compute::VcloudDirector | network requests', ['vclouddirector']) d
   @service = Fog::Compute::VcloudDirector.new
   @org = VcloudDirector::Compute::Helper.current_org(@service)
 
+  tests('Create network in non-existent vDC').raises(Fog::Compute::VcloudDirector::Forbidden) do
+    @service.post_create_org_vdc_network('00000000-0000-0000-0000-000000000000', 'bob')
+  end
+
   tests('#get_network').data_matches_schema(GET_NETWORK_FORMAT) do
     link = @org[:Link].detect do |l|
       l[:rel] == 'down' && l[:type] == 'application/vnd.vmware.vcloud.orgNetwork+xml'


### PR DESCRIPTION
Allows creation of an OrgVdcNetwork in isolated or natRouted mode.

I have Mock code available for this too, but wanted to keep this pull req simple and add that later.
