### PR TITLE
[google] Disk.ready? should not reload the data

### DIFF
--- a/lib/fog/google/models/compute/disk.rb
+++ b/lib/fog/google/models/compute/disk.rb
@@ -73,8 +73,6 @@ module Fog
         end
 
         def ready?
-          data = service.get_disk(self.name, self.zone_name).body
-          self.merge_attributes(data)
           self.status == RUNNING_STATE
         end
 


### PR DESCRIPTION
it's done in wait_for in other models and providers
