### PR TITLE
[openstack|compute] Allow to use Symbol when specifying the hash of NICs

### DIFF
--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -47,9 +47,9 @@ module Fog
           if options['nics']
             data['server']['networks'] =
             Array(options['nics']).map do |nic|
-              neti = { 'uuid' => nic['net_id'] }
-              neti['fixed_ip'] = nic['v4_fixed_ip'] unless nic['v4_fixed_ip'].nil?
-              neti['port'] = nic['port_id'] unless nic['port_id'].nil?
+              neti = { 'uuid' => (nic['net_id'] || nic[:net_id]) }
+              neti['fixed_ip'] = (nic['v4_fixed_ip'] || nic[:v4_fixed_ip]) unless (nic['v4_fixed_ip'] || nic[:v4_fixed_ip]).nil?
+              neti['port'] = (nic['port_id'] || nic[:port_id]) unless (nic['port_id'] || nic[:port_id]).nil?
               neti
             end
           end


### PR DESCRIPTION
When use VM with NICs that was introduce in #1669, at this time the key of hash can only use String.
This commit allows to use Symbol as the key of hash.
For example, it is useful when generate hash from yaml.
