### PR TITLE
Fix subnet mocking, related to #2510

### DIFF
--- a/lib/fog/aws/models/compute/subnet.rb
+++ b/lib/fog/aws/models/compute/subnet.rb
@@ -42,14 +42,14 @@ module Fog
         #
         # == Returns:
         #
-        # requestId and a subnetSet object
+        # requestId and a subnet object
         #
 
         def save
           requires :vpc_id, :cidr_block
           options = {}
           options['AvailabilityZone'] = availability_zone if availability_zone
-          data = service.create_subnet(vpc_id, cidr_block, options).body['subnetSet'].first
+          data = service.create_subnet(vpc_id, cidr_block, options).body['subnet']
           new_attributes = data.reject {|key,value| key == 'requestId'}
           merge_attributes(new_attributes)
           true

--- a/lib/fog/aws/parsers/compute/create_subnet.rb
+++ b/lib/fog/aws/parsers/compute/create_subnet.rb
@@ -7,7 +7,7 @@ module Fog
 
           def reset
             @subnet = { 'tagSet' => {} }
-            @response = { 'subnetSet' => [] }
+            @response = { 'subnet' => [] }
             @tag = {}
           end
 
@@ -35,8 +35,7 @@ module Fog
               when 'subnetId', 'state', 'vpcId', 'cidrBlock', 'availableIpAddressCount', 'availabilityZone'
                 @subnet[name] = value
               when 'subnet'
-                @response['subnetSet'] << @subnet
-                @subnet = { 'tagSet' => {} }
+                @response['subnet'] = @subnet
               when 'requestId'
                 @response[name] = value
               end

--- a/lib/fog/aws/requests/compute/create_subnet.rb
+++ b/lib/fog/aws/requests/compute/create_subnet.rb
@@ -46,30 +46,29 @@ module Fog
           Excon::Response.new.tap do |response|
             if cidrBlock  && vpcId
               response.status = 200
-              self.data[:subnets].push({
-                'subnetId'                 => Fog::AWS::Mock.request_id,
+              data = {
+                'subnetId'                 => Fog::AWS::Mock.subnet_id,
                 'state'                    => 'pending',
                 'vpcId'                    => vpcId,
                 'cidrBlock'                => cidrBlock,
                 'availableIpAddressCount'  => "255",
                 'availabilityZone'         => av_zone,
                 'tagSet'                   => {}
-              })
+              }
 
               # Add this subnet to the default network ACL
               accid = Fog::AWS::Mock.network_acl_association_id
               default_nacl = self.data[:network_acls].values.detect { |nacl| nacl['vpcId'] == vpcId && nacl['default'] }
-              if default_nacl
-                default_nacl['associationSet'] << {
-                  'networkAclAssociationId' => accid,
-                  'networkAclId'            => default_nacl['networkAclId'],
-                  'subnetId'                => self.data[:subnets].last['subnetId'],
-                }
-              end
+              default_nacl['associationSet'] << {
+                'networkAclAssociationId' => accid,
+                'networkAclId'            => default_nacl['networkAclId'],
+                'subnetId'                => data['subnetId'],
+              }
 
+              self.data[:subnets].push(data)
               response.body = {
                 'requestId'    => Fog::AWS::Mock.request_id,
-                'subnetSet'    => self.data[:subnets]
+                'subnet'       => data,
               }
             else
               response.status = 400

--- a/lib/fog/aws/requests/compute/create_vpc.rb
+++ b/lib/fog/aws/requests/compute/create_vpc.rb
@@ -43,7 +43,7 @@ module Fog
           Excon::Response.new.tap do |response|
             if cidrBlock 
               response.status = 200
