### PR TITLE
[dnsimple] make get_domain also match to domain name

### DIFF
--- a/lib/fog/dnsimple/requests/dns/get_domain.rb
+++ b/lib/fog/dnsimple/requests/dns/get_domain.rb
@@ -36,7 +36,9 @@ module Fog
       class Mock
 
         def get_domain(id)
-          domain = self.data[:domains].detect { |domain| domain["domain"]["id"] == id }
+          domain = self.data[:domains].detect do |domain|
+            domain["domain"]["id"] == id || domain["domain"]["name"] == id
+          end
           response = Excon::Response.new
           response.status = 200
           response.body = domain


### PR DESCRIPTION
As the real DNSimple behaviour, `get_domain` also accept a string argument to get an specific domain, but using the mocked behaviour, only passing the `id` is allowed.

The idea is to match against both `id` and `name` when calling to `get_domain`.

```
[1] pry(main)> require 'fog/dnsimple' 
[2] pry(main)> dnsimple = Fog::DNS.new(:provider => "DNSimple", :dnsimple_email => 'test@example.com', :dnsimple_password => 'mypassword')
[3] pry(main)> dnsimple.zones.get('wadus.me')
=>   <Fog::DNS::DNSimple::Zone
    id=1969,
    domain="wadus.me",
    created_at="2011-02-28T09:49:56Z",
    updated_at="2014-01-10T15:16:32Z"
  >
[4] pry(main)> dnsimple.zones.get 1969
=>   <Fog::DNS::DNSimple::Zone
    id=1969,
    domain="wadus.me",
    created_at="2011-02-28T09:49:56Z",
    updated_at="2014-01-10T15:16:32Z"
  >
```
