### PR TITLE
[google|compute] Rescue from Fog::Errors::NotFound instead of Excon

### DIFF
--- a/lib/fog/google/models/compute/flavors.rb
+++ b/lib/fog/google/models/compute/flavors.rb
@@ -18,7 +18,7 @@ module Fog
         def get(identity, zone_name = nil)
           data = connection.get_machine_type(identity, zone_name).body
           new(data)
-        rescue Excon::Errors::NotFound
+        rescue Fog::Errors::NotFound
           nil
         end
 

--- a/lib/fog/google/models/compute/servers.rb
+++ b/lib/fog/google/models/compute/servers.rb
@@ -40,7 +40,7 @@ module Fog
           else
             new(response.body)
           end
-        rescue Excon::Errors::NotFound
+        rescue Fog::Errors::NotFound
           nil
         end
 

--- a/lib/fog/google/models/compute/zones.rb
+++ b/lib/fog/google/models/compute/zones.rb
@@ -17,7 +17,7 @@ module Fog
         def get(identity)
           data = service.get_zone(identity).body
           new(data)
-        rescue Excon::Errors::NotFound
+        rescue Fog::Errors::NotFound
           nil
         end
 


### PR DESCRIPTION
Use Fog::Errors::NotFound as raised by build_excon_response
