### PR TITLE
If you are trying to :delete VM which ISO image defined key is nil.

### DIFF
--- a/lib/fog/libvirt/requests/compute/volume_action.rb
+++ b/lib/fog/libvirt/requests/compute/volume_action.rb
@@ -3,7 +3,7 @@ module Fog
     class Libvirt
       class Real
         def volume_action(key, action, options={})
-          get_volume({:key => key}, true).send(action)
+          get_volume({:key => key}, true).send(action) if not key.nil?
           true
         end
       end


### PR DESCRIPTION
Fog doesn't create correct volume for iso images, and therefore delete on iso image volume is problematic.
