### PR TITLE
[Rackspace]  Handle whitespace in keypair names on deletion

### DIFF
--- a/lib/fog/rackspace/requests/compute_v2/delete_keypair.rb
+++ b/lib/fog/rackspace/requests/compute_v2/delete_keypair.rb
@@ -15,7 +15,7 @@ module Fog
           request(
             :method   => 'DELETE',
             :expects  => 202,
-            :path     => "/os-keypairs/#{key_name}"
+            :path     => "/os-keypairs/#{URI.escape(key_name)}"
           )
         end
       end


### PR DESCRIPTION
Fixes #2586

Names can contain whitespaces but we weren't handling that case.
