### PR TITLE
Fixing [excon][WARNING] Invalid Excon request keys log noise when trying...

### DIFF
--- a/lib/fog/aws/sts.rb
+++ b/lib/fog/aws/sts.rb
@@ -123,7 +123,6 @@ module Fog
               :expects    => 200,
               :idempotent => idempotent,
               :headers    => { 'Content-Type' => 'application/x-www-form-urlencoded' },
-              :host       => @host,
               :method     => 'POST',
               :parser     => parser
             })


### PR DESCRIPTION
Currently when trying to use assume_role, fog generates the following noisy warning.  It doesn't affect the operation of the request, but does clog up the output.

```
[excon][WARNING] Invalid Excon request keys: :host
/Library/Ruby/Gems/2.0.0/gems/excon-0.31.0/lib/excon/connection.rb:389:in `validate_params'
/Library/Ruby/Gems/2.0.0/gems/excon-0.31.0/lib/excon/connection.rb:225:in `request'
/Library/Ruby/Gems/2.0.0/gems/fog-1.20.0/lib/fog/xml/sax_parser_connection.rb:36:in `request'
/Library/Ruby/Gems/2.0.0/gems/fog-1.20.0/lib/fog/core/deprecated/connection.rb:18:in `request'
/Library/Ruby/Gems/2.0.0/gems/fog-1.20.0/lib/fog/aws/sts.rb:121:in `request'
/Library/Ruby/Gems/2.0.0/gems/fog-1.20.0/lib/fog/aws/requests/sts/assume_role.rb:31:in `assume_role'
```
