### PR TITLE
Making local file interface follow AWS file interface

### DIFF
--- a/lib/fog/local/models/storage/file.rb
+++ b/lib/fog/local/models/storage/file.rb
@@ -11,6 +11,7 @@ module Fog
         attribute :content_length,  :aliases => 'Content-Length', :type => :integer
         # attribute :content_type,    :aliases => 'Content-Type'
         attribute :last_modified,   :aliases => 'Last-Modified'
+        attribute :encryption
 
         require 'uri'
 


### PR DESCRIPTION
Trying to use local file storage in place of AWS, but the encryption attribute does not exist on Fog::Storage::Local::File.

Making this a no-op to preserve the same API as Fog::Storage::AWS::File.
