### PR TITLE
Fix wrong aliases at Fog::Volume::SakuraCloud::Archive

### DIFF
--- a/lib/fog/sakuracloud/models/volume/archive.rb
+++ b/lib/fog/sakuracloud/models/volume/archive.rb
@@ -5,8 +5,8 @@ module Fog
     class SakuraCloud
       class Archive < Fog::Model
 
-        identity :id, :aliases => :ID
-        attribute :name, :aliases => :Name
+        identity :id, :aliases => 'ID'
+        attribute :name, :aliases => 'Name'
 
       end
     end


### PR DESCRIPTION
Fix Bug: archives returns nil.

```
 volume.archives
=> [  <Fog::Volume::SakuraCloud::Archive
    id=nil,
    name=nil
  >,
-- snip --
```

Expect below.

```
=> [  <Fog::Volume::SakuraCloud::Archive
    id="112500514887",
    name="CentOS 5.10 64bit (基本セット)"
  >,
-- snip --
```
