### PR TITLE
[Vsphere] Isolate helper from core

### DIFF
--- a/lib/fog/vsphere/core.rb
+++ b/lib/fog/vsphere/core.rb
@@ -13,5 +13,28 @@ module Fog
 
     service(:compute, 'Compute')
 
+    # This helper was originally added as Fog.class_as_string and moved to core but only used here
+    def self.class_from_string classname, defaultpath=""
+      if classname and classname.is_a? String then
+        chain = classname.split("::")
+        klass = Kernel
+        chain.each do |klass_string|
+          klass = klass.const_get klass_string
+        end
+        if klass.is_a? Class then
+          klass
+        elsif defaultpath != nil then
+          class_from_string((defaultpath.split("::")+chain).join("::"), nil)
+        else
+          nil
+        end
+      elsif classname and classname.is_a? Class then
+        classname
+      else
+        nil
+      end
+    rescue NameError
+      defaultpath != nil ? class_from_string((defaultpath.split("::")+chain).join("::"), nil) : nil
+    end
   end
 end

--- a/lib/fog/vsphere/models/compute/interface.rb
+++ b/lib/fog/vsphere/models/compute/interface.rb
@@ -24,10 +24,10 @@ module Fog
 
           if attributes.has_key? :type then
             if attributes[:type].is_a? String then
-              attributes[:type] = Fog.class_from_string(attributes[:type], "RbVmomi::VIM")
+              attributes[:type] = Fog::Vsphere.class_from_string(attributes[:type], "RbVmomi::VIM")
             end
           else
-            attributes[:type] = Fog.class_from_string("VirtualE1000", "RbVmomi::VIM")
+            attributes[:type] = Fog::Vsphere.class_from_string("VirtualE1000", "RbVmomi::VIM")
           end
 
           super defaults.merge(attributes)
@@ -84,7 +84,7 @@ module Fog
             :name=>"Network adapter",
             :network=>"VM Network",
             :summary=>"VM Network",
-            :type=> Fog.class_from_string(default_type, "RbVmomi::VIM"),
+            :type=> Fog::Vsphere.class_from_string(default_type, "RbVmomi::VIM"),
           }
         end
 

--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -87,7 +87,7 @@ module Fog
                     controller_default_options
                   end
           controller_class=if options[:type].is_a? String then
-                             Fog::class_from_string options[:type], "RbVmomi::VIM"
+                             Fog::Vsphere.class_from_string options[:type], "RbVmomi::VIM"
                            else
                              options[:type]
                            end

--- a/lib/fog/vsphere/requests/compute/list_interface_types.rb
+++ b/lib/fog/vsphere/requests/compute/list_interface_types.rb
@@ -15,8 +15,7 @@ module Fog
             :id => nic,
             :name => nic,
             :datacenter => datacenter,
-            :servertype => servertype,
-#            :class => Fog.class_from_string(nic)
+            :servertype => servertype
           }
         end
       end


### PR DESCRIPTION
`Fog.class_from_string` was moved to core but is only used by the
VSphere provider with very little capacity for reuse.

This moves it to the `Fog::Vsphere` namespace so we can delete it from
core.
