### PR TITLE
[google] Fix get_bucket_acl request method in Google Cloud Storage

### DIFF
--- a/lib/fog/google/requests/storage/get_bucket_acl.rb
+++ b/lib/fog/google/requests/storage/get_bucket_acl.rb
@@ -1,6 +1,6 @@
 module Fog
-  module Google
-    class Storage
+  module Storage
+    class Google
       class Real
 
         require 'fog/google/parsers/storage/access_control_list'


### PR DESCRIPTION
This PR fixes `get_bucket_acl` method visibility :
Before:

``` ruby
require './lib/fog/google' 
storage = Fog::Storage::Google.new(...) 
storage.methods.grep(/^get_b/)       # => [:get_bucket]
```

After:

``` ruby
require './lib/fog/google' 
storage = Fog::Storage::Google.new(...) 
storage.methods.grep(/^get_b/)       # => [:get_bucket, :get_bucket_acl]
```
