### PR TITLE
[AWS|EC2] request_spot_instances.rb requires that date parameters be iso...

### DIFF
--- a/lib/fog/aws/requests/compute/request_spot_instances.rb
+++ b/lib/fog/aws/requests/compute/request_spot_instances.rb
@@ -75,6 +75,14 @@ module Fog
             options['LaunchSpecification.UserData'] = Base64.encode64(options['LaunchSpecification.UserData'])
           end
 
+          if options['ValidFrom'] && options['ValidFrom'].is_a?(Time)
+            options['ValidFrom'] =  options['ValidFrom'].iso8601
+          end
+
+          if options['ValidUntil'] && options['ValidUntil'].is_a?(Time)
+            options['ValidUntil'] =  options['ValidUntil'].iso8601
+          end
+
           request({
             'Action'                            => 'RequestSpotInstances',
             'LaunchSpecification.ImageId'       => image_id,


### PR DESCRIPTION
Fix for #2465 

`Time#iso8601` does appear to be in 1.8.7 after all http://ruby-doc.org/stdlib-1.8.7/libdoc/time/rdoc/Time.html#method-i-iso8601