-              vpc_id = Fog::AWS::Mock.request_id
+              vpc_id = Fog::AWS::Mock.vpc_id
               self.data[:vpcs].push({
                 'vpcId'         => vpc_id,
                 'state'         => 'pending',

--- a/tests/aws/models/compute/network_acl_tests.rb
+++ b/tests/aws/models/compute/network_acl_tests.rb
@@ -1,5 +1,4 @@
 Shindo.tests("Fog::Compute[:aws] | network_acl", ['aws']) do
-  Fog::Compute::AWS::Mock.reset if Fog.mocking?
   @vpc    = Fog::Compute[:aws].vpcs.create('cidr_block' => '10.0.10.0/24')
   @subnet = Fog::Compute[:aws].subnets.create('vpc_id' => @vpc.id, 'cidr_block' => '10.0.10.16/28')
 
@@ -106,5 +105,5 @@ Shindo.tests("Fog::Compute[:aws] | network_acl", ['aws']) do
   end
 
   @subnet.destroy
-  @vpc.destroy
+  @vpc.destroy 
 end

--- a/tests/aws/requests/compute/route_tests.rb
+++ b/tests/aws/requests/compute/route_tests.rb
@@ -43,7 +43,7 @@ Shindo.tests('Fog::Compute[:aws] | route table requests', ['aws']) do
   if !Fog.mocking?
     vpc.wait_for { state.eql? "available" }
   end
-  @subnet_id = Fog::Compute[:aws].create_subnet(vpc.id, '10.0.10.0/24').body['subnetSet'].first['subnetId']
+  @subnet_id = Fog::Compute[:aws].create_subnet(vpc.id, '10.0.10.0/24').body['subnet']['subnetId']
   @network_interface = Fog::Compute[:aws].create_network_interface(@subnet_id, {"PrivateIpAddress" => "10.0.10.23"}).body
   @internet_gateway_id = Fog::Compute[:aws].create_internet_gateway.body['internetGatewaySet'].first['internetGatewayId']
   @network_interface_id = @network_interface['networkInterface']['networkInterfaceId']

--- a/tests/aws/requests/compute/subnet_tests.rb
+++ b/tests/aws/requests/compute/subnet_tests.rb
@@ -1,15 +1,22 @@
 Shindo.tests('Fog::Compute[:aws] | subnet requests', ['aws']) do
 
+  @subnet_format = {
+    'subnetId'                 => String,
+    'state'                    => String,
+    'vpcId'                    => String,
+    'cidrBlock'                => String,
+    'availableIpAddressCount'  => String,
+    'availabilityZone'         => String,
+    'tagSet'                   => Hash,
+  }
+
+  @single_subnet_format = {
+    'subnet'    => @subnet_format,
+    'requestId' => String,
+  }
+
   @subnets_format = {
-    'subnetSet' => [{
-      'subnetId'                 => String,
-      'state'                    => String,
-      'vpcId'                    => String,
-      'cidrBlock'                => String,
-      'availableIpAddressCount'  => String,
-      'availabilityZone'         => String,
-      'tagSet'                   => Hash,
-    }],
+    'subnetSet' => [@subnet_format],
     'requestId' => String
   }
 
@@ -18,9 +25,9 @@ Shindo.tests('Fog::Compute[:aws] | subnet requests', ['aws']) do
     @vpc_id = @vpc.id
     @subnet_id = nil
 
-    tests('#create_subnet').formats(@subnets_format) do
+    tests('#create_subnet').formats(@single_subnet_format) do
       data = Fog::Compute[:aws].create_subnet(@vpc_id, '10.0.10.16/28').body
-      @subnet_id = data['subnetSet'].first['subnetId']
+      @subnet_id = data['subnet']['subnetId']
       data
     end
 

--- a/tests/aws/requests/rds/subnet_groups_tests.rb
+++ b/tests/aws/requests/rds/subnet_groups_tests.rb
@@ -13,7 +13,7 @@ Shindo.tests('AWS::RDS | subnet group requests', ['aws', 'rds']) do
   subnet_range = 8
   @subnets = (1..4).map do
     subnet = Fog::Compute[:aws].create_subnet(@vpc.id, "10.#{vpc_range}.#{subnet_range}.0/24",
-      'AvailabilityZone' => subnet_az).body['subnetSet'].first
+      'AvailabilityZone' => subnet_az).body['subnet']
     subnet_az = subnet_az.succ
     subnet_range *= 2
     subnet


### PR DESCRIPTION
Subnet mocking would return a set of all the current subnets on create (incorrectly) and thus when .first is called, the wrong subnet would be return for all but the first subnet created.

As a result, this left `self.data` in a bad state, and would cause the Network ACL tests to fail randomly depending on test ordering.

Thanks to @fcheung for finding a test that would cause this failure consistently. 

@reemus

Related to #2510
