### PR TITLE
[Brightbox] Add support for Cloud SQL service

### DIFF
--- a/lib/fog/brightbox/compute.rb
+++ b/lib/fog/brightbox/compute.rb
@@ -48,6 +48,12 @@ module Fog
       model       :image
       collection  :load_balancers
       model       :load_balancer
+      collection  :database_servers
+      model       :database_server
+      collection  :database_snapshots
+      model       :database_snapshot
+      collection  :database_types
+      model       :database_type
       collection  :zones
       model       :zone
       collection  :cloud_ips
@@ -74,6 +80,7 @@ module Fog
       request :create_firewall_rule
       request :create_image
       request :create_load_balancer
+      request :create_database_server
       request :create_server
       request :create_server_group
       request :delete_api_client
@@ -84,6 +91,8 @@ module Fog
       request :delete_firewall_rule
       request :delete_image
       request :delete_load_balancer
+      request :delete_database_server
+      request :delete_database_snapshot
       request :delete_server
       request :delete_server_group
       request :delete_user_collaboration
@@ -98,6 +107,9 @@ module Fog
       request :get_image
       request :get_interface
       request :get_load_balancer
+      request :get_database_server
+      request :get_database_snapshot
+      request :get_database_type
       request :get_scoped_account
       request :get_server
       request :get_server_group
@@ -113,6 +125,9 @@ module Fog
       request :list_firewall_policies
       request :list_images
       request :list_load_balancers
+      request :list_database_servers
+      request :list_database_snapshots
+      request :list_database_types
       request :list_server_groups
       request :list_server_types
       request :list_servers
@@ -128,11 +143,13 @@ module Fog
       request :resend_collaboration
       request :reset_ftp_password_account
       request :reset_ftp_password_scoped_account
+      request :reset_password_database_server
       request :reset_secret_api_client
       request :reset_secret_application
       request :resend_collaboration
       request :reject_user_collaboration
       request :shutdown_server
+      request :snapshot_database_server
       request :snapshot_server
       request :start_server
       request :stop_server
@@ -145,6 +162,8 @@ module Fog
       request :update_firewall_rule
       request :update_image
       request :update_load_balancer
+      request :update_database_server
+      request :update_database_snapshot
       request :update_scoped_account
       request :update_server
       request :update_server_group

--- a/lib/fog/brightbox/models/compute/cloud_ip.rb
+++ b/lib/fog/brightbox/models/compute/cloud_ip.rb
@@ -23,6 +23,7 @@ module Fog
         attribute :server_id, :aliases => "server", :squash => "id"
         attribute :load_balancer, :alias => "load_balancer", :squash => "id"
         attribute :server_group, :alias => "server_group", :squash => "id"
+        attribute :database_server, :alias => "database_server", :squash => "id"
         attribute :port_translators
         attribute :name
 
@@ -57,7 +58,7 @@ module Fog
         end
 
         def destination_id
-          server_id || load_balancer || server_group || interface_id
+          server_id || load_balancer || server_group || database_server || interface_id
         end
 
       end

