### PR TITLE
Use Travis ENV for the tests ENV!

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 
 script: bundle exec rake travis
 
+env:
+  global:
+    - FOG_MOCK: true
+
 matrix:
   fast_finish: true
   include:

--- a/Rakefile
+++ b/Rakefile
@@ -57,7 +57,7 @@ namespace :test do
   task :travis do
       # jruby coveralls causes an OOM in travis
       ENV['COVERAGE'] = 'false' if RUBY_PLATFORM == 'java'
-      sh("export FOG_MOCK=#{mock} && bundle exec shindont")
+      sh("bundle exec shindont")
   end
   task :vsphere do
       sh("export FOG_MOCK=#{mock} && bundle exec shindont tests/vsphere")


### PR DESCRIPTION
Were setting the FOG_MOCK environment setting in the rake task, covering
up that we were running the tests this way (even though well known).

This makes it a lot clearer that in the Travis CI environment we are
using FOG_MOCK since it appears in the testing matrix.
