### PR TITLE
[google|compute] fix service_account scopes

### DIFF
--- a/lib/fog/google/examples/eric-fail.rb
+++ b/lib/fog/google/examples/eric-fail.rb
@@ -2,25 +2,31 @@ def test
   connection = Fog::Compute.new({ :provider => "Google" })
 
   name = "fog-smoke-test-#{Time.now.to_i}"
+  zone = "us-central1-a"
 
   disk = connection.disks.create({
     :name => name,
     :size_gb => 10,
-    :zone_name => 'us-central1-a',
-    :source_image => 'debian-7-wheezy-v20131120',
+    :zone_name => zone,
+    :source_image => 'debian-7-wheezy-v20140318',
   })
 
   disk.wait_for { disk.ready? }
+
+  scopes = [
+    "https://www.googleapis.com/auth/compute",
+    "devstorage.full_control",
+    "userinfo.email"
+  ]
 
   server = connection.servers.create({
     :name => name,
     :disks => [disk],
     :machine_type => "n1-standard-1",
-    :zone_name => "us-central1-a",
-    :private_key_path => File.expand_path("~/.ssh/id_rsa"),
-    :public_key_path => File.expand_path("~/.ssh/id_rsa.pub"),
-    :username => 'root',
-    :metadata => {'foo' => 'bar'}
+    :zone_name => zone,
+    :metadata => {'foo' => 'bar'},
+    :tags => ["t1", "t2", "t3"],
+    :servce_accounts => scopes
   })
   sleep(90)
 

--- a/lib/fog/google/models/compute/server.rb
+++ b/lib/fog/google/models/compute/server.rb
@@ -156,6 +156,16 @@ module Fog
               'tags' => tags
           }.delete_if {|key, value| value.nil?}
 
+          if service_accounts
+            options['serviceAccounts'] = [{
+              "kind" => "compute#serviceAccount",
+              "email" => "default",
+              "scopes" => service_accounts.map {
+                |w| w.start_with?("https://") ? w : "https://www.googleapis.com/auth/#{w}"
+              }
+            }]
+          end
+
           service.insert_server(name, zone_name, options)
           data = service.backoff_if_unfound {service.get_server(self.name, self.zone_name).body}
 


### PR DESCRIPTION
Setting scopes was failing since it didn't conform to Google API.  Added, "kind", "email", and allow for full URLs or short-cuts.

@icco - going on the assumption it's better to submit discrete PRs for each thing versus a larger / broader one.
