### PR TITLE
[cloudstack] Add models and requests to support CloudStack advanced network API

### DIFF
--- a/lib/fog/cloudstack/compute.rb
+++ b/lib/fog/cloudstack/compute.rb
@@ -39,10 +39,27 @@ module Fog
       collection :snapshots
       model :zone
       collection :zones
+      model :nat
+      collection :nats
+      model :vlan
+      collection :vlans
+      model :ipaddress
+      collection :ipaddresses
+      model :network
+      collection :networks
+      model :disk_offering
+      collection :disk_offerings
+      model :key_pair
+      collection :key_pairs
+      model :ostype
+      collection :ostypes
+      model :firewall
+      collection :firewalls
 
       request :acquire_ip_address
       request :assign_to_load_balancer_rule
       request :assign_virtual_machine
+      request :associate_ip_address
       request :attach_volume
       request :authorize_security_group_egress
       request :authorize_security_group_ingress
@@ -57,9 +74,13 @@ module Fog
       request :create_ssh_key_pair
       request :create_snapshot
       request :create_snapshot_policy
+      request :create_tags
+      request :create_template
       request :create_user
+      request :create_vlan_ip_range
       request :create_volume
       request :create_zone
+      request :copy_template
       request :delete_account
       request :delete_disk_offering
       request :delete_domain
@@ -69,13 +90,18 @@ module Fog
       request :delete_ssh_key_pair
       request :delete_snapshot
       request :delete_snapshot_policies
+      request :delete_tags 
       request :delete_template
       request :delete_user
+      request :delete_vlan_ip_range
       request :delete_volume
       request :detach_volume
       request :deploy_virtual_machine
       request :destroy_virtual_machine
+      request :disassociate_ip_address
+      request :disable_static_nat
       request :disable_user
+      request :enable_static_nat
       request :enable_user
       request :generate_usage_records
       request :get_vm_password
@@ -114,10 +140,12 @@ module Fog
       request :list_snapshot_policies
       request :list_ssh_key_pairs
       request :list_storage_pools
+      request :list_tags
       request :list_templates
       request :list_usage_records
       request :list_users
       request :list_virtual_machines
+      request :list_vlan_ip_ranges
       request :list_volumes
       request :list_zones
       request :migrate_virtual_machine
@@ -490,6 +518,49 @@ module Fog
                   "oscategoryid" => "56f67279-e082-45c3-a01c-d290d6cd4ce2",
                   "description"  => "Asianux 3(64-bit)"
                   }
+              },
+              :vlan_ip_ranges => {
+                'id'                => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'account'           => 'accountname',
+                'description'       => 'ip ranges',
+                'domain'            => domain,
+                'domainid'          => domain_id,
+                'forvirtualnetwork' => true,
+                'networkid'         => network_id,
+                'physicalnetworkid' => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'poid'              => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'podname'           => 'podname',
+                'project'           => 'projectname',
+                'projectid'         => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'zoneid'            => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'gateway'           => '172.17.13.254',
+                'netmask'           => '255.255.255.0',
+                'startip'           => '172.17.13.232',
+                'endip'             => '172.17.13.232',
+                'vlan'              => 102
+              },
+              :ip_info => {
+                'id'                        => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'account'                   => 'accountname',
+                'description'               => 'ip ranges',
+                'domain'                    => domain,
+                'domainid'                  => domain_id,
+                'associatednetworkid'       => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'forvirtualnetwork'         => true,
+                'ipaddress'                 => '172.17.13.232',
+                'issourcenat'               => true,
+                'isstaticnat'               => true,
+                'jobid'                     =>  '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'jobstatus'                 => 'pending',
+                'networkid'                 => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'state'                     => 'Allocated',
+                'virtualmachinedisplayname' => 'vm',
+                'virtualmachineid'          => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'virtualmachinename'        => '745c3088-4d8d-4198-8b1b-053658596cb9',
+                'vlanid'                    => 102,
+                'vlanname'                  => 'vlan',
+                'zoneid'                    => 100,
+                'zonename'                  => 'zone'
               }
             }
           end

--- a/lib/fog/cloudstack/models/compute/disk_offering.rb
+++ b/lib/fog/cloudstack/models/compute/disk_offering.rb
@@ -12,7 +12,8 @@ module Fog
         attribute :name
         attribute :storage_type,    :aliases => 'storagetype'
         attribute :tags
-
+        attribute :display_text,    :aliases => 'displaytext'
+        attribute :disk_size,       :aliases => 'disksize'
 
         def save
           requires :display_text, :name

