### PR TITLE
Add configuration for path_style to RiakCS Provisioning client. 

### DIFF
--- a/lib/fog/riakcs/provisioning.rb
+++ b/lib/fog/riakcs/provisioning.rb
@@ -8,7 +8,7 @@ module Fog
       class ServiceUnavailable < Fog::RiakCS::Provisioning::Error; end
 
       requires :riakcs_access_key_id, :riakcs_secret_access_key
-      recognizes :host, :path, :port, :scheme, :persistent
+      recognizes :host, :path, :port, :scheme, :persistent, :path_style
 
       request_path 'fog/riakcs/requests/provisioning'
       request :create_user
@@ -52,6 +52,7 @@ module Fog
           @riakcs_secret_access_key = options[:riakcs_secret_access_key]
           @connection_options       = options[:connection_options] || {}
           @persistent               = options[:persistent]         || false
+          @path_style               = options[:path_style]         || false
 
           @raw_connection = Fog::Connection.new(riakcs_uri, @persistent, @connection_options)
 
@@ -62,6 +63,7 @@ module Fog
             :host                  => @host,
             :port                  => @port,
             :scheme                => @scheme,
+            :path_style            => @path_style,
             :connection_options    => @connection_options
           )
         end


### PR DESCRIPTION
Defaults to false if no user input is given (following the style for the s3client default settings).
