### PR TITLE
[Rackspace] Monitoring pagination fix

### DIFF
--- a/lib/fog/rackspace/models/monitoring/entities.rb
+++ b/lib/fog/rackspace/models/monitoring/entities.rb
@@ -13,7 +13,7 @@ module Fog
 
         def all(options={})
           data = service.list_entities(options).body
-          marker = data['metadata']['next_marker']
+          self.marker = data['metadata']['next_marker']
 
           load(data['values'])
         end


### PR DESCRIPTION
Monitoring-specific soluton to pagination. 'marker' was being extracted but not stored.

Closes #2469

We could still use a more generic pagination solution. Started looking at this a little this afternoon.