--- a/lib/fog/brightbox/models/compute/database_server.rb
+++ b/lib/fog/brightbox/models/compute/database_server.rb
@@ -1,0 +1,91 @@
+require 'fog/core/model'
+
+module Fog
+  module Compute
+    class Brightbox
+      class DatabaseServer < Fog::Model
+        identity :id
+        attribute :url
+        attribute :resource_type
+
+        attribute :name
+        attribute :description
+        attribute :state, :aliases => "status"
+
+        attribute :admin_username
+        attribute :admin_password
+
+        attribute :database_engine
+        attribute :database_version
+
+        attribute :created_at, :type => :time
+        attribute :updated_at, :type => :time
+        attribute :deleted_at, :type => :time
+
+        attribute :allow_access
+
+        attribute :flavor_id, "alias" => "database_server_type", :squash => "id"
+        attribute :snapshot_id
+        attribute :zone_id, "alias" => "zone", :squash => "id"
+
+        attribute :cloud_ips
+
+        def save
+          options = {
+            :name => name,
+            :description => description
+          }
+
+          options[:allow_access] = allow_access if allow_access
+
+          if persisted?
+            data = update_database_server(options)
+          else
+            options[:snapshot] = snapshot_id if snapshot_id
+            options[:engine] = database_engine if database_engine
+            options[:version] = database_version if database_version
+            options[:database_type] = flavor_id if flavor_id
+            options[:zone] = zone_id if zone_id
+
+            data = create_database_server(options)
+          end
+
+          merge_attributes(data)
+          true
+        end
+
+        def ready?
+          state == "active"
+        end
+
+        def snapshot
+          requires :identity
+          merge_attributes(service.snapshot_database_server(identity))
+          true
+        end
+
+        def destroy
+          requires :identity
+          merge_attributes(service.destroy_database_server(identity))
+          true
+        end
+
+        def reset_password
+          requires :identity
+          merge_attributes(service.reset_password_database_server(identity))
+          true
+        end
+
+        private
+
+        def create_database_server(options)
+          service.create_database_server(options)
+        end
+
+        def update_database_server(options)
+          service.update_database_server(identity, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/models/compute/database_servers.rb
+++ b/lib/fog/brightbox/models/compute/database_servers.rb
@@ -1,0 +1,28 @@
+require 'fog/core/collection'
+require 'fog/brightbox/models/compute/database_server'
+
+module Fog
+  module Compute
+    class Brightbox
+
+      class DatabaseServers < Fog::Collection
+
+        model Fog::Compute::Brightbox::DatabaseServer
+
+        def all
+          data = service.list_database_servers
+          load(data)
+        end
+
+        def get(identifier)
+          data = service.get_database_server(identifier)
+          new(data)
+        rescue Excon::Errors::NotFound
+          nil
+        end
+
+      end
+
+    end
+  end
+end

--- a/lib/fog/brightbox/models/compute/database_snapshot.rb
+++ b/lib/fog/brightbox/models/compute/database_snapshot.rb
@@ -1,0 +1,52 @@
+require 'fog/core/model'
+
+module Fog
+  module Compute
+    class Brightbox
+      class DatabaseSnapshot < Fog::Model
+        identity :id
+        attribute :url
+        attribute :resource_type
+
+        attribute :name
+        attribute :description
+        attribute :state, :aliases => "status"
+
+        attribute :database_engine
+        attribute :database_version
+
+        attribute :size
+
+        attribute :created_at, :type => :time
+        attribute :updated_at, :type => :time
+        attribute :deleted_at, :type => :time
+
+        def save
+          options = {
+            :name => name,
+            :description => description
+          }
+          data = update_database_snapshot(options)
+          merge_attributes(data)
+          true
+        end
+
+        def ready?
+          state == "available"
+        end
+
+        def destroy
+          requires :identity
+          merge_attributes(service.destroy_database_snapshot(identity))
+          true
+        end
+
+        private
+
+        def update_database_snapshot(options)
+          service.update_database_snaphot(identity, options)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/models/compute/database_snapshots.rb
+++ b/lib/fog/brightbox/models/compute/database_snapshots.rb
@@ -1,0 +1,24 @@
+require 'fog/core/collection'
+require 'fog/brightbox/models/compute/database_snapshot'
+
+module Fog
+  module Compute
+    class Brightbox
+      class DatabaseSnapshots < Fog::Collection
+        model Fog::Compute::Brightbox::DatabaseSnapshot
+
+        def all
+          data = service.list_database_snapshots
+          load(data)
+        end
+
+        def get(identifier)
+          data = service.get_database_snapshot(identifier)
+          new(data)
+        rescue Excon::Errors::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/models/compute/database_type.rb
+++ b/lib/fog/brightbox/models/compute/database_type.rb
@@ -1,0 +1,19 @@
+require 'fog/core/model'
+
+module Fog
+  module Compute
+    class Brightbox
+      class DatabaseType < Fog::Model
+        identity :id
+        attribute :url
+        attribute :resource_type
+
+        attribute :name
+        attribute :description
+
+        attribute :disk, :aliases => "disk_size"
+        attribute :ram
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/models/compute/database_types.rb
+++ b/lib/fog/brightbox/models/compute/database_types.rb
@@ -1,0 +1,26 @@
+require 'fog/core/collection'
+require 'fog/brightbox/models/compute/database_type'
+
+module Fog
+  module Compute
+    class Brightbox
+
+      class DatabaseTypes < Fog::Collection
+
+        model Fog::Compute::Brightbox::DatabaseType
+
+        def all
+          data = service.list_database_types
+          load(data)
+        end
+
+        def get(identifier)
+          data = service.get_database_type(identifier)
+          new(data)
+        rescue Excon::Errors::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/create_database_server.rb
+++ b/lib/fog/brightbox/requests/compute/create_database_server.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # @param [Hash] options
+        # @option options [String] :name
+        # @option options [String] :description
+        # @option options [String] :version Database version to request
+        # @option options [Array] :allow_access ...
+        # @option options [String] :snapshot
+        # @option options [String] :zone
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        # @return [NilClass] if no options were passed
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_server_create_database_server
+        #
+        def create_database_server(options)
+          wrapped_request("post", "/1.0/database_servers", [202], options)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/delete_database_server.rb
+++ b/lib/fog/brightbox/requests/compute/delete_database_server.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # @param [String] identifier Unique reference to identify the resource
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_server_delete_database_server
+        #
+        def delete_database_server(identifier)
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("delete", "/1.0/database_servers/#{identifier}", [202])
+        end
+
+        # Old format of the delete request.
+        #
+        # @deprecated Use +#delete_database_server+ instead
+        #
+        def destroy_database_server(identifier)
+          delete_database_server(identifier)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/delete_database_snapshot.rb
+++ b/lib/fog/brightbox/requests/compute/delete_database_snapshot.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # @param [String] identifier Unique reference to identify the resource
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_snapshot_delete_database_snapshot
+        #
+        def delete_database_snapshot(identifier)
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("delete", "/1.0/database_snapshots/#{identifier}", [202])
+        end
+
+        # Old format of the delete request.
+        #
+        # @deprecated Use +#delete_database_snapshot+ instead
+        #
+        def destroy_database_snapshot(identifier)
+          delete_database_snapshot(identifier)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/get_database_server.rb
+++ b/lib/fog/brightbox/requests/compute/get_database_server.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # @param [String] identifier Unique reference to identify the resource
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_server_get_database_server
+        #
+        def get_database_server(identifier)
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("get", "/1.0/database_servers/#{identifier}", [200])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/get_database_snapshot.rb
+++ b/lib/fog/brightbox/requests/compute/get_database_snapshot.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # @param [String] identifier Unique reference to identify the resource
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_snapshot_get_database_snapshot
+        #
+        def get_database_snapshot(identifier)
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("get", "/1.0/database_snapshots/#{identifier}", [200])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/get_database_type.rb
+++ b/lib/fog/brightbox/requests/compute/get_database_type.rb
@@ -1,0 +1,21 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # Get details of the database server type.
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_type_get_database_type
+        #
+        def get_database_type(identifier)
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("get", "/1.0/database_types/#{identifier}", [200])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/list_database_servers.rb
+++ b/lib/fog/brightbox/requests/compute/list_database_servers.rb
@@ -1,0 +1,17 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_server_list_database_servers
+        #
+        def list_database_servers
+          wrapped_request("get", "/1.0/database_servers", [200])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/list_database_snapshots.rb
+++ b/lib/fog/brightbox/requests/compute/list_database_snapshots.rb
@@ -1,0 +1,17 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_snapshot_list_database_snapshots
+        #
+        def list_database_snapshots
+          wrapped_request("get", "/1.0/database_snapshots", [200])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/list_database_types.rb
+++ b/lib/fog/brightbox/requests/compute/list_database_types.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # List database server types.
+        #
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_type_list_database_types
+        #
+        def list_database_types
+          wrapped_request("get", "/1.0/database_types", [200])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/reset_password_database_server.rb
+++ b/lib/fog/brightbox/requests/compute/reset_password_database_server.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # @param [String] identifier Unique reference to identify the resource
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_server_reset_password_database_server
+        #
+        def reset_password_database_server(identifier)
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("post", "/1.0/database_servers/#{identifier}/reset_password", [202])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/snapshot_database_server.rb
+++ b/lib/fog/brightbox/requests/compute/snapshot_database_server.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # @param [String] identifier Unique reference to identify the resource
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_server_snapshot_database_server
+        #
+        def snapshot_database_server(identifier)
+          return nil if identifier.nil? || identifier == ""
+          wrapped_request("post", "/1.0/database_servers/#{identifier}/snapshot", [202])
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/update_database_server.rb
+++ b/lib/fog/brightbox/requests/compute/update_database_server.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [String] :name
+        # @option options [String] :description
+        # @option options [Array] :allow_access ...
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        # @return [NilClass] if no options were passed
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_server_update_database_server
+        #
+        def update_database_server(identifier, options)
+          return nil if identifier.nil? || identifier == ""
+          return nil if options.empty? || options.nil?
+          wrapped_request("put", "/1.0/database_servers/#{identifier}", [200], options)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/brightbox/requests/compute/update_database_snapshot.rb
+++ b/lib/fog/brightbox/requests/compute/update_database_snapshot.rb
@@ -1,0 +1,26 @@
+module Fog
+  module Compute
+    class Brightbox
+      class Real
+        # Update some details of the server.
+        #
+        # @param [String] identifier Unique reference to identify the resource
+        # @param [Hash] options
+        # @option options [String] :name Editable label
+        # @option options [String] :description Editable label
+        #
+        # @return [Hash] if successful Hash version of JSON object
+        # @return [NilClass] if no options were passed
+        #
+        # @see https://api.gb1.brightbox.com/1.0/#database_snapshot_update_database_snapshot
+        #
+        def update_database_snapshot(identifier, options)
+          return nil if identifier.nil? || identifier == ""
+          return nil if options.empty? || options.nil?
+          wrapped_request("put", "/1.0/database_snapshots/#{identifier}", [200], options)
+        end
+
+      end
+    end
+  end
+end

--- a/tests/brightbox/compute/schema.rb
+++ b/tests/brightbox/compute/schema.rb
@@ -99,6 +99,43 @@ class Brightbox
           "reverse_dns"     => String
         }
 
