### PR TITLE
Fixes class of error

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -365,7 +365,7 @@ module Fog
         def request(params)
           begin
             do_request(params)
-          rescue Excon::Errors::EOFError
+          rescue Excon::Errors::SocketError::EOFError
             # This error can occur if Vcloud receives a request from a network
             # it deems to be unauthorized; no HTTP response is sent, but the
             # connection is sent a signal to terminate early.


### PR DESCRIPTION
Fixes a typo in my previous PR.  EOFError is a child of Excon::Errors::SocketError.