--- a/lib/fog/cloudstack/models/compute/firewall.rb
+++ b/lib/fog/cloudstack/models/compute/firewall.rb
@@ -1,0 +1,35 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Firewall < Fog::Model
+        identity  :id,                                            :aliases => 'id'
+        attribute :ip_address_id,                                 :aliases => 'ipaddressid'
+        attribute :protocol,                                      :aliases => 'protocol'
+        attribute :cidr_list,                                     :aliases => 'cidrlist'
+        attribute :start_port,                                    :aliases => 'startport'
+        attribute :end_port,                                      :aliases => 'endport'
+        attribute :icmp_type,                                     :aliases => 'icmptype'
+        attribute :icmp_code,                                     :aliases => 'icmpcode'
+
+        def create_firewall_rule
+          requires :ip_address_id, :protocol, :cidr_list
+
+          options = {
+              'ipaddressid'        => ip_address_id,
+              'protocol'           => protocol,
+              'cidrlist'           => cidr_list,
+          }
+          options.merge!('startport' => start_port) if start_port
+          options.merge!('endport' => end_port) if end_port
+          options.merge!('icmptype' => icmp_type) if icmp_type
+          options.merge!('icmpcode' => icmp_code) if icmp_code
+
+          data = service.create_firewall_rule(options)
+          service.jobs.new(data["createfirewallruleresponse"])
+        end
+
+
+      end # Firewall
+    end # Cloudstack
+  end # Compute
+end # Fog

--- a/lib/fog/cloudstack/models/compute/firewalls.rb
+++ b/lib/fog/cloudstack/models/compute/firewalls.rb
@@ -1,0 +1,17 @@
+require 'fog/core/collection'
+require 'fog/cloudstack/models/compute/firewall'
+
+module Fog
+  module Compute
+    class Cloudstack
+
+      class Firewalls < Fog::Collection
+
+        model Fog::Compute::Cloudstack::Firewall
+
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/image.rb
+++ b/lib/fog/cloudstack/models/compute/image.rb
@@ -37,7 +37,7 @@ module Fog
         attribute :template_type,      :aliases => 'templatetype'
         attribute :zone_id,            :aliases => 'zoneid'
         attribute :zone_name,          :aliases => 'zonename'
-
+        attribute :format
         attr_accessor :bits, :requires_hvm, :snapshot_id, :url, :virtual_machine_id, :volume_id
 
         def save
@@ -65,6 +65,29 @@ module Fog
           requires :id
           service.delete_template('id' => self.id)
           true
+        end
+
+        def register
+          requires :display_text, :format, :hypervisor, :name, :os_type_id, :url, :zone_id
+          options = {
+              'displaytext' => display_text,
+              'format' => format,
+              'hypervisor' => hypervisor,
+              'name' => name,
+              'ostypeid' => os_type_id,
+              'url' => url,
+              'zoneid' => zone_id,
+              'isfeatured' => is_featured
+          }
+          data = service.register_template(options)
+          merge_attributes(data['registertemplateresponse']['template'][0])
+        end
+
+        def copy(to_zone)
+          requires :id
+          requires :zone_id
+          data = service.copy_template('id' => id, 'sourcezoneid' => zone_id, 'destzoneid' => to_zone.id)
+          service.jobs.new(data["copytemplateresponse"])
         end
       end # Server
     end # Cloudstack

--- a/lib/fog/cloudstack/models/compute/ipaddress.rb
+++ b/lib/fog/cloudstack/models/compute/ipaddress.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Ipaddress < Fog::Model
+        identity  :id,                                            :aliases => 'id'
+        attribute :virtual_machine_id,                            :aliases => 'virtualmachineid'
+        attribute :network_id,                                    :aliases => 'networkid'
+        attribute :ip_address,                                    :aliases => 'ipaddress'
+        attribute :associated_network_id,                         :aliases => 'associatednetworkid'
+        def associate
+          requires :network_id
+
+          data = service.associate_ip_address(options={'networkid' => self.associated_network_id})
+          merge_attributes(data['associateipaddressresponse'])
+          service.jobs.new(data["associateipaddressresponse"])
+        end
+
+        def disassociate
+          requires :id
+          data = service.disassociate_ip_address(options={'id' => self.id}) if (id != nil)
+        end
+
+      end # Ipaddress
+    end # Cloudstack
+  end # Compute
+end # Fog

