### PR TITLE
Reduce Travis CI burden

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,24 @@
 language: ruby
 
-gemfile:
-  - Gemfile
-  - Gemfile.1.8.7
-
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - jruby-18mode
-  - jruby-19mode
-  - jruby-head
-
 script: bundle exec rake travis
 
 matrix:
   include:
+    - rvm: 1.8.7
+      gemfile: Gemfile.1.8.7
+    - rvm: 1.9.3
+      gemfile: Gemfile
+    - rvm: 2.0.0
+      gemfile: Gemfile
     - rvm: 2.1.0
       gemfile: Gemfile
       env: COVERAGE=true
-  exclude:
-    - rvm: 2.1.0
-      gemfile: Gemfile
-      env:
-    - rvm: 1.8.7
-      gemfile: Gemfile
-    - rvm: 1.9.3
-      gemfile: Gemfile.1.8.7
-    - rvm: 2.0.0
-      gemfile: Gemfile.1.8.7
-    - rvm: 2.1.0
-      gemfile: Gemfile.1.8.7
     - rvm: jruby-18mode
-      gemfile: Gemfile
+      gemfile: Gemfile.1.8.7
     - rvm: jruby-19mode
-      gemfile: Gemfile.1.8.7
+      gemfile: Gemfile
     - rvm: jruby-head
-      gemfile: Gemfile.1.8.7
+      gemfile: Gemfile
 
   allow_failures:
     - rvm: jruby-head


### PR DESCRIPTION
This excludes the duplicated Ruby 2.1.0 run (without coverage)

Also drops testing of Ruby 1.9.2.

So two less boxes used and faster results I hope.
