### PR TITLE
Dynect Record and Zone put requests are idempotent.

### DIFF
--- a/lib/fog/dynect/requests/dns/put_record.rb
+++ b/lib/fog/dynect/requests/dns/put_record.rb
@@ -19,10 +19,11 @@ module Fog
           path = ["#{type}Record", zone, fqdn].join('/')
           path += "/#{options.delete('record_id')}" if options['record_id']
           request(
-            :body     => Fog::JSON.encode(options),
-            :expects  => 200,
-            :method   => :put,
-            :path     => path
+            :body       => Fog::JSON.encode(options),
+            :expects    => 200,
+            :idempotent => true,
+            :method     => :put,
+            :path       => path
           )
         end
       end

--- a/lib/fog/dynect/requests/dns/put_zone.rb
+++ b/lib/fog/dynect/requests/dns/put_zone.rb
@@ -14,10 +14,11 @@ module Fog
 
         def put_zone(zone, options = {})
           request(
-            :body     => Fog::JSON.encode(options),
-            :expects  => 200,
-            :method   => :put,
-            :path     => 'Zone/' << zone
+            :body       => Fog::JSON.encode(options),
+            :expects    => 200,
+            :idempotent => true,
+            :method     => :put,
+            :path       => 'Zone/' << zone
           )
         end
       end


### PR DESCRIPTION
Dynect's Record and Zone put requests are idempotent and should be flagged as such to allow excon to retry the requests.