--- a/lib/fog/cloudstack/models/compute/ipaddresses.rb
+++ b/lib/fog/cloudstack/models/compute/ipaddresses.rb
@@ -1,0 +1,21 @@
+require 'fog/core/collection'
+require 'fog/cloudstack/models/compute/ipaddress'
+
+module Fog
+  module Compute
+    class Cloudstack
+
+      class Ipaddresses < Fog::Collection
+
+        model Fog::Compute::Cloudstack::Ipaddress
+
+        def all
+          data = service.list_public_ip_addresses['listpublicipaddressesresponse']['publicipaddress'] || []
+          load(data)
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/key_pair.rb
+++ b/lib/fog/cloudstack/models/compute/key_pair.rb
@@ -1,0 +1,48 @@
+module Fog
+  module Compute
+    class Cloudstack
+
+      class KeyPair < Fog::Model
+
+        identity  :name
+
+        attribute :fingerprint
+        attribute :private_key,                           :aliases => 'privatekey'
+
+        def destroy
+          requires :name
+
+          service.delete_ssh_key_pair(name)
+          true
+        end
+
+        def save
+          requires :name
+
+          data = service.create_ssh_key_pair(name)
+
+          merge_attributes(data['createsshkeypairresponse']['keypair'])
+        end
+
+        def write(path="#{ENV['HOME']}/.ssh/fog_#{Fog.credential.to_s}_#{name}.pem")
+
+          if writable?
+            split_private_key = private_key.split(/\n/)
+            File.open(path, "w") do |f|
+              split_private_key.each {|line| f.puts line}
+              f.chmod 0600
+            end
+            "Key file built: #{path}"
+          else
+            "Invalid private key"
+          end
+        end
+
+        def writable?
+          !!(private_key && ENV.has_key?('HOME'))
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/key_pairs.rb
+++ b/lib/fog/cloudstack/models/compute/key_pairs.rb
@@ -1,0 +1,28 @@
+require 'fog/core/collection'
+require 'fog/cloudstack/models/compute/key_pair'
+
+module Fog
+  module Compute
+    class Cloudstack
+
+      class KeyPairs < Fog::Collection
+
+        model Fog::Compute::Cloudstack::KeyPair
+
+        def all
+          data = service.list_ssh_key_pairs["listsshkeypairsresponse"]["sshkeypair"] || []
+          load(data)
+        end
+
+        def get(key_pair_name)
+          if key_pair_name
+            self.all.select {|kp| kp.name == key_pair_name}.first
+          end
+        rescue Fog::Compute::Cloudstack::NotFound
+          nil
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/nat.rb
+++ b/lib/fog/cloudstack/models/compute/nat.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Nat < Fog::Model
+        identity  :id,                                            :aliases => 'id'
+        attribute :ip_address_id,                                 :aliases => 'ipaddressid'
+        attribute :virtual_machine_id,                            :aliases => 'virtualmachineid'
+        attribute :network_id,                                    :aliases => 'networkid'
+
+        def enable
+          requires :ip_address_id
+          requires :virtual_machine_id
+
+          options = {
+              'ipaddressid'        => self.ip_address_id,
+              'virtualmachineid'     => self.virtual_machine_id,
+              'networkid' => self.network_id,
+          }
+          data = service.enable_static_nat(options)
+        end
+
+        def disable
+          requires :ip_address_id
+          data = service.disable_static_nat(options={'ipaddressid' => self.ip_address_id})
+          service.jobs.new(data["disablestaticnatresponse"])
+        end
+
+      end # Nat
+    end # Cloudstack
+  end # Compute
+end # Fog

--- a/lib/fog/cloudstack/models/compute/nats.rb
+++ b/lib/fog/cloudstack/models/compute/nats.rb
@@ -1,0 +1,17 @@
+require 'fog/core/collection'
+require 'fog/cloudstack/models/compute/nat'
+
+module Fog
+  module Compute
+    class Cloudstack
+
+      class Nats < Fog::Collection
+
+        model Fog::Compute::Cloudstack::Nat
+
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/network.rb
+++ b/lib/fog/cloudstack/models/compute/network.rb
@@ -1,0 +1,11 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Network < Fog::Model
+        identity  :id
+        attribute :name
+        attribute :services,                   :type => :array, :aliases => 'service'
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/networks.rb
+++ b/lib/fog/cloudstack/models/compute/networks.rb
@@ -1,0 +1,21 @@
+require 'fog/core/collection'
+require 'fog/cloudstack/models/compute/network'
+
+module Fog
+  module Compute
+    class Cloudstack
+
+      class Networks < Fog::Collection
+
+        model Fog::Compute::Cloudstack::Network
+
+        def all
+          data = service.list_networks["listnetworksresponse"]["network"] || []
+          load(data)
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/ostype.rb
+++ b/lib/fog/cloudstack/models/compute/ostype.rb
@@ -1,0 +1,12 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Ostype < Fog::Model
+        identity  :id,              :aliases => 'id'
+        attribute :description,      :aliases => 'description'
+        attribute :oscategoryid,       :aliases => 'oscategoryid'
+
+      end # Ostype
+    end # Cloudstack
+  end # Compute
+end # Fog

--- a/lib/fog/cloudstack/models/compute/ostypes.rb
+++ b/lib/fog/cloudstack/models/compute/ostypes.rb
@@ -1,0 +1,17 @@
+require 'fog/core/collection'
+require 'fog/cloudstack/models/compute/ostype'
+module Fog
+  module Compute
+    class Cloudstack
+
+      class Ostypes < Fog::Collection
+
+        model Fog::Compute::Cloudstack::Ostype
+        def all(filters={})
+          data = service.list_os_types(filters)["listostypesresponse"]["ostype"]
+          load(data)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/snapshot.rb
+++ b/lib/fog/cloudstack/models/compute/snapshot.rb
@@ -37,9 +37,10 @@ module Fog
 
         def destroy
           requires :id
