### PR TITLE
Added find_by_name to openstack identity-users model and tests

### DIFF
--- a/lib/fog/openstack/models/identity/users.rb
+++ b/lib/fog/openstack/models/identity/users.rb
@@ -22,6 +22,15 @@ module Fog
             )
         end
 
+        def find_by_name(name)
+          self.find {|user| user.name == name} ||
+            Fog::Identity::OpenStack::User.new(
+              service.get_user_by_name(name).body['user'].merge(
+                'service' => service
+              )
+            )
+        end
+
         def destroy(id)
           user = self.find_by_id(id)
           user.destroy

--- a/tests/openstack/models/identity/users_tests.rb
+++ b/tests/openstack/models/identity/users_tests.rb
@@ -14,6 +14,11 @@ Shindo.tests("Fog::Identity[:openstack] | users", ['openstack']) do
       user.id == @instance.id
     end
 
+    tests('#find_by_name').succeeds do
+      user = Fog::Identity[:openstack].users.find_by_name(@instance.name)
+      user.name == @instance.name
+    end
+
     tests('#destroy').succeeds do
       Fog::Identity[:openstack].users.destroy(@instance.id)
     end
@@ -24,6 +29,10 @@ Shindo.tests("Fog::Identity[:openstack] | users", ['openstack']) do
 
     tests('#find_by_id').raises(Fog::Identity::OpenStack::NotFound) do
       Fog::Identity[:openstack].users.find_by_id('fake')
+    end
+
+    tests('#find_by_name').raises(Fog::Identity::OpenStack::NotFound) do
+      Fog::Identity[:openstack].users.find_by_name('fake')
     end
 
     tests('#destroy').raises(Fog::Identity::OpenStack::NotFound) do


### PR DESCRIPTION
Hello folks,

For our swift-service on anynines, we need the method `find_user_by_name` on the users collection on the  openstack fog adapter.

I would really appreciate, if you could add that feature to the next release. :heart: 

Greetz
Markus
