### PR TITLE
Don't read entire file into memory when saving to local blob storage.

### DIFF
--- a/lib/fog/local/models/storage/file.rb
+++ b/lib/fog/local/models/storage/file.rb
@@ -104,7 +104,7 @@ module Fog
           file = ::File.new(path, 'wb')
           if body.is_a?(String)
             file.write(body)
-          elsif body.kind_of? ::File and File.exists?(body.path)
+          elsif body.kind_of? ::File and ::File.exists?(body.path)
             FileUtils.cp(body.path, path)
           else
             file.write(body.read)


### PR DESCRIPTION
We are using the local blobstore as a backend for concurrent uploads and
observed that memory was leaking quite quickly as GC cannot keep up.

So here, when the dest, src are  both local files, instead of calling
File.read, simply copy the file.
