### PR TITLE
[google|compute] disk model: Add auto_delete option to get_as_boot_disk

### DIFF
--- a/lib/fog/google/models/compute/disk.rb
+++ b/lib/fog/google/models/compute/disk.rb
@@ -59,7 +59,7 @@ module Fog
 
         # auto_delete can only be applied to disks created before instance creation.
         # auto_delete = true will automatically delete disk upon instance termination.
-        def get_object(writable=true, boot=false, device_name=nil, auto_delete=nil)
+        def get_object(writable=true, boot=false, device_name=nil, auto_delete=false)
           mode = writable ? 'READ_WRITE' : 'READ_ONLY'
           value = {
             'autoDelete' => auto_delete,


### PR DESCRIPTION
Add the ability to automatically delete disk upon instance termination. Defaults to false to match GCE utils. Only can be applied to disks created before instance creation.
