### PR TITLE
[core] locking rbovirt down to version 0.0.24 as the newly released 0.0.25 had

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -57,7 +57,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rbvmomi')
   s.add_development_dependency('yard')
   s.add_development_dependency('thor')
-  s.add_development_dependency('rbovirt', '>= 0.0.24')
+  s.add_development_dependency('rbovirt', '0.0.24')
   s.add_development_dependency('shindo', '~> 0.3.4')
   s.add_development_dependency('fission')
   s.add_development_dependency('pry')


### PR DESCRIPTION
This pr is a stop gap to get fog building again.

rbovirt released 0.0.25 and it changes some of the xml parsing. 

```
  Fog::Compute[:ovirt] | interface model (ovirt)     
    tests/ovirt/models/compute/interface_tests.rb
      Fog::Compute[:ovirt] | interface model (ovirt)
    undefined method `text' for nil:NilClass (NoMethodError)
      /home/travis/.rvm/gems/ruby-2.1.1/gems/rbovirt-0.0.25/lib/ovirt/interface.rb:46:in `parse_xml_attributes!'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/rbovirt-0.0.25/lib/ovirt/interface.rb:16:in `initialize'
      /home/travis/build/fog/fog/lib/fog/ovirt/requests/compute/list_vm_interfaces.rb:14:in `new'
      /home/travis/build/fog/fog/lib/fog/ovirt/requests/compute/list_vm_interfaces.rb:14:in `block in list_vm_interfaces'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/nokogiri-1.6.1/lib/nokogiri/xml/node_set.rb:237:in `block in each'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/nokogiri-1.6.1/lib/nokogiri/xml/node_set.rb:236:in `upto'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/nokogiri-1.6.1/lib/nokogiri/xml/node_set.rb:236:in `each'
      /home/travis/build/fog/fog/lib/fog/ovirt/requests/compute/list_vm_interfaces.rb:13:in `collect'
      /home/travis/build/fog/fog/lib/fog/ovirt/requests/compute/list_vm_interfaces.rb:13:in `list_vm_interfaces'
      /home/travis/build/fog/fog/lib/fog/ovirt/models/compute/interfaces.rb:17:in `all'
      /home/travis/.rvm/gems/ruby-2.1.1/bundler/gems/fog-core-40277b90a2e1/lib/fog/core/collection.rb:139:in `lazy_load'
      /home/travis/.rvm/gems/ruby-2.1.1/bundler/gems/fog-core-40277b90a2e1/lib/fog/core/collection.rb:15:in `last'
      tests/ovirt/models/compute/interface_tests.rb:4:in `block in <top (required)>'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/shindo-0.3.8/lib/shindo.rb:79:in `instance_eval'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/shindo-0.3.8/lib/shindo.rb:79:in `tests'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/shindo-0.3.8/lib/shindo.rb:38:in `initialize'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/shindo-0.3.8/lib/shindo.rb:13:in `new'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/shindo-0.3.8/lib/shindo.rb:13:in `tests'
      tests/ovirt/models/compute/interface_tests.rb:1:in `<top (required)>'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/shindo-0.3.8/lib/shindo/bin.rb:61:in `load'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/shindo-0.3.8/lib/shindo/bin.rb:61:in `block (2 levels) in run_in_thread'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/shindo-0.3.8/lib/shindo/bin.rb:58:in `each'
      /home/travis/.rvm/gems/ruby-2.1.1/gems/shindo-0.3.8/lib/shindo/bin.rb:58:in `block in run_in_thread'
```
