### PR TITLE
[Openstack|Volumes] available? check method

### DIFF
--- a/lib/fog/openstack/models/volume/volume.rb
+++ b/lib/fog/openstack/models/volume/volume.rb
@@ -40,6 +40,10 @@ module Fog
           true
         end
 
+        def ready?
+          status == 'available'
+        end
+
       end
 
     end


### PR DESCRIPTION
available? simply returns whether the volume is being used or its
available. This is convenient for applications using the Fog API to
check if they can use a Volume by calling

``` ruby
openstack.volumes.select(&:available)
```
