### PR TITLE
[dns|aws] Return empty set on route53 if no records match on mock

### DIFF
--- a/lib/fog/aws/requests/dns/list_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/list_resource_record_sets.rb
@@ -75,11 +75,14 @@ module Fog
             raise(Excon::Errors.status_error({:expects => 200}, response))
           end
 
-          if options[:type]
-            records = zone[:records][options[:type]].values
+          records = if options[:type]
+            records_type = zone[:records][options[:type]]
+            records_type.values if records_type
           else
-            records = zone[:records].values.map{|r| r.values}.flatten
+            zone[:records].values.map{|r| r.values}.flatten
           end
+
+          records ||= []
 
           # sort for pagination
           records.sort! { |a,b| a[:name].gsub(zone[:name],"") <=> b[:name].gsub(zone[:name],"") }


### PR DESCRIPTION
On route53 AWS dns provider, when getting records by type a exception is thrown if no record matches. This behavior is different as the real one, that returns _nil_ if no record matches instead of raising an exception.

This patch handles that case and creates an empty array in this case.

``` ruby
require 'fog/aws/dns'
Fog.mock!
aws = { 
  :provider => 'AWS',
  :aws_access_key_id => 'KEY_ID',
  :aws_secret_access_key => 'SECRET_KEY'
} 


zone = Fog::DNS.new(aws).zones.create(:domain => 'wadus')
zone.records.get('wadus', 'AAAA')

NoMethodError: undefined method `values' for nil:NilClass
from gems/fog-1.20.0/lib/fog/aws/requests/dns/list_resource_record_sets.rb:79:in `list_resource_record_sets'
```

Real behaviour:

```
zone.records.get('wadus', 'AAAA')                                                                                               
=> nil
```

Patched:

```
zone.records.get('wadus', 'AAAA')
=> nil
```
