### PR TITLE
[storm_on_demand] don't pass host to request

### DIFF
--- a/lib/fog/storm_on_demand/shared.rb
+++ b/lib/fog/storm_on_demand/shared.rb
@@ -29,7 +29,6 @@ module Fog
               'Content-Type' => 'application/json',
               'Authorization' => 'Basic ' << Base64.encode64("#{@storm_on_demand_username}:#{@storm_on_demand_password}").chomp
             }.merge!(params[:headers] || {}),
-            :host     => @host,
             :path     => "#{@path}/#{API_VERSION}#{params[:path]}",
             :expects  => 200,
             :method   => :post


### PR DESCRIPTION
same issue as https://github.com/fog/fog/issues/2248

This gets rid of the warning "[excon][WARNING] Invalid Excon request keys: :host"  when making requests with storm_on_demand
