### PR TITLE
[Brightbox] Destroy snapshot after completion

### DIFF
--- a/tests/brightbox/models/compute/database_server_tests.rb
+++ b/tests/brightbox/models/compute/database_server_tests.rb
@@ -55,10 +55,22 @@ Shindo.tests("Fog::Compute[:brightbox] | DatabaseServer model", ["brightbox"]) d
 
     @database_server.wait_for { ready? }
 
-    test("#snapshot") do
-      @database_server.snapshot
+    tests("#snapshot") do
+      # Very messy but there is no feedback about if snapshotting or what the ID will be
+      existing_snapshots = @service.database_snapshots.all.map { |snapshot| snapshot.identity }
+      test do
+        @database_server.snapshot
+      end
+
+      current_snapshots = @service.database_snapshots.all.map { |snapshot| snapshot.identity }
+      snapshot_id = (current_snapshots - existing_snapshots).last
+
+      @snapshot = @service.database_snapshots.get(snapshot_id)
+      @snapshot.wait_for { ready? }
+      @snapshot.destroy
     end
 
+    # Can no longer destroy when snapshotting
     tests("#destroy") do
       @database_server.destroy
     end

--- a/tests/brightbox/requests/compute/database_server_tests.rb
+++ b/tests/brightbox/requests/compute/database_server_tests.rb
@@ -28,13 +28,13 @@ Shindo.tests('Fog::Compute[:brightbox] | database server requests', ['brightbox'
       data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SERVER, {:allow_extra_keys => true}) { result }
     end
 
+    Fog::Compute[:brightbox].database_servers.get(@database_server_id).wait_for { ready? }
+
     tests("#reset_password_database_server('#{@database_server_id}')") do
       result = Fog::Compute[:brightbox].reset_password_database_server(@database_server_id)
       data_matches_schema(Brightbox::Compute::Formats::Full::DATABASE_SERVER, {:allow_extra_keys => true}) { result }
       test("new password is visible") { ! result["admin_password"].nil? }
     end
-
-    Fog::Compute[:brightbox].database_servers.get(@database_server_id).wait_for { ready? }
 
     tests("#destroy_database_server('#{@database_server_id}')") do
       result = Fog::Compute[:brightbox].destroy_database_server(@database_server_id)

--- a/tests/brightbox/requests/compute/database_snapsnot_tests.rb
+++ b/tests/brightbox/requests/compute/database_snapsnot_tests.rb
@@ -15,7 +15,7 @@ Shindo.tests('Fog::Compute[:brightbox] | database snapshot requests', ['brightbo
     tests("#list_database_snapshots") do
       result = service.list_database_snapshots
       data_matches_schema(Brightbox::Compute::Formats::Collection::DATABASE_SNAPSHOTS, {:allow_extra_keys => true}) { result }
-      @database_snapshot_id = result.first["id"]
+      @database_snapshot_id = result.last["id"]
     end
 
     tests("#get_database_snapshot('#{@database_snapshot_id}')") do


### PR DESCRIPTION
This works around an issue where you can not detect if a Cloud SQL
Instance is being snapshotted.

A new API restriction is that you can no longer delete an instance that
is being snapshotted so this suddenly began failing.

Now we look for a new snapshot and poll until it is ready only then can
we safely issue the destroy command.
