### PR TITLE
Allow filter options to be passed to Storage::AWS::File#each

### DIFF
--- a/lib/fog/aws/models/storage/files.rb
+++ b/lib/fog/aws/models/storage/files.rb
@@ -42,15 +42,16 @@ module Fog
         end
 
         alias :each_file_this_page :each
-        def each
+        def each(options = nil)
           if !block_given?
             self
           else
-            subset = dup.all
+            subset = dup.all(options)
 
             subset.each_file_this_page {|f| yield f}
             while subset.is_truncated
-              subset = subset.all(:marker => subset.last.key)
+              options.merge!(:marker => subset.last.key) if options
+              subset = subset.all(options)
               subset.each_file_this_page {|f| yield f}
             end
 


### PR DESCRIPTION
This is a very small pull request that allows for specifying the same options you can pass to `File#all` to `File#each` as well. 

I personally needed it to be able to paginate through more than 1,000 objects on S3 with a prefix option set. 

If you think you may be interested in accepting this I can look into adding test coverage for it.
