### PR TITLE
[cloudstack] servers.get will now find VM in projects for normal users

### DIFF
--- a/lib/fog/cloudstack/models/compute/servers.rb
+++ b/lib/fog/cloudstack/models/compute/servers.rb
@@ -23,6 +23,9 @@ module Fog
 
         def get(server_id)
           servers = service.list_virtual_machines('id' => server_id)["listvirtualmachinesresponse"]["virtualmachine"]
+          if servers.nil? || servers.empty?
+            servers = service.list_virtual_machines('id' => server_id, 'projectid' => '-1')["listvirtualmachinesresponse"]["virtualmachine"]
+          end
           unless servers.nil? || servers.empty?
             new(servers.first)
           end


### PR DESCRIPTION
We have noticed that fog will not find VMs towards Cloudstack 3.0.6 with a normal user account if the VM was deployed in a project.

This issue only occurs for non-admin users.

To find VMs for a normal user you need to send 2 requests. One without projectid in case the VM is deployed in the default view and one with projectid set to _-1_ to search in all projects.

This pull-request proposes a solution where the second request will be made in case the first won't return the VM.

Following script was used to test this behaviour:

``` ruby
#!/usr/bin/env ruby
require 'fog'

# Precreate a vm in default view and specify id here
vm_in_default_view = 'b6c88916-55d6-456b-a81b-b1ed6c478fdb'

# Create a vm in a project and specify ids here
project = '4e86ebcb-a4ae-4da2-a407-795dab48d409'
vm_in_project = '589a324d-ae24-4a61-b5e8-6a24075603b8'

# Use other VMs for testing with admin account
vm_in_default_view = '445ee23f-d0d1-49c5-8f6b-f7e3e1684633'
project = '091ecbe5-f107-46e3-ad6d-62d7b9d6ee98'
vm_in_project = '4321de7f-ec47-4332-8144-e0cc3bed6c45'

## CASE A
puts
puts "Check if we can find the machine in the default view"
vm = Fog::Compute[:Cloudstack].list_virtual_machines('id' => vm_in_default_view)
if not vm['listvirtualmachinesresponse'].empty?
  puts "[A]: VM in default view found, " + vm['listvirtualmachinesresponse']['virtualmachine'][0]['name']
else
  puts "[A]: VM in default view NOT found"
end

## CASE B
puts
puts "Check if we can find the machine in the project"
vm = Fog::Compute[:Cloudstack].list_virtual_machines('id' => vm_in_project)
if not vm['listvirtualmachinesresponse'].empty?
  puts "[B]: VM in project found, " + vm['listvirtualmachinesresponse']['virtualmachine'][0]['name']
else
  puts "[B]: VM in project NOT found"
end

## CASE C
puts
puts "Check if we can find the machine in the project with projectid specified"
vm = Fog::Compute[:Cloudstack].list_virtual_machines('id' => vm_in_project, 'projectid' => project)
if not vm['listvirtualmachinesresponse'].empty?
  puts "[C]: VM in project found, " + vm['listvirtualmachinesresponse']['virtualmachine'][0]['name']
else
  puts "[C]: VM in project NOT found"
end

## CASE D
puts
puts "Check if we can find the machine in the project with projectid set to '-1'"
vm = Fog::Compute[:Cloudstack].list_virtual_machines('id' => vm_in_project, 'projectid' => '-1')
if not vm['listvirtualmachinesresponse'].empty?
  puts "[D]: VM in project found, " + vm['listvirtualmachinesresponse']['virtualmachine'][0]['name']
else
  puts "[D]: VM in project NOT found"
end

## CASE E
puts
puts "Check if we can find the machine in the default view with projectid set to '-1'"
vm = Fog::Compute[:Cloudstack].list_virtual_machines('id' => vm_in_default_view, 'projectid' => '-1')
if not vm['listvirtualmachinesresponse'].empty?
  puts "[E]: VM in default view found, " + vm['listvirtualmachinesresponse']['virtualmachine'][0]['name']
else
  puts "[E]: VM in default view NOT found"
end
```
#### Following is the result for admin user

``` bash
Check if we can find the machine in the default view
[A]: VM in default view found, esup-1247-3

Check if we can find the machine in the project
[B]: VM in project found, esup-1247-4

Check if we can find the machine in the project with projectid specified
[C]: VM in project found, esup-1247-4

Check if we can find the machine in the project with projectid set to '-1'
[D]: VM in project found, esup-1247-4

Check if we can find the machine in the default view with projectid set to '-1'
[E]: VM in default view NOT found
```
#### Following is the result for a normal user

``` bash
Check if we can find the machine in the default view
[A]: VM in default view found, esup-1247-1

Check if we can find the machine in the project
[B]: VM in project NOT found

Check if we can find the machine in the project with projectid specified
[C]: VM in project found, esup-1247-2

Check if we can find the machine in the project with projectid set to '-1'
[D]: VM in project found, esup-1247-2

Check if we can find the machine in the default view with projectid set to '-1'
[E]: VM in default view NOT found
```