+        DATABASE_SERVER = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "name"            => String,
+          "description"     => String,
+          "allow_access"    => Array,
+          "database_version" => String,
+          "status"          => String,
+          "created_at"      => String,
+          "deleted_at"      => Fog::Nullable::String
+        }
+
+        DATABASE_SNAPSHOT = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "name"            => String,
+          "description"     => String,
+          "database_version" => String,
+          "size"            => Integer,
+          "status"          => String,
+          "created_at"      => String,
+          "deleted_at"      => Fog::Nullable::String,
+          "account"         => Brightbox::Compute::Formats::Nested::ACCOUNT
+        }
+
+        DATABASE_SERVER_TYPE = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "name"            => String,
+          "description"     => String,
+          "ram"             => Integer,
+          "disk_size"       => Integer
+        }
+
         FIREWALL_POLICY = {
           "id"              => String,
           "resource_type"   => String,
@@ -288,6 +325,43 @@ class Brightbox
           "load_balancer"   => Fog::Brightbox::Nullable::LoadBalancer,
           "server"          => Fog::Brightbox::Nullable::Server,
           "server_group"     => Fog::Brightbox::Nullable::ServerGroup
+        }
+
+        DATABASE_SERVER = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "name"            => String,
+          "description"     => String,
+          "allow_access"    => Array,
+          "database_version" => String,
+          "status"          => String,
+          "created_at"      => String,
+          "deleted_at"      => Fog::Nullable::String
+        }
+
+        DATABASE_SNAPSHOT = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "name"            => String,
+          "description"     => String,
+          "database_version" => String,
+          "size"            => Integer,
+          "status"          => String,
+          "created_at"      => String,
+          "deleted_at"      => Fog::Nullable::String,
+          "account"         => Brightbox::Compute::Formats::Nested::ACCOUNT
+        }
+
+        DATABASE_SERVER_TYPE = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "name"            => String,
+          "description"     => String,
+          "ram"             => Integer,
+          "disk_size"       => Integer
         }
 
         FIREWALL_POLICY = {
@@ -498,6 +572,45 @@ class Brightbox
           "server_group"    => Fog::Brightbox::Nullable::ServerGroup
         }
 
