### PR TITLE
Allow for Blue Box blocks to be created with IPv6 addresses only

### DIFF
--- a/lib/fog/bluebox/models/compute/server.rb
+++ b/lib/fog/bluebox/models/compute/server.rb
@@ -92,7 +92,7 @@ module Fog
 
           options['username'] = username
           options['hostname'] = hostname if @hostname
-          options['ipv6_only'] = ipv6_only if @ipv6_only
+          options['ipv6_only'] = ipv6_only if ipv6_only
           data = service.create_block(flavor_id, image_id, location_id, options)
           merge_attributes(data.body)
           true

--- a/lib/fog/bluebox/requests/compute/create_block.rb
+++ b/lib/fog/bluebox/requests/compute/create_block.rb
@@ -30,6 +30,8 @@ module Fog
             'location' => location_id
           }
 
+          query['ipv6_only'] = options.delete('ipv6_only') if options['ipv6_only']
+
           request(
             :expects  => 200,
             :method   => 'POST',


### PR DESCRIPTION
The Blue Box API allows for this, and we use it for Travis CI.

Merging in this PR would mean we could drop using our fork, which was meant as a stop gap.
