### PR TITLE
Add the ability to pass an options Hash to DataPipeline#describe_objects

### DIFF
--- a/lib/fog/aws/requests/data_pipeline/describe_objects.rb
+++ b/lib/fog/aws/requests/data_pipeline/describe_objects.rb
@@ -11,14 +11,15 @@ module Fog
         # * ObjectIds <~Array> - Identifiers of the pipeline objects that contain the definitions
         #                        to be described. You can pass as many as 25 identifiers in a
         #                        single call to DescribeObjects.
+        # * Options <~Hash> - A Hash of additional options desrcibed in the API docs.
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
-        def describe_objects(id, objectIds)
-          params = {
+        def describe_objects(id, objectIds, options={})
+          params = options.merge({
             'pipelineId' => id,
             'objectIds' => objectIds,
-          }
+          })
 
           response = request({
             :body => Fog::JSON.encode(params),
@@ -31,7 +32,7 @@ module Fog
       end
 
       class Mock
-        def describe_objects(id, objects)
+        def describe_objects(id, objects, options={})
           Fog::Mock.not_implemented
         end
       end


### PR DESCRIPTION
@tucker250

This pull enables the ability to page through results from the API call.
