### PR TITLE
Adding support for IAM roles and AssumeRole for IAM API

### DIFF
--- a/lib/fog/aws/iam.rb
+++ b/lib/fog/aws/iam.rb
@@ -145,6 +145,7 @@ module Fog
       end
 
       class Real
+        include Fog::AWS::CredentialFetcher::ConnectionMethods
 
         # Initialize connection to IAM
         #
@@ -195,6 +196,7 @@ module Fog
         end
 
         def request(params)
+          refresh_credentials_if_expired
           idempotent  = params.delete(:idempotent)
           parser      = params.delete(:parser)
 


### PR DESCRIPTION
I noticed today that the IAM service does not support IAM roles and credentials from AssumeRole.  At first I thought this was a limitation from AWS, but another developer let me know that this works fine in boto.  So I've gone ahead and tossed together a patch, which adds this support.  I've tested it using ~./fog credentials and an IAM role.  The unit tests still run correctly also.
