### PR TITLE
[google|compute] fix instance tags and remove zone lookup call

### DIFF
--- a/lib/fog/google/models/compute/server.rb
+++ b/lib/fog/google/models/compute/server.rb
@@ -18,7 +18,7 @@ module Fog
         attribute :disks, :aliases => 'disks'
         attribute :metadata
         attribute :service_accounts, :aliases => 'serviceAccounts'
-        attribute :tags, :squash => 'items'
+        attribute :tags
         attribute :self_link, :aliases => 'selfLink'
         attribute :auto_restart
         attribute :on_host_maintenance

--- a/lib/fog/google/requests/compute/set_tags.rb
+++ b/lib/fog/google/requests/compute/set_tags.rb
@@ -13,7 +13,7 @@ module Fog
       class Real
 
         def set_tags(instance, zone, tags=[])
-          me = self.servers.get(instance)
+          me = self.servers.get(instance, zone)
           fp = me.tags["fingerprint"]
 
           api_method = @compute.instances.set_tags


### PR DESCRIPTION
@icco - sorry!  I thought I could leave that :squash in there, but it rips out the tags fingerprint.  Also passed in the zone_name so we can avoid another api call.
