### PR TITLE
Fix issue #2796 (AWS describe_dhcp_options request parsing)

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_dhcp_options.rb
+++ b/lib/fog/aws/parsers/compute/describe_dhcp_options.rb
@@ -61,8 +61,7 @@ module Fog
                 @dhcp_options[name] = value
               when 'item'
                 @response['dhcpOptionsSet'] << @dhcp_options
-                @dhcp_options = { 'tagSet' => {} }
-                @dhcp_options = { 'dhcpConfigurationSet' => {} }
+                @dhcp_options = { 'dhcpConfigurationSet' => {}, 'tagSet' => {} }
               when 'requestId'
                 @response[name] = value
               end


### PR DESCRIPTION
Properly initialize @dhcp_options for each dhcpOptionsSet
