### PR TITLE
[rackspace|compute_v2] removing hard coded timeout in servers

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/servers.rb
+++ b/lib/fog/rackspace/models/compute_v2/servers.rb
@@ -41,7 +41,7 @@ module Fog
         # @raise [Fog::Compute::RackspaceV2::InvalidServerStateException] if server state is an error state
         def bootstrap(new_attributes = {})
           server = create(new_attributes)
-          server.wait_for(1500) { ready? && !public_ip_address.empty? }
+          server.wait_for { ready? && !public_ip_address.empty? }
           server.setup(:password => server.password)
           server
         end


### PR DESCRIPTION
This PR removes a hard coded pull request that was added to help reduce timeout issues in knife-rackspace. See this [thread](https://groups.google.com/forum/?fromgroups=#!topic/ruby-fog/vPRJYiQzq_A) for more information.
