### PR TITLE
[core] Use fog-core v1.21.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,4 @@ group :development, :test do
   gem 'coveralls', :require => false
 end
 
-gem "fog-core", :github => "fog/fog-core", :branch => "master"
 gemspec

--- a/Gemfile.1.8.7
+++ b/Gemfile.1.8.7
@@ -8,5 +8,4 @@ group :development, :test do
   gem 'coveralls', :require => false
 end
 
-gem "fog-core", :github => "fog/fog-core", :branch => "master"
 gemspec

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
-  s.add_dependency("fog-core")
+  s.add_dependency("fog-core", "~> 1.21.0")
   s.add_dependency("fog-json")
 
   s.add_dependency('builder')


### PR DESCRIPTION
Rather than tracking the Github repo, this references the gem directly.

Locally seeing an issue with 1.8.7 / unf gem test which surprised not
seeing on Travis.
