### PR TITLE
[vsphere] fix broken detection of existing network interface type

### DIFF
--- a/lib/fog/vsphere/models/compute/interface.rb
+++ b/lib/fog/vsphere/models/compute/interface.rb
@@ -22,8 +22,10 @@ module Fog
           # Assign server first to prevent race condition with persisted?
           self.server_id = attributes.delete(:server_id)
 
-          if attributes.has_key? :type and attributes[:type].is_a? String then
-            attributes[:type] = Fog.class_from_string(attributes[:type], "RbVmomi::VIM")
+          if attributes.has_key? :type then
+            if attributes[:type].is_a? String then
+              attributes[:type] = Fog.class_from_string(attributes[:type], "RbVmomi::VIM")
+            end
           else
             attributes[:type] = Fog.class_from_string("VirtualE1000", "RbVmomi::VIM")
           end


### PR DESCRIPTION
Commit 035129e40f1b05b12427fa7ea2fbcfd2cd5d42d4 has broken the detection of existing network interface type by overwriting a supplied Class with the VirtualE1000 class.
