### PR TITLE
Fix Joyent service declarations

### DIFF
--- a/lib/fog/joyent.rb
+++ b/lib/fog/joyent.rb
@@ -6,8 +6,8 @@ module Fog
   module Joyent
     extend Fog::Provider
 
-    service(:analytics, 'joyent/analytics', 'Analytics')
-    service(:compute, 'joyent/compute', 'Compute')
+    service(:analytics, 'Analytics')
+    service(:compute, 'Compute')
 
   end
 end


### PR DESCRIPTION
When the Joyent provider was merged in it was after a reworking of how
requires and services were declared.

This meant the call to `service` was no longer correct.

This updates the signature and the mocked tests now pass (locally at
least) however the structuring and placement of the files may not be
inconsistent with the results of [GH-1712]
