### PR TITLE
[aws] mock block device mapping on run_instances

### DIFF
--- a/lib/fog/aws/parsers/compute/run_instances.rb
+++ b/lib/fog/aws/parsers/compute/run_instances.rb
@@ -75,7 +75,7 @@ module Fog
             when 'ebsOptimized'
               @instance['ebsOptimized'] = (value == 'true')
             when 'associatePublicIP'
-              @instance['associatePublicIP'] = (value == 'true')              
+              @instance['associatePublicIP'] = (value == 'true')
             end
           end
 


### PR DESCRIPTION
set up volumes based on block device mappings provided in the `#run_instances` call
