### PR TITLE
ignore more Ruby version manager files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 *.gem
 *.rbc
 *.sw?
+.rbenv
 .rvmrc
+.ruby-gemset
 .ruby-version
 .bundle
 .DS_Store


### PR DESCRIPTION
Both rbenv and rvm now generate some files that have no bearing on
the project, and leave the local repo in a dirty state.
