### PR TITLE
[GH-2706] Update ruby-libvirt dependency to 0.5

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -69,8 +69,9 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry')
   s.add_development_dependency('google-api-client', '~>0.6.2')
   s.add_development_dependency('unf')
-  if ENV["FOG_USE_LIBVIRT"] && RUBY_PLATFORM != 'java'
-    s.add_development_dependency('ruby-libvirt','~>0.4.0')
+
+  if ENV["FOG_USE_LIBVIRT"]
+    s.add_development_dependency('ruby-libvirt','~> 0.5.0')
   end
 
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
Also removed guard related to JRuby since the important part is opting
into lib-virt
