### PR TITLE
[internetarchive] Correct test tagging

### DIFF
--- a/tests/internet_archive/models/storage/directory_tests.rb
+++ b/tests/internet_archive/models/storage/directory_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests("Storage[:internet_archive] | directory", ["internet_archive"]) do
+Shindo.tests("Storage[:internet_archive] | directory", ["internetarchive"]) do
 
   directory_attributes = {
     :key => "fogdirectorytests-#{rand(65536)}",

--- a/tests/internet_archive/models/storage/file_tests.rb
+++ b/tests/internet_archive/models/storage/file_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests("Storage[:internet_archive] | file", ["internet_archive"]) do
+Shindo.tests("Storage[:internetarchive] | file", ["internetarchive"]) do
 
   # Fog.mock!
 

--- a/tests/internet_archive/models/storage/files_tests.rb
+++ b/tests/internet_archive/models/storage/files_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests("Storage[:internet_archive] | files", ["internet_archive"]) do
+Shindo.tests("Storage[:internetarchive] | files", ["internetarchive"]) do
 
   file_attributes = {
       :key => 'fog_file_tests',

--- a/tests/internet_archive/models/storage/url_tests.rb
+++ b/tests/internet_archive/models/storage/url_tests.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-Shindo.tests('InternetArchive | url', ["internet_archive"]) do
+Shindo.tests('InternetArchive | url', ["internetarchive"]) do
 
   @expires = Time.utc(2013,1,1).utc.to_i
 

--- a/tests/internet_archive/requests/storage/acl_utils_tests.rb
+++ b/tests/internet_archive/requests/storage/acl_utils_tests.rb
@@ -1,6 +1,6 @@
 require 'fog/internet_archive/requests/storage/acl_utils'
 
-Shindo.tests('Fog::Storage::InternetArchive | ACL utils', ["internet_archive"]) do
+Shindo.tests('Fog::Storage::InternetArchive | ACL utils', ["internetarchive"]) do
   tests(".hash_to_acl") do
     tests(".hash_to_acl({}) at xpath //AccessControlPolicy").returns("", "has an empty AccessControlPolicy") do
       xml = Fog::Storage::InternetArchive.hash_to_acl({})

--- a/tests/internet_archive/requests/storage/bucket_tests.rb
+++ b/tests/internet_archive/requests/storage/bucket_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests('Fog::Storage[:internetarchive] | bucket requests', ["internet_archive"]) do
+Shindo.tests('Fog::Storage[:internetarchive] | bucket requests', ["internetarchive"]) do
   @ia_bucket_name = 'fogbuckettests-' + Time.now.to_i.to_s(32)
 
   tests('success') do

--- a/tests/internet_archive/requests/storage/cors_utils_tests.rb
+++ b/tests/internet_archive/requests/storage/cors_utils_tests.rb
@@ -1,6 +1,6 @@
 require 'fog/internet_archive/requests/storage/cors_utils'
 
-Shindo.tests('Fog::Storage::InternetArchive | CORS utils', ["internet_archive"]) do
+Shindo.tests('Fog::Storage::InternetArchive | CORS utils', ["internetarchive"]) do
   tests(".hash_to_cors") do
     tests(".hash_to_cors({}) at xpath //CORSConfiguration").returns("", "has an empty CORSConfiguration") do
       xml = Fog::Storage::InternetArchive.hash_to_cors({})

--- a/tests/internet_archive/requests/storage/multipart_upload_tests.rb
+++ b/tests/internet_archive/requests/storage/multipart_upload_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests('Fog::Storage[:internetarchive] | multipart upload requests', ["internet_archive"]) do
+Shindo.tests('Fog::Storage[:internetarchive] | multipart upload requests', ["internetarchive"]) do
 
   @directory = Fog::Storage[:internetarchive].directories.create(:key => "fogmultipartuploadtests-#{rand(65536)}")
 

--- a/tests/internet_archive/requests/storage/object_tests.rb
+++ b/tests/internet_archive/requests/storage/object_tests.rb
@@ -1,4 +1,4 @@
-Shindo.tests('InternetArchive::Storage | object requests', ['internet_archive']) do
+Shindo.tests('InternetArchive::Storage | object requests', ['internetarchive']) do
   @directory = Fog::Storage[:internetarchive].directories.create(:key => 'fogobjecttests-' + Time.now.to_i.to_s(32))
   @ia_owner = Fog::Storage[:internetarchive].get_bucket_acl(@directory.key).body['Owner']
 

--- a/tests/internet_archive/signaturev4_tests.rb
+++ b/tests/internet_archive/signaturev4_tests.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 
-Shindo.tests('InternetArchive | signaturev4', ['internet_archive']) do
+Shindo.tests('InternetArchive | signaturev4', ['internetarchive']) do
 
   # These testcases are from http://docs.amazonwebservices.com/general/latest/gr/signature-v4-test-suite.html
   @signer = Fog::InternetArchive::SignatureV4.new('AKIDEXAMPLE', 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY', 'us-east-1','host')

--- a/tests/internet_archive/signed_params_tests.rb
+++ b/tests/internet_archive/signed_params_tests.rb
@@ -1,5 +1,5 @@
 # encoding: utf-8
 
-Shindo.tests('InternetArchive | signed_params', ['internet_archive']) do
+Shindo.tests('InternetArchive | signed_params', ['internetarchive']) do
   returns( Fog::InternetArchive.escape( "'Stöp!' said Fred_-~." ) ) { "%27St%C3%B6p%21%27%20said%20Fred_-~." }
 end


### PR DESCRIPTION
The provider is declaring itself as "internetarchive" which does not
match the tags "internet_archive" used on the tests.

Since we blacklist the tests that are run, it meant they continued to
run even if no credentials were present.
