### PR TITLE
AWS RDS - enhancements to IOPS support

### DIFF
--- a/lib/fog/aws/parsers/rds/db_parser.rb
+++ b/lib/fog/aws/parsers/rds/db_parser.rb
@@ -100,6 +100,12 @@ module Fog
               @vpc_security_group = {}
             when 'VpcSecurityGroupId'
               @vpc_security_group[name] = value
+            when 'Iops'
+              if @in_pending_modified_values
+                @pending_modified_values[name] = value.to_i
+              else
+                @db_instance[name] = value.to_i
+              end
             when 'AllocatedStorage'
               if @in_pending_modified_values
                 @pending_modified_values[name] = value.to_i

--- a/lib/fog/aws/parsers/rds/snapshot_parser.rb
+++ b/lib/fog/aws/parsers/rds/snapshot_parser.rb
@@ -27,6 +27,7 @@ module Fog
             when 'Engine' then @db_snapshot['Engine'] = value
             when 'EngineVersion' then @db_snapshot['EngineVersion'] = value
             when 'InstanceCreateTime' then @db_snapshot['InstanceCreateTime'] = Time.parse value
+            when 'Iops' then @db_snapshot['Iops'] = value
             when 'MasterUsername' then @db_snapshot['MasterUsername'] = value
             when 'Port' then @db_snapshot['Port'] = value.to_i
             when 'SnapshotCreateTime' then @db_snapshot['SnapshotCreateTime'] = Time.parse value

--- a/lib/fog/aws/requests/rds/create_db_instance.rb
+++ b/lib/fog/aws/requests/rds/create_db_instance.rb
@@ -18,6 +18,7 @@ module Fog
         # @param DBSecurityGroups [Array] A list of DB Security Groups to authorize on this DB Instance
         # @param Engine [String] The name of the database engine to be used for this instance.
         # @param EngineVersion [String] The version number of the database engine to use.
+        # @param Iops [Integer] IOPS rate
         # @param MasterUsername [String] The db master user
         # @param MasterUserPassword [String] The new password for the DB Instance master user
         # @param MultiAZ [Boolean] Specifies if the DB Instance is a Multi-AZ deployment
@@ -98,6 +99,7 @@ module Fog
                  "DBInstanceStatus"=>"creating",
                  "BackupRetentionPeriod"=> options["BackupRetentionPeriod"] || 1,
                  "AllocatedStorage"=> options["AllocatedStorage"],
+                 "Iops" => options["Iops"],
                  "DBParameterGroups"=> # I think groups should be in the self.data method
                           [{"DBParameterGroupName"=>"default.mysql5.5",
                             "ParameterApplyStatus"=>"in-sync"}],

--- a/lib/fog/aws/requests/rds/create_db_instance_read_replica.rb
+++ b/lib/fog/aws/requests/rds/create_db_instance_read_replica.rb
@@ -51,6 +51,7 @@ module Fog
             'Engine' => source['Engine'],
             'EngineVersion' => options['EngineVersion'] || '5.5.12',
             'InstanceCreateTime' => nil,
+            'Iops' => source['Iops'],
             'LatestRestorableTime' => nil,
             'LicenseModel' => 'general-public-license',
             'MasterUsername' => source['MasterUsername'],

--- a/lib/fog/aws/requests/rds/create_db_snapshot.rb
+++ b/lib/fog/aws/requests/rds/create_db_snapshot.rb
@@ -47,7 +47,7 @@ module Fog
             'InstanceCreateTime'   => Time.now
           }
           # Copy attributes from server
-          %w(Engine EngineVersion AvailabilityZone AllocatedStorage MasterUsername InstanceCreateTime).each do |key|
+          %w(Engine EngineVersion AvailabilityZone AllocatedStorage Iops MasterUsername InstanceCreateTime).each do |key|
             snapshot_data[key] = server_data[key]
           end
           snapshot_data['Port'] = server_data['Endpoint']['Port']

--- a/lib/fog/aws/requests/rds/modify_db_instance.rb
+++ b/lib/fog/aws/requests/rds/modify_db_instance.rb
@@ -19,6 +19,7 @@ module Fog
         # * DBParameterGroupName <~String> The name of the DB Parameter Group to apply to this DB Instance  
         # * DBSecurityGroups <~Array> A list of DB Security Groups to authorize on this DB Instance 
         # * EngineVersion <~String> The version number of the database engine to upgrade to.
+        # * Iops <~Integer> IOPS rate
         # * MasterUserPassword  <~String> The new password for the DB Instance master user
         # * MultiAZ <~Boolean> Specifies if the DB Instance is a Multi-AZ deployment
         # * PreferredBackupWindow <~String> The daily time range during which automated backups are created if automated backups are enabled


### PR DESCRIPTION
Some fixes for missing features of Iops. E.g. Iops value was not returned from describe_db_instances or the pending value hash. It should also be available to snapshots.
