### PR TITLE
[Rackspace | Compute] 1.8.7 fix plus better passwd -l handling

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -532,6 +532,8 @@ module Fog
           ]
           commands.compact
 
+          @password = nil if password_lock
+
           Fog::SSH.new(public_ip_address, username, credentials).run(commands)
         rescue Errno::ECONNREFUSED
           sleep(1)


### PR DESCRIPTION
Broke 1.8.7 test suite (parsing error) with my previous PR. This fixes that.

Also, new servers that have been passwd -l'd now return nil for their password.
