### PR TITLE
Remove :host key in SNS request method to eliminate excon error

### DIFF
--- a/lib/fog/aws/sns.rb
+++ b/lib/fog/aws/sns.rb
@@ -102,7 +102,6 @@ module Fog
             :expects    => 200,
             :idempotent => idempotent,
             :headers    => { 'Content-Type' => 'application/x-www-form-urlencoded' },
-            :host       => @host,
             :method     => 'POST',
             :parser     => parser
           })


### PR DESCRIPTION
Another one related to #2265