+        DATABASE_SERVER = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "name"            => String,
+          "description"     => String,
+          "admin_username"  => Fog::Nullable::String,
+          "admin_password"  => Fog::Nullable::String,
+          "allow_access"    => Array,
+          "database_version" => String,
+          "status"          => String,
+          "created_at"      => String,
+          "deleted_at"      => Fog::Nullable::String
+        }
+
+        DATABASE_SNAPSHOT = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "name"            => String,
+          "description"     => String,
+          "database_version" => String,
+          "size"            => Integer,
+          "status"          => String,
+          "created_at"      => String,
+          "deleted_at"      => Fog::Nullable::String,
+          "account"         => Brightbox::Compute::Formats::Nested::ACCOUNT
+        }
+
+        DATABASE_SERVER_TYPE = {
+          "id"              => String,
+          "resource_type"   => String,
+          "url"             => String,
+          "name"            => String,
+          "description"     => String,
+          "ram"             => Integer,
+          "disk_size"       => Integer
+        }
+
         FIREWALL_POLICY = {
           "id"              => String,
           "resource_type"   => String,
@@ -670,6 +783,9 @@ class Brightbox
         APPLICATION = [Brightbox::Compute::Formats::Collected::APPLICATION]
         CLOUD_IPS = [Brightbox::Compute::Formats::Collected::CLOUD_IP]
         COLLABORATIONS = [Brightbox::Compute::Formats::Collected::COLLABORATION]
+        DATABASE_SERVERS = [Brightbox::Compute::Formats::Collected::DATABASE_SERVER]
+        DATABASE_SERVER_TYPES = [Brightbox::Compute::Formats::Collected::DATABASE_SERVER_TYPE]
+        DATABASE_SNAPSHOTS = [Brightbox::Compute::Formats::Collected::DATABASE_SNAPSHOT]
         FIREWALL_POLICIES = [Brightbox::Compute::Formats::Collected::FIREWALL_POLICY]
         IMAGES = [Brightbox::Compute::Formats::Collected::IMAGE]
         LOAD_BALANCERS = [Brightbox::Compute::Formats::Collected::LOAD_BALANCER]

--- a/tests/brightbox/helper.rb
+++ b/tests/brightbox/helper.rb
@@ -1,0 +1,1 @@
+Excon.defaults[:ssl_verify_peer] = false

--- a/tests/brightbox/models/compute/database_server_tests.rb
+++ b/tests/brightbox/models/compute/database_server_tests.rb
@@ -1,0 +1,66 @@
+Shindo.tests("Fog::Compute[:brightbox] | DatabaseServer model", ["brightbox"]) do
+  pending if Fog.mocking?
+
+  @service = Fog::Compute[:brightbox]
+
+  tests("success") do
+    tests("#create") do
+      test("a new database server is returned") do
+        @database_server = @service.database_servers.create
+        !@database_server.nil?
+      end
+
+      test("state is not nil") do
+        !@database_server.state.nil?
+      end
+
+      test("database_version is not nil") do
+        !@database_server.database_version.nil?
+      end
+
+      test("admin_username is not nil") do
+        !@database_server.admin_username.nil?
+      end
+
+      test("admin_password is not nil") do
+        !@database_server.admin_password.nil?
+      end
+    end
+
+    @sample_identifier = @database_server.id
+    pending if @sample_identifier.nil?
+
+    tests("#all") do
+      test("returns results") do
+        @database_servers = @service.database_servers.all
+        @database_servers.any? do |dbs|
+          dbs.identity == @database_server.identity
+        end
+      end
+    end
+
+    tests("#get('#{@sample_identifier}')") do
+      @database_server = @service.database_servers.get(@sample_identifier)
+
+      @database_server.wait_for { ready? }
+
+      test("admin_username is not nil") do
+        !@database_server.admin_username.nil?
+      end
+
+      test("admin_password is nil") do
+        @database_server.admin_password.nil?
+      end
+    end
+
+    @database_server.wait_for { ready? }
+
+    test("#snapshot") do
+      @database_server.snapshot
+    end
+
+    tests("#destroy") do
+      @database_server.destroy
+    end
+  end
+end

--- a/tests/brightbox/models/compute/database_snapshot_tests.rb
+++ b/tests/brightbox/models/compute/database_snapshot_tests.rb
@@ -1,0 +1,26 @@
+Shindo.tests("Fog::Compute[:brightbox] | DatabaseSnapshot model", ["brightbox"]) do
+  pending if Fog.mocking?
+
+  @service = Fog::Compute[:brightbox]
+
+  tests("success") do
+    tests("#all") do
+      test("returns results") do
+        @database_snapshots = @service.database_snapshots.all
+        !@database_snapshots.empty?
+      end
+    end
+
+    pending if @database_snapshots.empty?
+    @sample_identifier = @database_snapshots.first.identity
+    tests("#get('#{@sample_identifier}')") do
+      @database_snapshot = @service.database_snapshots.get(@sample_identifier)
+    end
+
+    # @database_snapshot.wait_for { ready? }
+
+    # tests("#destroy") do
+    #   @database_snapshot.destroy
+    # end
+  end
+end

--- a/tests/brightbox/models/compute/database_type_tests.rb
+++ b/tests/brightbox/models/compute/database_type_tests.rb
@@ -1,0 +1,27 @@
+Shindo.tests("Fog::Compute[:brightbox] | DatabaseType model", ["brightbox"]) do
+  pending if Fog.mocking?
+
+  @service = Fog::Compute[:brightbox]
+
+  tests("success") do
+    tests("#all") do
+      @database_types = @service.database_types.all
+      test("returns results") { !@database_types.empty? }
+    end
+
+    @sample_identifier = @database_types.first.id
+    pending if @sample_identifier.nil?
+
+    tests("#get(#{@sample_identifier})") do
+      @database_type = @service.database_types.get(@sample_identifier)
+
+      test("disk is not nil") do
+        !@database_type.disk.nil?
+      end
+
+      test("ram is not nil") do
+        !@database_type.ram.nil?
+      end
+    end
+  end
+end

--- a/tests/brightbox/requests/compute/database_server_tests.rb
+++ b/tests/brightbox/requests/compute/database_server_tests.rb
@@ -1,0 +1,54 @@
+Shindo.tests('Fog::Compute[:brightbox] | database server requests', ['brightbox']) do
+  pending if Fog.mocking?
+
+  tests('success') do
+
+    create_options = {}
+    tests("#create_database_server(#{create_options.inspect})") do
+      result = Fog::Compute[:brightbox].create_database_server(create_options)
+      @database_server_id = result["id"]
+      data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SERVER, {:allow_extra_keys => true}) { result }
+    end
+
+    tests("#list_database_servers") do
+      result = Fog::Compute[:brightbox].list_database_servers
+      data_matches_schema(Brightbox::Compute::Formats::Collection::DATABASE_SERVERS, {:allow_extra_keys => true}) { result }
+    end
+
+    tests("#get_database_server('#{@database_server_id}')") do
+      result = Fog::Compute[:brightbox].get_database_server(@database_server_id)
+      data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SERVER, {:allow_extra_keys => true}) { result }
+    end
+
+    update_options = {
+      :name => "New name"
+    }
+    tests("#update_database_server('#{@database_server_id}', update_options)") do
+      result = Fog::Compute[:brightbox].update_database_server(@database_server_id, update_options)
+      data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SERVER, {:allow_extra_keys => true}) { result }
+    end
+
+    tests("#reset_password_database_server('#{@database_server_id}')") do
+      result = Fog::Compute[:brightbox].reset_password_database_server(@database_server_id)
+      data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SERVER, {:allow_extra_keys => true}) { result }
+      test("new password is visible") { ! result["admin_password"].nil? }
+    end
+
+    Fog::Compute[:brightbox].database_servers.get(@database_server_id).wait_for { ready? }
+
+    tests("#destroy_database_server('#{@database_server_id}')") do
+      result = Fog::Compute[:brightbox].destroy_database_server(@database_server_id)
+      data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SERVER, {:allow_extra_keys => true}) { result }
+    end
+  end
+
+  tests('failure') do
+    tests("create_database_server").raises(ArgumentError) do
+      Fog::Compute[:brightbox].create_database_server
+    end
+
+    tests("get_database_server").raises(Excon::Errors::NotFound) do
+      Fog::Compute[:brightbox].get_database_server("dbs-00000")
+    end
+  end
+end

