### PR TITLE
[Brightbox] Update testing to MiniTest::Spec

### DIFF
--- a/providers/brightbox/Rakefile
+++ b/providers/brightbox/Rakefile
@@ -4,5 +4,5 @@ require "rake/testtask"
 task :default => :test
 
 Rake::TestTask.new do |t|
-  t.pattern = File.join("test", "**", "*_test.rb")
+  t.pattern = File.join("spec", "**", "*_spec.rb")
 end

--- a/providers/brightbox/spec/fog/compute/brightbox_spec.rb
+++ b/providers/brightbox/spec/fog/compute/brightbox_spec.rb
@@ -1,8 +1,8 @@
 require "minitest/autorun"
 require "fog/brightbox"
 
-class Fog::Compute::BrightboxTest < Minitest::Test
-  def setup
+describe Fog::Compute::Brightbox do
+  before do
     @arguments = {
       :brightbox_auth_url => "http://localhost",
       :brightbox_api_url => "http://localhost",
@@ -23,15 +23,15 @@ class Fog::Compute::BrightboxTest < Minitest::Test
     end
   end
 
-  def test_respond_to_request
+  it "responds to #request" do
     assert_respond_to @service, :request
   end
 
-  def test_respond_to_request_access_token
+  it "responds to #request_access_token" do
     assert_respond_to @service, :request_access_token
   end
 
-  def test_respond_to_wrapped_request
+  it "responds to #wrapped_request" do
     assert_respond_to @service, :wrapped_request
   end
 end


### PR DESCRIPTION
Using spec form is going to be the standard way to testing (but relying
on asserts). This update allows the test(s) to be picked up by the main
rake task again.
