### PR TITLE
[Brightbox] Replace use of Fog::Connection

### DIFF
--- a/lib/fog/brightbox/compute/shared.rb
+++ b/lib/fog/brightbox/compute/shared.rb
@@ -33,9 +33,9 @@ module Fog
         # @option options [String] :brightbox_account
         #   Account identifier to scope this connection to
         # @option options [String] :connection_options
-        #   Settings to pass to underlying {Fog::Connection}
+        #   Settings to pass to underlying {Fog::Core::Connection}
         # @option options [Boolean] :persistent
-        #   Sets a persistent HTTP {Fog::Connection}
+        #   Sets a persistent HTTP {Fog::Core::Connection}
         # @option options [String] :brightbox_access_token
         #   Sets the OAuth access token to use rather than requesting a new token
         # @option options [String] :brightbox_refresh_token
@@ -46,12 +46,12 @@ module Fog
         def initialize(options)
           # Currently authentication and api endpoints are the same but may change
           @auth_url            = options[:brightbox_auth_url]  || Fog.credentials[:brightbox_auth_url] || API_URL
-          @auth_connection     = Fog::Connection.new(@auth_url)
+          @auth_connection     = Fog::Core::Connection.new(@auth_url)
 
           @api_url             = options[:brightbox_api_url]   || Fog.credentials[:brightbox_api_url]  || API_URL
           @connection_options  = options[:connection_options]  || {}
           @persistent          = options[:persistent]          || false
-          @connection          = Fog::Connection.new(@api_url, @persistent, @connection_options)
+          @connection          = Fog::Core::Connection.new(@api_url, @persistent, @connection_options)
 
           # Authentication options
           client_id            = options[:brightbox_client_id] || Fog.credentials[:brightbox_client_id]

--- a/lib/fog/brightbox/oauth2.rb
+++ b/lib/fog/brightbox/oauth2.rb
@@ -8,7 +8,7 @@ module Fog::Brightbox::OAuth2
   # This builds the simplest form of requesting an access token
   # based on the arguments passed in
   #
-  # @param [Fog::Connection] connection
+  # @param [Fog::Core::Connection] connection
   # @param [CredentialSet] credentials
   #
   # @return [Excon::Response]


### PR DESCRIPTION
`Fog::Connection` is a wrapper around XML parsing behaviour which is no
longer in `fog-core` but will be moved to `fog-xml`

So should be using `Fog::Core::Connection` for the simpler behaviour.
