### PR TITLE
Use endpoint, port, and path_style options in AWS storage Mock

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -363,9 +363,18 @@ module Fog
         def initialize(options={})
           @use_iam_profile = options[:use_iam_profile]
           setup_credentials(options)
-          @region = options[:region] || DEFAULT_REGION
-          @host   = options[:host]   || region_to_host(@region)
-          @scheme = options[:scheme] || DEFAULT_SCHEME
+          if @endpoint = options[:endpoint]
+            endpoint = URI.parse(@endpoint)
+            @host = endpoint.host
+            @scheme = endpoint.scheme
+            @port = endpoint.port
+          else
+            @region     = options[:region]      || DEFAULT_REGION
+            @host       = options[:host]        || region_to_host(@region)
+            @scheme     = options[:scheme]      || DEFAULT_SCHEME
+            @port       = options[:port]        || DEFAULT_SCHEME_PORT[@scheme]
+          end
+          @path_style = options[:path_style] || false
         end
 
         def data


### PR DESCRIPTION
Our tests were assuming these options were used, but when mocking they were not. So we are using the same initialization code that the Real class uses.