-          service.delete_snapshot('id' => id)
-          true
+          data = service.delete_snapshot('id' => id)
+          service.jobs.new(data["deletesnapshotresponse"])
         end
+
       end # Snapshot
     end # Cloudstack
   end # Compute

--- a/lib/fog/cloudstack/models/compute/snapshots.rb
+++ b/lib/fog/cloudstack/models/compute/snapshots.rb
@@ -13,10 +13,14 @@ module Fog
           data = service.list_snapshots["listsnapshotsresponse"]["snapshot"] || []
           load(data)
         end
-
+        
         def get(snapshot_id)
-          snapshot = service.list_snapshots('id' => snapshot_id)["listsnapshotsresponse"]["snapshot"].first
-          new(snapshot) if snapshot
+          snapshots = service.list_snapshots('id' => snapshot_id)["listsnapshotsresponse"]["snapshot"]
+          unless snapshots.nil? || snapshots.empty?
+              new(snapshots.first)
+          end
+        rescue Fog::Compute::Cloudstack::BadRequest
+          nil
         end
       end
 

--- a/lib/fog/cloudstack/models/compute/vlan.rb
+++ b/lib/fog/cloudstack/models/compute/vlan.rb
@@ -1,0 +1,53 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Vlan < Fog::Model
+        identity  :id
+        attribute :start_ip,                                    :aliases => 'startip'
+        attribute :end_ip,                                      :aliases => 'endip'
+        attribute :netmask
+        attribute :gateway
+        attribute :account
+        attribute :domain
+        attribute :domain_id,                                   :aliases => 'domainid'
+        attribute :for_virtual_network,   :type => :boolean,    :aliases => 'forvirtualnetwork'
+        attribute :network_id,                                  :aliases => 'networkid'
+        attribute :physical_network_id,                         :aliases => 'physicalnetworkid'
+        attribute :pod_id,                                      :aliases => 'podid'
+        attribute :pod_name,                                    :aliases => 'podname'
+        attribute :project
+        attribute :project_id,                                  :aliases => 'projectid'
+        attribute :vlan
+        attribute :zone_id,                                     :aliases => 'zoneid'
+
+        def create_vlan_ip_range
+          requires :start_ip, :end_ip, :netmask, :gateway, :zone_id
+          options = {
+              'startip'        => start_ip,
+              'endip'          => end_ip,
+              'netmask'        => netmask,
+              'gateway'        => gateway,
+              'zoneid'         => zone_id,
+              'vlan'           => vlan
+          }
+
+          data = service.create_vlan_ip_range(options)
+          merge_attributes(data['createvlaniprangeresponse']['vlan'])
+        end
+
+        def delete_vlan_ip_range
+          requires :id
+          data = service.delete_vlan_ip_range(options={'id' => self.id})
+        end
+
+        def list_vlan_ip_ranges
+          requires :zone_id
+
+          data = service.list_vlan_ip_ranges(options={'zoneid' => self.zone_id})
+          merge_attributes(data['listvlaniprangesresponse'])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/vlans.rb
+++ b/lib/fog/cloudstack/models/compute/vlans.rb
@@ -1,0 +1,17 @@
+require 'fog/core/collection'
+require 'fog/cloudstack/models/compute/vlan'
+
+module Fog
+  module Compute
+    class Cloudstack
+
+      class Vlans < Fog::Collection
+
+        model Fog::Compute::Cloudstack::Vlan
+
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/cloudstack/models/compute/volume.rb
+++ b/lib/fog/cloudstack/models/compute/volume.rb
@@ -25,7 +25,7 @@ module Fog
         attribute :server_id,                  :aliases => 'virtualmachineid'
         attribute :server_name,                :aliases => 'vmname'
         attribute :server_display_name,        :aliases => 'vmdisplayname'
-
+        attribute :device_id,                  :aliases => 'deviceid'
         attr_accessor :snapshot_id, :project_id
 
         def save

