### PR TITLE
[vcloud_director] making xml generators reusable

### DIFF
--- a/lib/fog/vcloud_director/generators/compute/cpu_item.rb
+++ b/lib/fog/vcloud_director/generators/compute/cpu_item.rb
@@ -1,0 +1,35 @@
+module Fog
+  module Generators
+    module Compute
+      module VcloudDirector
+        class CpuItem
+
+          def generate_xml id, cpu, end_point
+            Nokogiri::XML::Builder.new do |xml|
+              xml.Item(
+                  'xmlns' => "http://www.vmware.com/vcloud/v1.5",
+                  'xmlns:rasd' => "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
+                  'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
+                  'xmlns:ns12' => "http://www.vmware.com/vcloud/v1.5",
+                  'ns12:href' => "#{end_point}vApp/#{id}/virtualHardwareSection/cpu",
+                  'ns12:type' => "application/vnd.vmware.vcloud.rasdItem+xml",
+                  'xsi:schemaLocation' => "http://www.vmware.com/vcloud/v1.5 http://10.194.1.65/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd"
+              ) {
+                xml.send('rasd:AllocationUnits', 'hertz * 10^6')
+                xml.send('rasd:Description', 'Number of Virtual CPUs')
+                xml.send('rasd:ElementName', "#{cpu} virtual CPU(s)")
+                xml.send('rasd:InstanceID', 4)
+                xml.send('rasd:Reservation', 0)
+                xml.send('rasd:ResourceType', 3)
+                xml.send('rasd:VirtualQuantity', cpu)
+                xml.send('rasd:Weight', 0)
+                xml.Link(:rel => "edit", :type => "application/vnd.vmware.vcloud.rasdItem+xml", :href => "#{end_point}vApp/#{id}/virtualHardwareSection/cpu")
+              }
+            end.to_xml
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vcloud_director/generators/compute/memory_item.rb
+++ b/lib/fog/vcloud_director/generators/compute/memory_item.rb
@@ -1,0 +1,34 @@
+module Fog
+  module Generators
+    module Compute
+      module VcloudDirector
+        class MemoryItem
+
+          def generate_xml id, memory, end_point
+            Nokogiri::XML::Builder.new do |xml|
+              xml.Item(
+                  'xmlns' => "http://www.vmware.com/vcloud/v1.5",
+                  'xmlns:rasd' => "http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData",
+                  'xmlns:xsi' => "http://www.w3.org/2001/XMLSchema-instance",
+                  'xmlns:ns12' => "http://www.vmware.com/vcloud/v1.5",
+                  'ns12:href' => "#{end_point}vApp/#{id}/virtualHardwareSection/memory",
+                  'ns12:type' => "application/vnd.vmware.vcloud.rasdItem+xml",
+                  'xsi:schemaLocation' => "http://www.vmware.com/vcloud/v1.5 http://10.194.1.65/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd"
+              ) {
+                xml.send('rasd:AllocationUnits', 'byte * 2^20')
+                xml.send('rasd:Description', 'Memory Size')
+                xml.send('rasd:ElementName', "#{memory} MB of memory")
+                xml.send('rasd:InstanceID', 5)
+                xml.send('rasd:Reservation', 0)
+                xml.send('rasd:ResourceType', 4)
+                xml.send('rasd:VirtualQuantity', memory)
+                xml.send('rasd:Weight', 0)
+                xml.Link(:rel => "edit", :type => "application/vnd.vmware.vcloud.rasdItem+xml", :href => "#{end_point}vApp/#{id}/virtualHardwareSection/memory")
+              }
+            end.to_xml
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vcloud_director/requests/compute/put_cpu.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_cpu.rb
@@ -5,6 +5,8 @@ module Fog
         extend Fog::Deprecation
         deprecate :put_vm_cpu, :put_cpu
 
+        require 'fog/vcloud_director/generators/compute/cpu_item'
+
         # Update the RASD item that specifies CPU properties of a VM.
         #
         # This operation is asynchronous and returns a task that you can
@@ -18,19 +20,7 @@ module Fog
         # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/operations/PUT-Cpu.html
         # @since vCloud API version 0.9
         def put_cpu(id, num_cpus)
-          data = <<EOF
-          <Item xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns12="http://www.vmware.com/vcloud/v1.5" ns12:href="#{end_point}vApp/#{id}/virtualHardwareSection/cpu" ns12:type="application/vnd.vmware.vcloud.rasdItem+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.194.1.65/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <rasd:AllocationUnits>hertz * 10^6</rasd:AllocationUnits>
-            <rasd:Description>Number of Virtual CPUs</rasd:Description>
-            <rasd:ElementName>#{num_cpus} virtual CPU(s)</rasd:ElementName>
-            <rasd:InstanceID>4</rasd:InstanceID>
-            <rasd:Reservation>0</rasd:Reservation>
-            <rasd:ResourceType>3</rasd:ResourceType>
-            <rasd:VirtualQuantity>#{num_cpus}</rasd:VirtualQuantity>
-            <rasd:Weight>0</rasd:Weight>
-            <Link rel="edit" type="application/vnd.vmware.vcloud.rasdItem+xml" href="#{end_point}vApp/#{id}/virtualHardwareSection/cpu"/>
-          </Item>
-EOF
+          data = Fog::Generators::Compute::VcloudDirector::CpuItem.new.generate_xml(id, num_cpus, end_point)
 
           request(
             :body    => data,

--- a/lib/fog/vcloud_director/requests/compute/put_memory.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_memory.rb
@@ -5,6 +5,8 @@ module Fog
         extend Fog::Deprecation
         deprecate :put_vm_memory, :put_memory
 
+        require 'fog/vcloud_director/generators/compute/memory_item'
+
         # Update the RASD item that specifies memory properties of a VM.
         #
         # This operation is asynchronous and returns a task that you can
@@ -18,19 +20,7 @@ module Fog
         # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/operations/PUT-Memory.html
         # @since vCloud API version 0.9
         def put_memory(id, memory)
-          data = <<EOF
-          <Item xmlns="http://www.vmware.com/vcloud/v1.5" xmlns:rasd="http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns12="http://www.vmware.com/vcloud/v1.5" ns12:href="#{end_point}vApp/#{id}/virtualHardwareSection/memory" ns12:type="application/vnd.vmware.vcloud.rasdItem+xml" xsi:schemaLocation="http://www.vmware.com/vcloud/v1.5 http://10.194.1.65/api/v1.5/schema/master.xsd http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2.22.0/CIM_ResourceAllocationSettingData.xsd">
-            <rasd:AllocationUnits>byte * 2^20</rasd:AllocationUnits>
-            <rasd:Description>Memory Size</rasd:Description>
-            <rasd:ElementName>#{memory} MB of memory</rasd:ElementName>
-            <rasd:InstanceID>5</rasd:InstanceID>
-            <rasd:Reservation>0</rasd:Reservation>
-            <rasd:ResourceType>4</rasd:ResourceType>
-            <rasd:VirtualQuantity>#{memory}</rasd:VirtualQuantity>
-            <rasd:Weight>0</rasd:Weight>
-            <Link rel="edit" type="application/vnd.vmware.vcloud.rasdItem+xml" href="#{end_point}vApp/#{id}/virtualHardwareSection/memory"/>
-          </Item>
-EOF
+          data = Fog::Generators::Compute::VcloudDirector::MemoryItem.new.generate_xml(id, memory, end_point)
 
           request(
             :body    => data,


### PR DESCRIPTION
pulled out the xml generators from request classes. This would be helpful as virtualHardwareSection is repeated in multiple api requests.
