### PR TITLE
[aws|fog] Don't pass :host to Excon request

### DIFF
--- a/lib/fog/aws/emr.rb
+++ b/lib/fog/aws/emr.rb
@@ -117,7 +117,6 @@ module Fog
               :expects    => 200,
               :headers    => { 'Content-Type' => 'application/x-www-form-urlencoded' },
               :idempotent => idempotent,
-              :host       => @host,
               :method     => 'POST',
               :parser     => parser
             })


### PR DESCRIPTION
See issue #2284