--- a/tests/brightbox/requests/compute/database_snapsnot_tests.rb
+++ b/tests/brightbox/requests/compute/database_snapsnot_tests.rb
@@ -1,0 +1,47 @@
+Shindo.tests('Fog::Compute[:brightbox] | database snapshot requests', ['brightbox']) do
+  pending if Fog.mocking?
+
+  service = Fog::Compute[:brightbox]
+
+  tests('success') do
+
+    # Create a Database Server, then snapshot it
+    database_server = service.database_servers.create
+    database_server.wait_for { ready? }
+
+    result = service.snapshot_database_server(database_server.id)
+    database_server.destroy
+
+    tests("#list_database_snapshots") do
+      result = service.list_database_snapshots
+      data_matches_schema(Brightbox::Compute::Formats::Collection::DATABASE_SNAPSHOTS, {:allow_extra_keys => true}) { result }
+      @database_snapshot_id = result.first["id"]
+    end
+
+    tests("#get_database_snapshot('#{@database_snapshot_id}')") do
+      result = service.get_database_snapshot(@database_snapshot_id)
+      data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SNAPSHOT, {:allow_extra_keys => true}) { result }
+    end
+
+    update_options = {
+      :name => "New name"
+    }
+    tests("#update_database_snapshot('#{@database_snapshot_id}', update_options)") do
+      result = service.update_database_snapshot(@database_snapshot_id, update_options)
+      data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SNAPSHOT, {:allow_extra_keys => true}) { result }
+    end
+
+    service.database_snapshots.get(@database_snapshot_id).wait_for { ready? }
+
+    tests("#destroy_database_snapshot('#{@database_snapshot_id}')") do
+      result = service.destroy_database_snapshot(@database_snapshot_id)
+      data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SNAPSHOT, {:allow_extra_keys => true}) { result }
+    end
+  end
+
+  tests('failure') do
+    tests("get_database_snapshot").raises(Excon::Errors::NotFound) do
+      service.get_database_snapshot("dbs-00000")
+    end
+  end
+end

--- a/tests/brightbox/requests/compute/database_type_tests.rb
+++ b/tests/brightbox/requests/compute/database_type_tests.rb
@@ -1,0 +1,17 @@
+Shindo.tests('Fog::Compute[:brightbox] | database type requests', ['brightbox']) do
+
+  tests('success') do
+    tests("#list_database_types") do
+      pending if Fog.mocking?
+      result = Fog::Compute[:brightbox].list_database_types
+      data_matches_schema(Brightbox::Compute::Formats::Collection::DATABASE_SERVER_TYPES, {:allow_extra_keys => true}) { result }
+    end
+  end
+
+  tests('failure') do
+    tests("#get_database_type").raises(Excon::Errors::NotFound) do
+      pending if Fog.mocking?
+      Fog::Compute[:brightbox].get_database_type("dbt-00000")
+    end
+  end
+end


### PR DESCRIPTION
This adds support for Brightbox's Cloud SQL DBaaS.

It is currently still part of the Compute service so all resources can
be managed from one connection to the service.
