### PR TITLE
[aws|iam] Add get_account_summary.

### DIFF
--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -35,6 +35,7 @@ module Fog
       request :delete_signing_certificate
       request :delete_user
       request :delete_user_policy
+      request :get_account_summary
       request :get_group
       request :get_group_policy
       request :get_instance_profile

--- a/lib/fog/aws/parsers/iam/get_account_summary.rb
+++ b/lib/fog/aws/parsers/iam/get_account_summary.rb
@@ -1,0 +1,46 @@
+module Fog
+  module Parsers
+    module AWS
+      module IAM
+
+        class GetAccountSummary < Fog::Parsers::Base
+
+          def reset
+            super
+            @stack = []
+            @response = {'Summary' => {}}
+          end
+
+          def start_element(name, attrs = [])
+            super
+            case name
+            when 'SummaryMap'
+              @stack << name
+            end
+          end
+
+          def end_element(name)
+            case name
+            when 'SummaryMap'
+              @stack.pop
+            when 'key'
+              if @stack.last == 'SummaryMap'
+                @key = value
+              end
+            when 'value'
+              if @stack.last == 'SummaryMap'
+                @response['Summary'][@key] = value.strip.to_i
+              end
+            when 'RequestId'
+              if @stack.empty?
+                @response['RequestId'] = value.strip
+              end
+            end
+          end
+
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/iam/get_account_summary.rb
+++ b/lib/fog/aws/requests/iam/get_account_summary.rb
@@ -1,0 +1,80 @@
+module Fog
+  module AWS
+    class IAM
+      class Real
+
+        require 'fog/aws/parsers/iam/get_account_summary'
+
+        # Retrieve account level information about account entity usage and IAM quotas
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~Hash>:
+        #     * 'Summary'<~Hash>:
+        #       * 'AccessKeysPerUserQuota'<~Integer> - Maximum number of access keys that can be created per user
+        #       * 'AccountMFAEnabled'<~Integer> - 1 if the root account has an MFA device assigned to it, 0 otherwise
+        #       * 'AssumeRolePolicySizeQuota'<~Integer> - Maximum allowed size for assume role policy documents (in kilobytes)
+        #       * 'GroupPolicySizeQuota'<~Integer> - Maximum allowed size for Group policy documents (in kilobytes)
+        #       * 'Groups'<~Integer> - Number of Groups for the AWS account
+        #       * 'GroupsPerUserQuota'<~Integer> - Maximum number of groups a user can belong to
+        #       * 'GroupsQuota'<~Integer> - Maximum groups allowed for the AWS account
+        #       * 'InstanceProfiles'<~Integer> - Number of instance profiles for the AWS account
+        #       * 'InstanceProfilesQuota'<~Integer> - Maximum instance profiles allowed for the AWS account
+        #       * 'MFADevices'<~Integer> - Number of MFA devices, either assigned or unassigned
+        #       * 'MFADevicesInUse'<~Integer> - Number of MFA devices that have been assigned to an IAM user or to the root account
+        #       * 'Providers'<~Integer> -
+        #       * 'RolePolicySizeQuota'<~Integer> - Maximum allowed size for role policy documents (in kilobytes)
+        #       * 'Roles'<~Integer> - Number of roles for the AWS account
+        #       * 'RolesQuota'<~Integer> - Maximum roles allowed for the AWS account
+        #       * 'ServerCertificates'<~Integer> - Number of server certificates for the AWS account
+        #       * 'ServerCertificatesQuota'<~Integer> - Maximum server certificates allowed for the AWS account
+        #       * 'SigningCertificatesPerUserQuota'<~Integer> - Maximum number of X509 certificates allowed for a user
+        #       * 'UserPolicySizeQuota'<~Integer> - Maximum allowed size for user policy documents (in kilobytes)
+        #       * 'Users'<~Integer> - Number of users for the AWS account
+        #       * 'UsersQuota'<~Integer> - Maximum users allowed for the AWS account
+        #     * 'RequestId'<~String> - Id of the request
+        #
+        # ==== See Also
+        # http://docs.amazonwebservices.com/IAM/latest/APIReference/API_CreateAccessKey.html
+        #
+        def get_account_summary
+          request(
+            'Action'    => 'GetAccountSummary',
+            :parser     => Fog::Parsers::AWS::IAM::GetAccountSummary.new
+            )
+        end
+
+      end
+
+      class Mock
+
+        def get_account_summary
+          Excon::Response.new.tap do |response|
+            response.status = 200
+            response.body = {
+              'Summary' => {
+                'AccessKeysPerUserQuota' => 2,
+                'AccountMFAEnabled' => 0,
+                'GroupPolicySizeQuota' => 10240,
+                'Groups' => 31,
+                'GroupsPerUserQuota' => 10,
+                'GroupsQuota' => 50,
+                'MFADevices' => 20,
+                'MFADevicesInUse' => 10,
+                'ServerCertificates' => 5,
+                'ServerCertificatesQuota' => 10,
+                'SigningCertificatesPerUserQuota' => 2,
+                'UserPolicySizeQuota' => 10240,
+                'Users' => 35,
+                'UsersQuota' => 150,
+              },
+              'RequestId' => Fog::AWS::Mock.request_id
+            }
+          end
+        end
+
+      end
+
+    end
+  end
+end

--- a/tests/aws/requests/iam/account_tests.rb
+++ b/tests/aws/requests/iam/account_tests.rb
@@ -1,0 +1,34 @@
+Shindo.tests('AWS::IAM | account requests', ['aws']) do
+  tests('success') do
+    @get_account_summary_format = {
+      'Summary' => {
+        'AccessKeysPerUserQuota' => Integer,
+        'AccountMFAEnabled' => Integer,
+        'AssumeRolePolicySizeQuota' => Fog::Nullable::Integer,
+        'GroupPolicySizeQuota' => Integer,
+        'Groups' => Integer,
+        'GroupsPerUserQuota' => Integer,
+        'GroupsQuota' => Integer,
+        'InstanceProfiles' => Fog::Nullable::Integer,
+        'InstanceProfilesQuota' => Fog::Nullable::Integer,
+        'MFADevices' => Integer,
+        'MFADevicesInUse' => Integer,
+        'Providers' => Fog::Nullable::Integer,
+        'RolePolicySizeQuota' => Fog::Nullable::Integer,
+        'Roles' => Fog::Nullable::Integer,
+        'RolesQuota' => Fog::Nullable::Integer,
+        'ServerCertificates' => Integer,
+        'ServerCertificatesQuota' => Integer,
+        'SigningCertificatesPerUserQuota' => Integer,
+        'UserPolicySizeQuota' => Integer,
+        'Users' => Integer,
+        'UsersQuota' => Integer,
+      },
+      'RequestId' => String,
+    }
+
+    tests('#get_account_summary').formats(@get_account_summary_format) do
+      Fog::AWS[:iam].get_account_summary.body
+    end
+  end
+end


### PR DESCRIPTION
Adds support for the [`GetAccountSummary`](http://docs.aws.amazon.com/IAM/latest/APIReference/API_GetAccountSummary.html) IAM API action.
