### PR TITLE
Fixed error when accessing files via atmos where keys contain spaces

### DIFF
--- a/lib/fog/atmos/requests/storage/get_namespace.rb
+++ b/lib/fog/atmos/requests/storage/get_namespace.rb
@@ -8,7 +8,7 @@ module Fog
           request({
                     :expects  => 200,
                     :method   => 'GET',
-                    :path     => "namespace/" + namespace,
+                    :path     => "namespace/" + URI.escape(namespace),
                     :query    => {},
                     :parse => true
                   }.merge(options))

--- a/lib/fog/atmos/requests/storage/head_namespace.rb
+++ b/lib/fog/atmos/requests/storage/head_namespace.rb
@@ -8,7 +8,7 @@ module Fog
           request({
                     :expects  => 200,
                     :method   => 'HEAD',
-                    :path     => "namespace/" + namespace,
+                    :path     => "namespace/" + URI.escape(namespace),
                     :query    => {},
                     :parse => true
                   }.merge(options))


### PR DESCRIPTION
When trying to iterate of all files in a directory, using atmos, If the key of a file contains a space an error would occur. Escaped the file path for header and get lookups.
