### PR TITLE
[DigitalOcean] Skip consistently timing out tests

### DIFF
--- a/tests/digitalocean/models/compute/servers_tests.rb
+++ b/tests/digitalocean/models/compute/servers_tests.rb
@@ -8,6 +8,9 @@ Shindo.tests('Fog::Compute[:digitalocean] | servers collection', ['digitalocean'
   public_key_path = File.join(File.dirname(__FILE__), '../../fixtures/id_rsa.pub')
   private_key_path = File.join(File.dirname(__FILE__), '../../fixtures/id_rsa')
 
+  # Collection tests are consistently timing out on Travis wasting people's time and resources
+  pending if Fog.mocking?
+
   collection_tests(service.servers, options, true) do
     @instance.wait_for { ready? }
   end


### PR DESCRIPTION
The server tests in digital ocean have been frequently timing out.
- https://travis-ci.org/fog/fog/jobs/20605301#L1030
- https://travis-ci.org/fog/fog/jobs/19765753#L1233
  ...and many more

Each timeout run wastes Travis resources and the time of the people who
have to check why their unrelated changes are failed.

We've even become so complacent about it, standard practice is to just
comment and merge.

So I'm disabling the tests until someone fixes it or we replace the
server tests with a cleaner approach, whichever comes first.
