### PR TITLE
Adding S3 snapshot location for elasticache

### DIFF
--- a/lib/fog/aws/models/elasticache/cluster.rb
+++ b/lib/fog/aws/models/elasticache/cluster.rb
@@ -32,6 +32,8 @@ module Fog
           :aliases => 'CacheSubnetGroupName'
         attribute :vpc_security_groups,
           :aliases => 'VpcSecurityGroups', :type => :array
+        attribute :s3_snapshot_location,
+          :aliases => 'SnapshotArns', :type => :array
 
         attr_accessor :parameter_group_name
 
@@ -63,6 +65,7 @@ module Fog
               :port                         => port,
               :preferred_availablility_zone => zone,
               :preferred_maintenance_window => maintenance_window,
+              :s3_snapshot_location         => s3_snapshot_location,
               :parameter_group_name         => parameter_group_name || parameter_group['CacheParameterGroupName'],
               :cache_subnet_group_name      => cache_subnet_group_name,
               :vpc_security_groups          => vpc_security_groups,

--- a/lib/fog/aws/requests/elasticache/create_cache_cluster.rb
+++ b/lib/fog/aws/requests/elasticache/create_cache_cluster.rb
@@ -23,6 +23,7 @@ module Fog
         #   * :preferred_availablility_zone <~String>
         #   * :preferred_maintenance_window <~String>
         #   * :cache_subnet_group_name <~String>
+        #   * :s3_snapshot_location <~String> - Amazon resource location for snapshot
         # === Returns
         # * response <~Excon::Response>:
         #   * body <~Hash>
@@ -44,6 +45,10 @@ module Fog
             'PreferredMaintenanceWindow'  => options[:preferred_maintenance_window],
             :parser => Fog::Parsers::AWS::Elasticache::SingleCacheCluster.new
           }
+
+          if s3_snapshot_location = options.delete(:s3_snapshot_location)
+            req_options.merge!(Fog::AWS.indexed_param('SnapshotArns.member.%d', [*s3_snapshot_location]))
+          end
 
           if cache_security_groups = options.delete(:security_group_names)
               req_options.merge!(Fog::AWS.indexed_param('CacheSecurityGroupNames.member.%d', [*cache_security_groups]))


### PR DESCRIPTION
You can now add a amazon resource location for a redis snapshot when creating an elasticache redis cluster.

I'm not super familiar with all of Fog's internals yet so let me know if I missed a location where the attribute should be added.