--- a/lib/fog/cloudstack/requests/compute/associate_ip_address.rb
+++ b/lib/fog/cloudstack/requests/compute/associate_ip_address.rb
@@ -1,0 +1,30 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Aassociate an ip address.
+        #
+        # {CloudStack API Reference}[http://download.cloud.com/releases/2.2.0/api_2.2.4/global_admin/associateIpAddress.html]
+        def associate_ip_address(options={})
+          options.merge!(
+              'command' => 'associateIpAddress'
+          )
+          request(options)
+        end
+
+      end
+
+      class Mock
+        def associate_ip_address(options={})
+          ip_info = self.data[:ip_info]
+          { 'associateipaddressresponse' =>
+                { 'count' => ip_info.count,
+                  'ip_info' => ip_info
+                }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/requests/compute/copy_template.rb
+++ b/lib/fog/cloudstack/requests/compute/copy_template.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Copy a template from one zoen to another
+        #
+        # {CloudStack API Reference}[http://cloudstack.apache.org/docs/api/apidocs-4.2/user/copyTemplate.html]
+        def copy_template(options={})
+          options.merge!(
+              'command' => 'copyTemplate'
+          )
+
+          request(options)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/requests/compute/create_firewall_rule.rb
+++ b/lib/fog/cloudstack/requests/compute/create_firewall_rule.rb
@@ -1,0 +1,21 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Creates a firewall rule of an IP address.
+        #
+        # {CloudStack API Reference}[http://incubator.apache.org/cloudstack/docs/api/apidocs-4.0.0/root_admin/createFirewallRule.html]
+        def create_firewall_rule(options={})
+          options.merge!(
+            'command' => 'createFirewallRule'
+          )
+
+          request(options)
+        end
+
+      end
+    end
+  end
+end
+

--- a/lib/fog/cloudstack/requests/compute/create_tags.rb
+++ b/lib/fog/cloudstack/requests/compute/create_tags.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # creates resource tags.
+        #
+        # {CloudStack API Reference}[http://cloudstack.apache.org/docs/api/apidocs-4.2/user/createTags.html]
+        def create_tags(options={})
+          options.merge!(
+            'command' => 'createTags'
+          )
+
+          request(options)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/requests/compute/create_template.rb
+++ b/lib/fog/cloudstack/requests/compute/create_template.rb
@@ -1,0 +1,16 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+        def create_template(options={})
+          options.merge!(
+              'command' => 'createTemplate'
+          )
+
+          request(options)
+        end
+      end
+    end
+  end
+end
+

--- a/lib/fog/cloudstack/requests/compute/create_vlan_ip_range.rb
+++ b/lib/fog/cloudstack/requests/compute/create_vlan_ip_range.rb
@@ -1,0 +1,32 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Creates a VLAN IP range.
+        #
+        # {CloudStack API Reference}[http://incubator.apache.org/cloudstack/docs/api/apidocs-4.0.0/root_admin/createVlanIpRange.html]
+        def create_vlan_ip_range(options={})
+          options.merge!(
+            'command' => 'createVlanIpRange'
+          )
+
+          request(options)
+        end
+
+      end
+
+      class Mock
+        def create_vlan_ip_range(options={})
+          vlan_ip_ranges = self.data[:vlan_ip_ranges]
+          { 'createvlaniprangeresponse' =>
+                { 'count' => vlan_ip_ranges.count,
+                  'vlan_ip_ranges' => vlan_ip_ranges
+                }
+          }
+        end
+      end
+    end
+  end
+end
+

--- a/lib/fog/cloudstack/requests/compute/delete_tags.rb
+++ b/lib/fog/cloudstack/requests/compute/delete_tags.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Deletes resource tags.
+        #
+        # {CloudStack API Reference}[http://cloudstack.apache.org/docs/api/apidocs-4.2/user/deleteTags.html]
+        def delete_tags(options={})
+          options.merge!(
+            'command' => 'deleteTags'
+          )
+
+          request(options)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/requests/compute/delete_vlan_ip_range.rb
+++ b/lib/fog/cloudstack/requests/compute/delete_vlan_ip_range.rb
@@ -1,0 +1,37 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Deletes a VLAN IP range.
+        #
+        # {CloudStack API Reference}[http://incubator.apache.org/cloudstack/docs/api/apidocs-4.0.0/root_admin/deleteVlanIpRange.html]
+        def delete_vlan_ip_range(options={})
+          options.merge!(
+              'command' => 'deleteVlanIpRange'
+          )
+
+          request(options)
+        end
+
+      end
+
+      class Mock
+
+        # Deletes a VLAN IP range.
+        #
+        # {CloudStack API Reference}[http://incubator.apache.org/cloudstack/docs/api/apidocs-4.0.0/root_admin/deleteVlanIpRange.html]
+        def delete_vlan_ip_range(options={})
+          { 'deletevlaniprangeresponse' =>
+                { 'count' => 2,
+                  'delete_info' => {
+                     'displaytext' => 'displaytext',
+                     'success'     => true
+                  }
+                }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/requests/compute/disable_static_nat.rb
+++ b/lib/fog/cloudstack/requests/compute/disable_static_nat.rb
@@ -1,0 +1,38 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Disable static nat.
+        #
+        # {CloudStack API Reference}[http://incubator.apache.org/cloudstack/docs/api/apidocs-4.0.0/root_admin/disableStaticNat.html]
+        def disable_static_nat(options={})
+          options.merge!(
+              'command' => 'disableStaticNat'
+          )
+
+          request(options)
+        end
+
+      end
+
+      class Mock
+        # Disable static nat mock.
+        #
+        # {CloudStack API Reference}[http://incubator.apache.org/cloudstack/docs/api/apidocs-4.0.0/root_admin/disableStaticNat.html]
+        def disable_static_nat(options={})
+          { 'disablestaticnatresponse' =>
+                { 'count' => 2,
+                  'nat_info' => {
+                     'displaytext' => 'displaytext',
+                     'success'     => true
+                  }
+                }
+          }
+ 
+        end
+ 
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/requests/compute/disassociate_ip_address.rb
+++ b/lib/fog/cloudstack/requests/compute/disassociate_ip_address.rb
@@ -1,0 +1,39 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Disassociate an ip address.
+        #
+        # {CloudStack API Reference}[http://download.cloud.com/releases/2.2.0/api_2.2.4/global_admin/disassociateIpAddress.html]
+        def disassociate_ip_address(options={})
+          options.merge!(
+              'command' => 'disassociateIpAddress'
+          )
+
+          request(options)
+        end
+
+      end
+
+      class Mock
+
+        # Disassociate an ip address mock.
+        #
+        # {CloudStack API Reference}[http://download.cloud.com/releases/2.2.0/api_2.2.4/global_admin/disassociateIpAddress.html]
+        def disassociate_ip_address(options={})
+          { 'disassociateipaddressresponse' =>
+                { 'count' => 2,
+                  'disassociate_info' => {
+                     'displaytext' => 'displaytext',
+                     'success'     => true
+                  }
+                }
+          }
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/cloudstack/requests/compute/enable_static_nat.rb
+++ b/lib/fog/cloudstack/requests/compute/enable_static_nat.rb
@@ -1,0 +1,41 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Enable static nat.
+        #
+        # {CloudStack API Reference}[http://incubator.apache.org/cloudstack/docs/api/apidocs-4.0.0/root_admin/enableStaticNat.html]
+        def enable_static_nat(options={})
+          options.merge!(
+              'command' => 'enableStaticNat'
+          )
+
+          request(options)
+        end
+
+      end
+     
+     class Mock
+
+        # Enable static nat mock.
+        #
+        # {CloudStack API Reference}[http://incubator.apache.org/cloudstack/docs/api/apidocs-4.0.0/root_admin/enableStaticNat.html]
+        def enable_static_nat(options={})
+          { 'enablestaticnatresponse' =>
+                { 'count' => 2,
+                  'nat_info' => {
+                     'displaytext' => 'displaytext',
+                     'success'     => true
+                  }
+                }
+          }
+ 
+        end
+
+      end
+
+
+    end
+  end
+end

--- a/lib/fog/cloudstack/requests/compute/list_tags.rb
+++ b/lib/fog/cloudstack/requests/compute/list_tags.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Lists resource tags.
+        #
+        # {CloudStack API Reference}[http://cloudstack.apache.org/docs/api/apidocs-4.2/user/listTags.html]
+        def list_tags(options={})
+          options.merge!(
+            'command' => 'listTags'
+          )
+
+          request(options)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/cloudstack/requests/compute/list_vlan_ip_ranges.rb
+++ b/lib/fog/cloudstack/requests/compute/list_vlan_ip_ranges.rb
@@ -1,0 +1,31 @@
+module Fog
+  module Compute
+    class Cloudstack
+      class Real
+
+        # Lists all VLAN IP ranges.
+        #
+        # {CloudStack API Reference}[http://incubator.apache.org/cloudstack/docs/api/apidocs-4.0.0/root_admin/listVlanIpRanges.html]
+        def list_vlan_ip_ranges(options={})
+          options.merge!(
+              'command' => 'listVlanIpRanges'
+          )
+
+          request(options)
+        end
+
+      end
+
+      class Mock
+        def list_vlan_ip_ranges(options={})
+          vlan_ip_ranges = self.data[:vlan_ip_ranges]
+          { 'listvlaniprangeresponse' =>
+                { 'count' => vlan_ip_ranges.count,
+                  'vlan_ip_ranges' => vlan_ip_ranges
+                }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/schema/data_validator.rb
+++ b/lib/fog/schema/data_validator.rb
@@ -105,7 +105,6 @@ module Fog
       #
       def validate_value(validator, value, options)
         Fog::Logger.write :debug, "[yellow][DEBUG] #{value.inspect} against #{validator.inspect}[/]\n"
-
         case validator
         when Array
           return false if value.is_a?(Hash)

--- a/tests/cloudstack/requests/assosiate_ip_address_tests.rb
+++ b/tests/cloudstack/requests/assosiate_ip_address_tests.rb
@@ -1,0 +1,38 @@
+Shindo.tests('Fog::Compute[:cloudstack] | assosiate ip address requests', ['cloudstack']) do
+
+  @ip_info_format = {
+      'associateipaddressresponse'  => {
+          'count'                   => Integer,
+          'ip_info'                 => {
+              'id'                        => String,
+              'account'                   => String, 
+              'description'               => Fog::Nullable::String,
+              'domain'                    => Hash,
+              'domainid'                  => String,
+              'associatednetworkid'       => String,
+              'forvirtualnetwork'         => Fog::Boolean,
+              'ipaddress'                 => String,
+              'issourcenat'               => Fog::Boolean,
+              'isstaticnat'               => Fog::Boolean,
+              'jobid'                     => String,
+              'jobstatus'                 => String,
+              'networkid'                 => String,
+              'state'                     => String,
+              'virtualmachinedisplayname' => String,
+              'virtualmachineid'          => String,
+              'virtualmachinename'        => String,
+              'vlanid'                    => Integer,
+              'vlanname'                  => String,
+              'zoneid'                    => Integer,
+              'zonename'                  => String
+          }
+      }
+  }
+
+  tests('success') do
+    tests('#assosiate_ip_address').formats(@ip_info_format) do
+      Fog::Compute[:cloudstack].associate_ip_address
+    end
+  end
+
+end

--- a/tests/cloudstack/requests/create_vlan_range_tests.rb
+++ b/tests/cloudstack/requests/create_vlan_range_tests.rb
@@ -1,0 +1,36 @@
+Shindo.tests('Fog::Compute[:cloudstack] | create vlan ip range requests', ['cloudstack']) do
+
+  @ip_range_info_format = {
+      'createvlaniprangeresponse'  => {
+          'count'                   => Integer,
+          'vlan_ip_ranges'                 => {
+              'id'                => String,
+              'account'           => String,
+              'description'       => Fog::Nullable::String,
+              'domain'            => Hash,
+              'domainid'          => String,
+              'forvirtualnetwork' => Fog::Boolean,
+              'networkid'         => String,
+              'physicalnetworkid' => String,
+              'poid'              => String,
+              'podname'           => String,
+              'project'           => String,
+              'projectid'         => String,
+              'zoneid'            => String,
+              'gateway'           => String,
+              'netmask'           => String,
+              'startip'           => String,
+              'endip'             => String,
+              'vlan'              => Integer
+
+          }
+      }
+  }
+
+  tests('success') do
+    tests('#create_vlan_ip_range').formats(@ip_range_info_format) do
+      Fog::Compute[:cloudstack].create_vlan_ip_range
+    end
+  end
+
+end

--- a/tests/cloudstack/requests/delete_vlan_range_tests.rb
+++ b/tests/cloudstack/requests/delete_vlan_range_tests.rb
@@ -1,0 +1,19 @@
+Shindo.tests('Fog::Compute[:cloudstack] | delete vlan ip range requests', ['cloudstack']) do
+
+  @delete_info_format = {
+      'deletevlaniprangeresponse'  => {
+          'count'                   => Integer,
+          'delete_info'            => {
+            'displaytext'           => String,
+            'success'               => Fog::Boolean
+          }
+      }
+  }
+
+  tests('success') do
+    tests('#delete_vlan_ip_range').formats(@delete_info_format) do
+      Fog::Compute[:cloudstack].delete_vlan_ip_range
+    end
+  end
+
+end

--- a/tests/cloudstack/requests/disable_static_nat_tests.rb
+++ b/tests/cloudstack/requests/disable_static_nat_tests.rb
@@ -1,0 +1,20 @@
+Shindo.tests('Fog::Compute[:cloudstack] | disable static nat requests', ['cloudstack']) do
+
+  @nat_info_format = {
+      'disablestaticnatresponse'  => {
+          'count'          => Integer,
+          'nat_info'       => {
+             'displaytext' => String,
+             'success'     => Fog::Boolean
+
+          }
+      }
+  }
+
+  tests('success') do
+    tests('#disable_static_nat').formats(@nat_info_format) do
+      Fog::Compute[:cloudstack].disable_static_nat
+    end
+  end
+
+end

--- a/tests/cloudstack/requests/disassosiate_ip_address_tests.rb
+++ b/tests/cloudstack/requests/disassosiate_ip_address_tests.rb
@@ -1,0 +1,19 @@
+Shindo.tests('Fog::Compute[:cloudstack] | disassosiate ip address requests', ['cloudstack']) do
+
+  @disassociate_format = {
+      'disassociateipaddressresponse'  => {
+          'count'                   => Integer,
+          'disassociate_info'                 => {
+              'displaytext'       => String,
+              'success'         => Fog::Boolean
+          }
+      }
+  }
+
+  tests('success') do
+    tests('#disassosiate_ip_address').formats(@disassociate_format) do
+      Fog::Compute[:cloudstack].disassociate_ip_address
+    end
+  end
+
+end

--- a/tests/cloudstack/requests/disk_offering_tests.rb
+++ b/tests/cloudstack/requests/disk_offering_tests.rb
@@ -25,5 +25,4 @@ Shindo.tests('Fog::Compute[:cloudstack] | disk offering requests', ['cloudstack'
     end
 
   end
-
 end

--- a/tests/cloudstack/requests/enable_static_nat_tests.rb
+++ b/tests/cloudstack/requests/enable_static_nat_tests.rb
@@ -1,0 +1,20 @@
+Shindo.tests('Fog::Compute[:cloudstack] | enable static nat requests', ['cloudstack']) do
+
+  @nat_info_format = {
+      'enablestaticnatresponse'  => {
+          'count'          => Integer,
+          'nat_info'       => {
+             'displaytext' => String,
+             'success'     => Fog::Boolean
+
+          }
+      }
+  }
+
+  tests('success') do
+    tests('#enable_static_nat').formats(@nat_info_format) do
+      Fog::Compute[:cloudstack].enable_static_nat
+    end
+  end
+
+end

--- a/tests/cloudstack/requests/list_vlan_range_tests.rb
+++ b/tests/cloudstack/requests/list_vlan_range_tests.rb
@@ -1,0 +1,35 @@
+Shindo.tests('Fog::Compute[:cloudstack] | list vlan ip range requests', ['cloudstack']) do
+
+  @vlan_format = {
+      'listvlaniprangeresponse'  => {
+      'count'                    => Integer,
+      'vlan_ip_ranges'           => {
+        'id'                => String,
+        'account'           => String,
+        'description'       => Fog::Nullable::String,
+        'domain'            => Hash,
+        'domainid'          => String,
+        'forvirtualnetwork' => Fog::Boolean,
+        'networkid'         => String,
+        'physicalnetworkid' => String,
+        'poid'              => String,
+        'podname'           => String,
+        'project'           => String,
+        'projectid'         => String,
+        'zoneid'            => String,
+        'gateway'           => String,
+        'netmask'           => String,
+        'startip'           => String,
+        'endip'             => String,
+        'vlan'              => Integer
+      }
+    }
+  }
+
+  tests('success') do
+    tests('#list_vlan_ip_ranges').formats(@vlan_format) do
+      Fog::Compute[:cloudstack].list_vlan_ip_ranges
+    end
+  end
+
+end


### PR DESCRIPTION
Add models and requests to support CloudStack advanced network API, which should be used in Cloud Foundry BOSH-CloudStack-CPI project. Most of these features belong to ClousStack API 4.0.x

These features include firewall management, associating IP address to vm, enabling static nat, and vlan ip range management etc.

Files affected:

lib/fog/cloudstack/models/compute/firewall.rb
lib/fog/cloudstack/models/compute/firewalls.rb
lib/fog/cloudstack/models/compute/ipaddress.rb
lib/fog/cloudstack/models/compute/ipaddresses.rb
lib/fog/cloudstack/models/compute/key_pair.rb
lib/fog/cloudstack/models/compute/key_pairs.rb
lib/fog/cloudstack/models/compute/nat.rb
lib/fog/cloudstack/models/compute/nats.rb
lib/fog/cloudstack/models/compute/network.rb
lib/fog/cloudstack/models/compute/networks.rb
lib/fog/cloudstack/models/compute/ostype.rb
lib/fog/cloudstack/models/compute/ostypes.rb
lib/fog/cloudstack/models/compute/vlan.rb
lib/fog/cloudstack/models/compute/vlans.rb
lib/fog/cloudstack/requests/compute/associate_ip_address.rb
lib/fog/cloudstack/requests/compute/copy_template.rb
lib/fog/cloudstack/requests/compute/create_firewall_rule.rb
lib/fog/cloudstack/requests/compute/create_tags.rb
lib/fog/cloudstack/requests/compute/create_template.rb
lib/fog/cloudstack/requests/compute/create_vlan_ip_range.rb
lib/fog/cloudstack/requests/compute/delete_tags.rb
lib/fog/cloudstack/requests/compute/delete_vlan_ip_range.rb
lib/fog/cloudstack/requests/compute/disable_static_nat.rb
lib/fog/cloudstack/requests/compute/disassociate_ip_address.rb
lib/fog/cloudstack/requests/compute/enable_static_nat.rb
lib/fog/cloudstack/requests/compute/list_tags.rb
lib/fog/cloudstack/requests/compute/list_vlan_ip_ranges.rb
tests/cloudstack/requests/assosiate_ip_address_tests.rb
tests/cloudstack/requests/create_vlan_range_tests.rb
tests/cloudstack/requests/delete_vlan_range_tests.rb
tests/cloudstack/requests/disable_static_nat_tests.rb
tests/cloudstack/requests/disassosiate_ip_address_tests.rb
tests/cloudstack/requests/enable_static_nat_tests.rb
tests/cloudstack/requests/list_vlan_range_tests.rb
