### PR TITLE
[vsphere] return cloned vm object by default

### DIFF
--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -129,8 +129,8 @@ module Fog
           req_options = options.inject({}) { |hsh, (k,v)| hsh[k.to_s] = v; hsh }
 
           # Give our path to the request
-          req_options['template_path'] ="#{relative_path}/#{name}"
-          req_options['datacenter'] = "#{datacenter}"
+          req_options['template_path'] ||= "#{relative_path}/#{name}"
+          req_options['datacenter'] ||= "#{datacenter}"
 
           # Perform the actual clone
           clone_results = service.vm_clone(req_options)

--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -265,11 +265,10 @@ module Fog
             end
           end
 
-          # Return hash
           {
-            'vm_ref'        => new_vm ? new_vm._ref : nil,
-            'new_vm'        => new_vm ? get_virtual_machine("#{options['dest_folder']}/#{options['name']}", options['datacenter']) : nil,
-            'task_ref'      => task._ref
+            'vm_ref'   => new_vm ? new_vm._ref : nil,
+            'new_vm'   => new_vm ? get_virtual_machine(new_vm.config.instanceUuid) : nil,
+            'task_ref' => task._ref
           }
         end
 


### PR DESCRIPTION
Using the instance id for finding vm and keeping template path if given in options.

Finding by name never seemed to work for me, this fixes that.

@nirvdrum are you the person to look at this?

I made this change for a PR on foreman https://github.com/theforeman/foreman/pull/1183
