### PR TITLE
[aws|elb] Mimic real behavior in create_load_balancer mock

### DIFF
--- a/lib/fog/aws/requests/elb/create_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer.rb
@@ -27,7 +27,7 @@ module Fog
           params = Fog::AWS.indexed_param('AvailabilityZones.member', [*availability_zones])
           params.merge!(Fog::AWS.indexed_param('Subnets.member.%d', options[:subnet_ids]))
           params.merge!(Fog::AWS.serialize_keys('Scheme', options[:scheme]))
-          params.merge!(Fog::AWS.indexed_param('SecurityGroups.member.%d', options[:security_groups])) 
+          params.merge!(Fog::AWS.indexed_param('SecurityGroups.member.%d', options[:security_groups]))
 
           listener_protocol = []
           listener_lb_port = []
@@ -74,7 +74,8 @@ module Fog
 
           dns_name = Fog::AWS::ELB::Mock.dns_name(lb_name, @region)
 
-          region = availability_zones ? availability_zones.first.gsub(/[a-z]$/, '') : "us-east-1"
+          availability_zones = [*availability_zones]
+          region = availability_zones.empty? ? "us-east-1" : availability_zones.first.gsub(/[a-z]$/, '')
           supported_platforms = Fog::Compute::AWS::Mock.data[region][@aws_access_key_id][:account_attributes].detect { |h| h["attributeName"] == "supported-platforms" }["values"]
           security_group = if supported_platforms.include?("EC2")
                              Fog::Compute::AWS::Mock.data[region][@aws_access_key_id][:security_groups]['amazon-elb-sg']


### PR DESCRIPTION
This PR mimics the behavior like the real one, as a availability_zones can be nil on real class and not in mock class.

At this moment, I ran into an error in `availability_zones.first.gsub(/[a-z]$/, '')` in a Chef elb cookbook that assumes availability_zones as an optional argument, so its default value it's `nil`.

I tried to write a spec to catch this behaviour, but it was difficult to me.
