### PR TITLE
Pass params necessary to upload key pairs.

### DIFF
--- a/lib/fog/rackspace/requests/compute_v2/create_keypair.rb
+++ b/lib/fog/rackspace/requests/compute_v2/create_keypair.rb
@@ -26,7 +26,7 @@ module Fog
             key_data.merge!("public_key" => attributes)
           end
 
-          key_data.merge!(attributes) unless attributes.nil?
+          key_data.merge!(attributes) if attributes.is_a?(Hash)
 
           data = {
             'keypair' => key_data


### PR DESCRIPTION
The original implementation did not pass the required attributes to upload
an existing key pair up to the API. This commit addresses that problem
while maintaining backwards compatibility. The 2nd argument was changed
from a string to a hash, a deprecation warning is generated.
