### PR TITLE
[libvirt|compute] Allow volumes to have backing volumes

### DIFF
--- a/lib/fog/libvirt/models/compute/templates/volume.xml.erb
+++ b/lib/fog/libvirt/models/compute/templates/volume.xml.erb
@@ -11,4 +11,16 @@
             <label>virt_image_t</label>
           </permissions>
         </target>
+        <% if backing_volume -%>
+        <backingStore>
+          <path><%= backing_volume.path %></path>
+          <format type="<%= backing_volume.format_type %>"/>
+          <permissions>
+            <owner>0</owner>
+            <group>0</group>
+            <mode>0744</mode>
+            <label>virt_image_t</label>
+          </permissions>
+        </backingStore>
+        <% end -%>
 </volume>

--- a/lib/fog/libvirt/models/compute/volume.rb
+++ b/lib/fog/libvirt/models/compute/volume.rb
@@ -19,6 +19,7 @@ module Fog
         attribute :capacity
         attribute :allocation
         attribute :format_type
+        attribute :backing_volume
 
         # Can be created by passing in :xml => "<xml to create volume>"
         # A volume always belongs to a pool, :pool_name => "<name of pool>"


### PR DESCRIPTION
Useful for qcow2 volumes, so you can do COW layering of disks.

http://libvirt.org/formatstorage.html#StorageVolBacking
