### PR TITLE
[google|compute] fix mismatched variable names in disk.create_snapshot

### DIFF
--- a/lib/fog/google/models/compute/disk.rb
+++ b/lib/fog/google/models/compute/disk.rb
@@ -99,7 +99,7 @@ module Fog
           requires :name
           requires :zone_name
 
-          if snap_name.nil? or snap_name.empty?
+          if snapshot_name.nil? or snapshot_name.empty?
             raise ArgumentError, 'Invalid snapshot name'
           end
 


### PR DESCRIPTION
Fixes mismatched variable names for disks.create_snapshot.

Very minor update for you @icco
