### PR TITLE
[google|compute] Change projects we search for images in.

### DIFF
--- a/lib/fog/google/examples/image_all.rb
+++ b/lib/fog/google/examples/image_all.rb
@@ -1,0 +1,6 @@
+def test
+  connection = Fog::Compute.new({ :provider => "Google" })
+
+  # If this doesn't raise an exception, everything is good.
+  connection.images.all
+end


### PR DESCRIPTION
This removes Google (which has no valid v1 images) and adds rhel-cloud and suse-cloud. It also wraps the lookups in a catch block for not-found exceptions because not everyone has access to everything.

This fixes https://github.com/fog/fog/issues/2743

This mimics the gcutil code, and is sadly the way Google wants us to do this check.

@geemus and @kbockmanrs PTAL
