### PR TITLE
support rackspace storage delete_at and delete_after headers

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -353,6 +353,7 @@
 * Mark Phillips <mark.phillips2@bskyb.com>
 * Mark Rushakoff <mark.rushakoff@gmail.com>
 * Mark Turner <mark@amerine.net>
+* Marshall Yount <marshall@yountlabs.com>
 * Martin Emde <martin.emde@gmail.com>
 * Martin Englund <martin@englund.nu>
 * Martin Matuska <martin@matuska.org>

--- a/lib/fog/rackspace/models/storage/file.rb
+++ b/lib/fog/rackspace/models/storage/file.rb
@@ -47,6 +47,18 @@ module Fog
         # @see http://docs.rackspace.com/files/api/v1/cf-devguide/content/Enabling_File_Compression_with_the_Content-Encoding_Header-d1e2198.html
         attribute :content_encoding, :aliases => 'Content-Encoding'
 
+        # @!attribute [rw] delete_at
+        # A Unix Epoch Timestamp, in integer form, representing the time when this object will be automatically deleted.
+        # @return [Integer] the unix epoch timestamp of when this object will be automatically deleted
+        # @see http://docs.rackspace.com/files/api/v1/cf-devguide/content/Expiring_Objects-e1e3228.html
+        attribute :delete_at, :aliases => ['X-Delete-At']
+
+        # @!attribute [rw] delete_after
+        # A number of seconds representing how long from now this object will be automatically deleted.
+        # @return [Integer] the number of seconds until this object will be automatically deleted
+        # @see http://docs.rackspace.com/files/api/v1/cf-devguide/content/Expiring_Objects-e1e3228.html
+        attribute :delete_after, :aliases => ['X-Delete-After']
+
         # @!attribute [r] directory
         # @return [Fog::Storage::Rackspace::Directory] directory containing file
         attr_accessor :directory
@@ -254,6 +266,8 @@ module Fog
           options['Content-Disposition'] = content_disposition if content_disposition
           options['Etag'] = etag if etag
           options['Content-Encoding'] = content_encoding if content_encoding
+          options['X-Delete-At'] = delete_at if delete_at
+          options['X-Delete-After'] = delete_after if delete_after
           options.merge!(metadata.to_headers)
 
           data = service.put_object(directory.key, key, body, options)

--- a/tests/rackspace/models/storage/file_tests.rb
+++ b/tests/rackspace/models/storage/file_tests.rb
@@ -278,6 +278,55 @@ Shindo.tests('Fog::Rackspace::Storage | file', ['rackspace']) do
 
     end
 
+    tests("#delete_at") do
+      tests("#delete_at should default to nil").returns(nil) do
+        @instance.delete_at
+      end
+
+      @instance.delete_at = 1
+      @instance.save
+      tests("#delete_at should return delete_at attribute").returns(1) do
+        @instance.delete_at
+      end
+
+      @instance.delete_at = 1
+      @instance.save
+      tests("#delete_at= should update delete_at").returns(2) do
+        @instance.delete_at = 2
+        @instance.save
+        @instance.delete_at
+      end
+
+      tests("#delete_at= should not blow up on nil") do
+        @instance.delete_at = nil
+        @instance.save
+      end
+    end
+
+    tests("#delete_after") do
+      tests("#delete_after should default to nil").returns(nil) do
+        @instance.delete_after
+      end
+
+      @instance.delete_after = 1
+      @instance.save
+      tests("#delete_after should return delete_after attribute").returns(1) do
+        @instance.delete_after
+      end
+
+      @instance.delete_after = 1
+      @instance.save
+      tests("#delete_after= should update delete_after").returns(2) do
+        @instance.delete_after = 2
+        @instance.save
+        @instance.delete_after
+      end
+
+      tests("#delete_after= should not blow up on nil") do
+        @instance.delete_after = nil
+        @instance.save
+      end
+    end
   end
 
 


### PR DESCRIPTION
Rackspace Cloud Files allows the caller to set a time in the future
after which the uploaded asset will be automatically deleted.

http://docs.rackspace.com/files/api/v1/cf-devguide/content/Storage_Object_Services-d1e4300.html

This commit adds `deleted_at` and `deleted_after` attributes to the
`rackspace/models/storage/file.rb`. They are then added to the HTTP
headers when requested.

Thanks to @smashwilson for a lot of help with this
