### PR TITLE
Fixes for AWS Mocking

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -192,11 +192,7 @@ module Fog
       end
 
       def self.ip_address
-        ip = []
-        4.times do
-          ip << Fog::Mock.random_numbers(rand(3) + 1).to_i.to_s # remove leading 0
-        end
-        ip.join('.')
+        Fog::Mock.random_ip
       end
 
       def self.private_ip_address

--- a/lib/fog/aws/requests/compute/associate_address.rb
+++ b/lib/fog/aws/requests/compute/associate_address.rb
@@ -51,6 +51,7 @@ module Fog
               allocation_ip = describe_addresses( 'allocation-id'  => "#{allocation_id}").body['addressesSet'].first
               if !allocation_ip.nil?
                 public_ip = allocation_ip['publicIp']
+                address = public_ip.nil? ? nil : self.data[:addresses][public_ip]
               end
             end
             if !address.nil?

--- a/lib/fog/aws/requests/compute/describe_addresses.rb
+++ b/lib/fog/aws/requests/compute/describe_addresses.rb
@@ -46,7 +46,7 @@ module Fog
 
           addresses_set = self.data[:addresses].values
 
-          aliases = {'public-ip' => 'publicIp', 'instance-id' => 'instanceId'}
+          aliases = {'public-ip' => 'publicIp', 'instance-id' => 'instanceId', 'allocation-id' => 'allocationId'}
           for filter_key, filter_value in filters
             aliased_key = aliases[filter_key]
             addresses_set = addresses_set.reject{|address| ![*filter_value].include?(address[aliased_key])}


### PR DESCRIPTION
Was writing some unit tests for code that uses AWS 'associate_address' method... found issues in mock code.

lib/fog/aws.rb
Previously chose 4xRandom numbers between 0 and 999, now uses the Mock random_ip which returns numbers that will be within acceptable number range.
Old method was returning invalid numbers that then failed to pass range checks.

lib/fog/aws/requests/compute/associate_address.rb
Re-fetch address if we have to look up public-ip using allocation-id, otherwise it remains nil and the ip-address/instance aren't updated correctly.

lib/fog/aws/requests/compute/describe_addresses.rb
The allocate-address request uses allocation-id to look up ip address if allocation-id is given instead of public-ip, so added that as searchable in mock data.
