### PR TITLE
[vcloud_director] Allow for specification of vcloud_token via ENV

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -446,11 +446,15 @@ module Fog
         private
 
         def login
-          response = post_login_session
-          x_vcloud_authorization = response.headers.keys.detect do |key|
-            key.downcase == 'x-vcloud-authorization'
+          if @vcloud_token = ENV['FOG_VCLOUD_TOKEN']
+            response = get_current_session
+          else
+            response = post_login_session
+            x_vcloud_authorization = response.headers.keys.detect do |key|
+              key.downcase == 'x-vcloud-authorization'
+            end
+            @vcloud_token = response.headers[x_vcloud_authorization]
           end
-          @vcloud_token = response.headers[x_vcloud_authorization]
           @org_name = response.body[:org]
           @user_name = response.body[:user]
         end


### PR DESCRIPTION
This change permits the use of an external login method for vCloud
Director, relying on the fact that the password is only needed to
create a session in the API, subsequently accessed via the token.

In effect, this means that users do not need to store a valid
password in the FOG_RC, significantly reducing the risk footprint.

The default token lifetime is '30 minutes idle' - any activity
extends the life by another 30 mins. This makes this a very workable
solution for general user sessions.
