### PR TITLE
[GH-1390] Remove redundant calls to Fog.credentials

### DIFF
--- a/lib/fog/glesys/compute.rb
+++ b/lib/fog/glesys/compute.rb
@@ -44,9 +44,9 @@ module Fog
       class Mock
 
         def initialize(options={})
-          @api_url            = options[:glesys_api_url] || Fog.credentials[:glesys_api_url] || API_URL
-          @glesys_username    = options[:glesys_username] || Fog.credentials[:glesys_api_key]
-          @glesys_api_key     = options[:glesys_api_key] || Fog.credentials[:glesys_api_key]
+          @api_url            = options[:glesys_api_url] || API_URL
+          @glesys_username    = options[:glesys_username]
+          @glesys_api_key     = options[:glesys_api_key]
           @connection_options = options[:connection_options] || {}
         end
 
@@ -74,9 +74,9 @@ module Fog
         def initialize(options)
           require 'base64'
 
-          @api_url            = options[:glesys_api_url] || Fog.credentials[:glesys_api_url] || API_URL
-          @glesys_username    = options[:glesys_username] || Fog.credentials[:glesys_api_key]
-          @glesys_api_key     = options[:glesys_api_key] || Fog.credentials[:glesys_api_key]
+          @api_url            = options[:glesys_api_url] || API_URL
+          @glesys_username    = options[:glesys_username]
+          @glesys_api_key     = options[:glesys_api_key]
           @connection_options = options[:connection_options] || {}
           @persistent         = options[:persistent] || false
           @connection = Fog::XML::Connection.new(@api_url, @persistent, @connection_options)

--- a/lib/fog/joyent/analytics.rb
+++ b/lib/fog/joyent/analytics.rb
@@ -132,8 +132,8 @@ module Fog
         end
 
         def initialize(options = {})
-          @joyent_username = options[:joyent_username] || Fog.credentials[:joyent_username]
-          @joyent_password = options[:joyent_password] || Fog.credentials[:joyent_password]
+          @joyent_username = options[:joyent_username]
+          @joyent_password = options[:joyent_password]
           @joyent_url = 'https://us-sw-1.api.joyentcloud.com'
           @joyent_version = '~7'
         end

--- a/lib/fog/joyent/compute.rb
+++ b/lib/fog/joyent/compute.rb
@@ -101,8 +101,8 @@ module Fog
         end
 
         def initialize(options = {})
-          @joyent_username = options[:joyent_username] || Fog.credentials[:joyent_username]
-          @joyent_password = options[:joyent_password] || Fog.credentials[:joyent_password]
+          @joyent_username = options[:joyent_username]
+          @joyent_password = options[:joyent_password]
         end
 
         def request(opts)

--- a/lib/fog/ninefold/compute.rb
+++ b/lib/fog/ninefold/compute.rb
@@ -71,9 +71,9 @@ module Fog
       class Mock
 
         def initialize(options)
-          @api_url = options[:ninefold_api_url] || Fog.credentials[:ninefold_api_url] || API_URL
-          @ninefold_compute_key = options[:ninefold_compute_key] || Fog.credentials[:ninefold_compute_key]
-          @ninefold_compute_secret = options[:ninefold_compute_secret] || Fog.credentials[:ninefold_compute_secret]
+          @api_url = options[:ninefold_api_url] || API_URL
+          @ninefold_compute_key = options[:ninefold_compute_key]
+          @ninefold_compute_secret = options[:ninefold_compute_secret]
         end
 
         def request(options)
@@ -84,9 +84,9 @@ module Fog
       class Real
 
         def initialize(options)
-          @api_url                  = options[:ninefold_api_url] || Fog.credentials[:ninefold_api_url] || API_URL
-          @ninefold_compute_key     = options[:ninefold_compute_key] || Fog.credentials[:ninefold_compute_key]
-          @ninefold_compute_secret  = options[:ninefold_compute_secret] || Fog.credentials[:ninefold_compute_secret]
+          @api_url                  = options[:ninefold_api_url] || API_URL
+          @ninefold_compute_key     = options[:ninefold_compute_key]
+          @ninefold_compute_secret  = options[:ninefold_compute_secret]
           @connection_options       = options[:connection_options] || {}
           @persistent               = options[:persistent] || false
           @connection = Fog::XML::Connection.new(@api_url, @persistent, @connection_options)

--- a/lib/fog/serverlove/compute.rb
+++ b/lib/fog/serverlove/compute.rb
@@ -42,8 +42,8 @@ module Fog
       class Mock
 
         def initialize(options)
-          @serverlove_uuid = options[:serverlove_uuid] || Fog.credentials[:serverlove_uuid]
-          @serverlove_api_key = options[:serverlove_api_key] || Fog.credentials[:serverlove_api_key]
+          @serverlove_uuid = options[:serverlove_uuid]
+          @serverlove_api_key = options[:serverlove_api_key]
         end
 
         def request(options)

--- a/providers/brightbox/lib/fog/brightbox/compute/shared.rb
+++ b/providers/brightbox/lib/fog/brightbox/compute/shared.rb
@@ -45,21 +45,21 @@ module Fog
         #
         def initialize(options)
           # Currently authentication and api endpoints are the same but may change
-          @auth_url            = options[:brightbox_auth_url]  || Fog.credentials[:brightbox_auth_url] || API_URL
+          @auth_url            = options[:brightbox_auth_url]  || API_URL
           @auth_connection     = Fog::Core::Connection.new(@auth_url)
 
-          @api_url             = options[:brightbox_api_url]   || Fog.credentials[:brightbox_api_url]  || API_URL
+          @api_url             = options[:brightbox_api_url]   || API_URL
           @connection_options  = options[:connection_options]  || {}
           @persistent          = options[:persistent]          || false
           @connection          = Fog::Core::Connection.new(@api_url, @persistent, @connection_options)
 
           # Authentication options
-          client_id            = options[:brightbox_client_id] || Fog.credentials[:brightbox_client_id]
-          client_secret        = options[:brightbox_secret]    || Fog.credentials[:brightbox_secret]
+          client_id            = options[:brightbox_client_id]
+          client_secret        = options[:brightbox_secret]
 
-          username             = options[:brightbox_username]  || Fog.credentials[:brightbox_username]
-          password             = options[:brightbox_password]  || Fog.credentials[:brightbox_password]
-          @configured_account  = options[:brightbox_account]   || Fog.credentials[:brightbox_account]
+          username             = options[:brightbox_username]
+          password             = options[:brightbox_password]
+          @configured_account  = options[:brightbox_account]
           # Request account can be changed at anytime and changes behaviour of future requests
           @scoped_account      = @configured_account
 


### PR DESCRIPTION
If you use the supported means to create services such as:

```
Fog::Service.new(:provider => "Example")
```

It already loads the contents of `~/.fog` and filters the values based
on if they are recognised or required.

That means in a number of services that are initialising based on
`options` or a value from `Fog.credentials` both are the same.

The `options` should have been loaded and merged from credentials in the
service "builder".
