### PR TITLE
Removed unicode NFC normalization of S3 object keys.

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -62,7 +62,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('fission')
   s.add_development_dependency('pry')
   s.add_development_dependency('google-api-client', '~> 0.6', '>= 0.6.2')
-  s.add_development_dependency('unf')
 
   if ENV["FOG_USE_LIBVIRT"]
     s.add_development_dependency('ruby-libvirt','~> 0.5.0')

--- a/lib/fog/aws/core.rb
+++ b/lib/fog/aws/core.rb
@@ -89,15 +89,6 @@ module Fog
     end
 
     def self.escape(string)
-      unless @unf_loaded_or_warned
-        begin
-          require('unf/normalizer')
-        rescue LoadError
-          Fog::Logger.warning("Unable to load the 'unf' gem. Your AWS strings may not be properly encoded.")
-        end
-        @unf_loaded_or_warned = true
-      end
-      string = defined?(::UNF::Normalizer) ? ::UNF::Normalizer.normalize(string, :nfc) : string
       string.gsub(/([^a-zA-Z0-9_.\-~]+)/) {
         "%" + $1.unpack("H2" * $1.bytesize).join("%").upcase
       }

--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -177,15 +177,6 @@ module Fog
 
         # NOTE: differs from Fog::AWS.escape by NOT escaping `/`
         def escape(string)
-          unless @unf_loaded_or_warned
-            begin
-              require('unf/normalizer')
-            rescue LoadError
-              Fog::Logger.warning("Unable to load the 'unf' gem. Your AWS strings may not be properly encoded.")
-            end
-            @unf_loaded_or_warned = true
-          end
-          string = defined?(::UNF::Normalizer) ? ::UNF::Normalizer.normalize(string, :nfc) : string
           string.gsub(/([^a-zA-Z0-9_.\-~\/]+)/) {
             "%" + $1.unpack("H2" * $1.bytesize).join("%").upcase
           }

--- a/tests/aws/signed_params_tests.rb
+++ b/tests/aws/signed_params_tests.rb
@@ -3,11 +3,15 @@
 Shindo.tests('AWS | signed_params', ['aws']) do
   returns( Fog::AWS.escape( "'Stöp!' said Fred_-~./" ) ) { "%27St%C3%B6p%21%27%20said%20Fred_-~.%2F" }
 
-  tests('Keys should be canonicalised using Unicode NFC') do
-    returns( Fog::AWS.escape( ["00E9".to_i(16)].pack("U*") ) ) { "%C3%A9" }
+  tests('Unicode characters should be escaped') do
+    unicode = ["00E9".to_i(16)].pack("U*")
+    escaped = "%C3%A9"
+    returns( escaped ) { Fog::AWS.escape( unicode ) }
+  end
 
-    tests('Characters with combining mark should be combined and then escaped') do
-      returns( Fog::AWS.escape( ["0065".to_i(16), "0301".to_i(16)].pack("U*") ) ) { "%C3%A9" }
-    end
+  tests('Unicode characters with combining marks should be escaped') do
+    unicode = ["0065".to_i(16), "0301".to_i(16)].pack("U*")
+    escaped = "e%CC%81"
+    returns( escaped ) { Fog::AWS.escape( unicode ) }
   end
 end


### PR DESCRIPTION
S3 does not require normalization of S3 object keys and uses strict byte
comparison of object keys, not equivalent unicode character comparisons,
to store and retrieve objects. This means that storing and retrieving objects
with fog would cause the objects to be inaccessible by other libraries,
languages, and systems that don't normalize object keys. Given that there is
no benefit to normalization, except perhaps reducing byte count of object
keys, it ought to be removed.

This resolves issue #2790.
