### PR TITLE
[core] Make the wait timeout truly global

### DIFF
--- a/tests/core/timeout_tests.rb
+++ b/tests/core/timeout_tests.rb
@@ -1,5 +1,5 @@
 Shindo.tests('Fog#timeout', 'core') do
-  tests('timeout').returns(600) do
+  tests('timeout').returns(FOG_TESTING_TIMEOUT) do
     Fog.timeout
   end
 

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -21,6 +21,15 @@ Excon.defaults.merge!(:debug_request => true, :debug_response => true)
 
 require File.expand_path(File.join(File.dirname(__FILE__), 'helpers', 'mock_helper'))
 
+# This overrides the default 600 seconds timeout during live test runs
+if Fog.mocking?
+  FOG_TESTING_TIMEOUT = ENV['FOG_TEST_TIMEOUT'] || 2000
+  Fog.timeout = 2000
+  Fog::Logger.warning "Setting default fog timeout to #{Fog.timeout} seconds"
+else
+  FOG_TESTING_TIMEOUT = Fog.timeout
+end
+
 def lorem_file
   File.open(File.dirname(__FILE__) + '/lorem.txt', 'r')
 end

--- a/tests/rackspace/helper.rb
+++ b/tests/rackspace/helper.rb
@@ -5,17 +5,11 @@ LINKS_FORMAT = [{
 
 module Shindo
   class Tests
-
-    unless Fog.mocking?
-      Fog.timeout = 2000
-      Fog::Logger.warning "Setting default fog timeout to #{Fog.timeout} seconds"
-    end
-
     def given_a_load_balancer_service(&block)
       @service = Fog::Rackspace::LoadBalancers.new
       instance_eval(&block)
     end
-    
+
     def given_a_load_balancer(&block)
         @lb = @service.load_balancers.create({
             :name => ('fog' + Time.now.to_i.to_s),
@@ -32,7 +26,7 @@ module Shindo
         @lb.destroy
       end
     end
-  
+
    def wait_for_request(description = "waiting", &block)
      return if Fog.mocking?
      tests(description) do


### PR DESCRIPTION
The Rackspace helper changed the Fog.timeout global for all live tests
so the core test which expected "600" failed since it was now "2000"

Since it is a global setting it has been moved to the global test helper

It can now also be controlled by the FOG_TEST_TIMEOUT env variable.
