### PR TITLE
Remove deprecated `host` Excon option from dynamodb

### DIFF
--- a/lib/fog/aws/dynamodb.rb
+++ b/lib/fog/aws/dynamodb.rb
@@ -112,7 +112,6 @@ module Fog
           # defaults for all dynamodb requests
           params.merge!({
             :expects  => 200,
-            :host     => @host,
             :method   => :post,
             :path     => '/'
           })


### PR DESCRIPTION
This addresses an excon warning:

```
[excon][WARNING] Invalid Excon request keys: :host
/Users/pedro/.rvm/gems/ruby-1.9.3-p448/gems/excon-0.32.1/lib/excon/connection.rb:389:in `validate_params'
/Users/pedro/.rvm/gems/ruby-1.9.3-p448/gems/excon-0.32.1/lib/excon/connection.rb:225:in `request'
```

Thanks!
