### PR TITLE
drop dependency on deprecated ruby-hmac gem, fixes #2034

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -49,7 +49,6 @@ Gem::Specification.new do |s|
   s.add_dependency('net-scp', '~>1.1')
   s.add_dependency('net-ssh', '>=2.1.3')
   s.add_dependency('nokogiri', '~>1.5')
-  s.add_dependency('ruby-hmac')
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development

--- a/lib/fog/core/hmac.rb
+++ b/lib/fog/core/hmac.rb
@@ -25,22 +25,9 @@ module Fog
     end
 
     def setup_sha256
-      begin
-        @digest = OpenSSL::Digest.new('sha256')
-        @signer = lambda do |data|
-          OpenSSL::HMAC.digest(@digest, @key, data)
-        end
-      rescue RuntimeError => error
-        unless error.message == 'Unsupported digest algorithm (sha256).'
-          raise error
-        else
-          require 'hmac-sha2'
-          @hmac = ::HMAC::SHA256.new(@key)
-          @signer = lambda do |data|
-            @hmac.update(data)
-            @hmac.digest
-          end
-        end
+      @digest = OpenSSL::Digest.new('sha256')
+      @signer = lambda do |data|
+        OpenSSL::HMAC.digest(@digest, @key, data)
       end
     end
 


### PR DESCRIPTION
Ruby 1.8 compiled against OpenSSL 0.9.8 supports SHA256 for some time now.
Ref: https://github.com/ruby/ruby/blob/ruby_1_8_7/ChangeLog#L12025-L12029
