### PR TITLE
[rackspace|compute_v2] updates key_pair model to pass additional attributes

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/key_pair.rb
+++ b/lib/fog/rackspace/models/compute_v2/key_pair.rb
@@ -33,7 +33,7 @@ module Fog
         # @raise  [Fog::Compute::RackspaceV2::ServiceError]
         def save
           requires :name
-          data = service.create_keypair(name, public_key)
+          data = service.create_keypair(name, attributes)
           merge_attributes(data.body['keypair'])
           data.body['keypair']['name'] == name
         end


### PR DESCRIPTION
updates key_pair model to pass additional attributes onto compute service. (You can now pass public and private keys via the model)
