### PR TITLE
Follow DEPRECATION message for sakuracloud

### DIFF
--- a/lib/fog/sakuracloud/compute.rb
+++ b/lib/fog/sakuracloud/compute.rb
@@ -41,7 +41,7 @@ module Fog
 
           @sakuracloud_api_url = options[:sakuracloud_api_url] || 'https://secure.sakura.ad.jp'
 
-          @connection = Fog::Connection.new(@sakuracloud_api_url)
+          @connection = Fog::Core::Connection.new(@sakuracloud_api_url)
         end
 
         def request(params)

--- a/lib/fog/sakuracloud/volume.rb
+++ b/lib/fog/sakuracloud/volume.rb
@@ -38,7 +38,7 @@ module Fog
 
           @sakuracloud_api_url = options[:sakuracloud_api_url] || 'https://secure.sakura.ad.jp'
 
-          @connection = Fog::Connection.new(@sakuracloud_api_url)
+          @connection = Fog::Core::Connection.new(@sakuracloud_api_url)
         end
 
         def request(params)


### PR DESCRIPTION
update to `Fog::Core::Connection` from `Fog::Connection`

```
[fog][DEPRECATION] Fog::XML::Connection is deprecated use Fog::Core::Connection instead
```
