### PR TITLE
[openstack|storage] Fix extracted request

### DIFF
--- a/lib/fog/openstack/requests/storage/get_object_http_url.rb
+++ b/lib/fog/openstack/requests/storage/get_object_http_url.rb
@@ -1,13 +1,21 @@
-# Get an expiring object http url
-#
-# ==== Parameters
-# * container<~String> - Name of container containing object
-# * object<~String> - Name of object to get expiring url for
-# * expires<~Time> - An expiry time for this url
-#
-# ==== Returns
-# * response<~Excon::Response>:
-#   * body<~String> - url for object
-def get_object_http_url(container, object, expires, options = {})
-  create_temp_url(container, object, expires, "GET", options.merge(:scheme => "http"))
+module Fog
+  module Storage
+    class OpenStack
+      class Real
+        # Get an expiring object http url
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container containing object
+        # * object<~String> - Name of object to get expiring url for
+        # * expires<~Time> - An expiry time for this url
+        #
+        # ==== Returns
+        # * response<~Excon::Response>:
+        #   * body<~String> - url for object
+        def get_object_http_url(container, object, expires, options = {})
+          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "http"))
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
`Fog::OpenStack::Storage#get_object_http_url` was extracted in
https://github.com/fog/fog/commit/8012318d but did not get the
modules/classes to put it back into the structure.

So it had become a private method and failing some tests.
