### PR TITLE
AWS SQS signature mismatch and Excon warning fixes

### DIFF
--- a/lib/fog/aws/sqs.rb
+++ b/lib/fog/aws/sqs.rb
@@ -4,7 +4,7 @@ module Fog
   module AWS
     class SQS < Fog::Service
       extend Fog::AWS::CredentialFetcher::ServiceMethods
-
+      
       requires :aws_access_key_id, :aws_secret_access_key
       recognizes :region, :host, :path, :port, :scheme, :persistent, :aws_session_token, :use_iam_profile, :aws_credentials_expire_at
 
@@ -30,7 +30,7 @@ module Fog
             end
           end
         end
-
+        
         def self.reset
           @data = nil
         end
@@ -123,7 +123,9 @@ module Fog
               :aws_access_key_id  => @aws_access_key_id,
               :aws_session_token  => @aws_session_token,
               :hmac               => @hmac,
+              :host               => @host,
               :path               => path || @path,
+              :port               => @port,
               :version            => '2009-02-01'
             }
           )


### PR DESCRIPTION
Attempting to perform SQS operations in 1.19.0 fails with the following error because commit 8c5ea5d removes the `host` and `port` needed to generate the signature correctly:

```
#<Excon::Response:0x007fdfcdecdb78 @data={:body=>"<?xml version=\"1.0\"?><ErrorResponse xmlns=\"http://queue.amazonaws.com/doc/2009-02-01/\"><Error><Type>Sender</Type><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.</Message><Detail/></Error><RequestId>3c3fbde1-cc14-5255-9d5d-f6a76af4f112</RequestId></ErrorResponse>", :headers=>{"Server"=>"Server", "Date"=>"Wed, 08 Jan 2014 01:06:40 GMT", "Content-Type"=>"text/xml", "Content-Length"=>"436", "Connection"=>"close", "x-amzn-RequestId"=>"3c3fbde1-cc14-5255-9d5d-f6a76af4f112"}, :status=>403, :remote_ip=>"72.21.202.145"}, @body="<?xml version=\"1.0\"?><ErrorResponse xmlns=\"http://queue.amazonaws.com/doc/2009-02-01/\"><Error><Type>Sender</Type><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.</Message><Detail/></Error><RequestId>3c3fbde1-cc14-5255-9d5d-f6a76af4f112</RequestId></ErrorResponse>", @headers={"Server"=>"Server", "Date"=>"Wed, 08 Jan 2014 01:06:40 GMT", "Content-Type"=>"text/xml", "Content-Length"=>"436", "Connection"=>"close", "x-amzn-RequestId"=>"3c3fbde1-cc14-5255-9d5d-f6a76af4f112"}, @status=403, @remote_ip="72.21.202.145">
```

I've rolled back that commit and removed `host` from the request args being passed to Excon, which was generating a warning.

Related to https://github.com/fog/fog/issues/2284
