### PR TITLE
ISSUE-2824 Adding user_data to rackspace provider

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -117,6 +117,11 @@ module Fog
         # @see http://docs.rackspace.com/servers/api/v2/cs-devguide/content/config_drive_ext.html
         attribute :config_drive
 
+        # @!attribute [rw] user_data
+        # @return [Boolean] User-data
+        # @see http://docs.rackspace.com/servers/api/v2/cs-devguide/content/config_drive_ext.html
+        attribute :user_data
+
         # @!attribute [r] bandwidth
         # @return [Array] The amount of bandwidth used for the specified audit period.
         # @see http://docs.rackspace.com/servers/api/v2/cs-devguide/content/ch_extensions.html#bandwidth_extension
@@ -246,6 +251,7 @@ module Fog
           modified_options[:metadata] = metadata.to_hash unless @metadata.nil?
           modified_options[:personality] = personality unless personality.nil?
           modified_options[:config_drive] = config_drive unless config_drive.nil?
+          modified_options[:user_data] = user_data_encoded unless user_data_encoded.nil?
           modified_options[:key_name] ||= attributes[:key_name]
 
           if modified_options[:networks]
@@ -593,6 +599,10 @@ module Fog
 
         def password_lock
           "passwd -l #{username}" unless attributes[:no_passwd_lock]
+        end
+
+        def user_data_encoded
+           self.user_data.nil? ? nil : [self.user_data].pack('m')
         end
       end
     end

--- a/lib/fog/rackspace/requests/compute_v2/create_server.rb
+++ b/lib/fog/rackspace/requests/compute_v2/create_server.rb
@@ -30,6 +30,8 @@ module Fog
         #       * networks [Array]:
         #         * [Hash]:
         #           * uuid [String] - uuid of attached network
+        #       * config_drive [Boolean]: Wether to use a config drive or not
+        #       * user_data [String]: User data for cloud init
         # @raise [Fog::Compute::RackspaceV2::NotFound] - HTTP 404
         # @raise [Fog::Compute::RackspaceV2::BadRequest] - HTTP 400
         # @raise [Fog::Compute::RackspaceV2::InternalServerError] - HTTP 500
@@ -57,8 +59,8 @@ module Fog
           data['server']['OS-DCF:diskConfig'] = options[:disk_config] unless options[:disk_config].nil?
           data['server']['metadata'] = options[:metadata] unless options[:metadata].nil?
           data['server']['personality'] = options[:personality] unless options[:personality].nil?
-          data['server']['config_drive'] = options[:config_drive] unless
-options[:config_drive].nil?
+          data['server']['config_drive'] = options[:config_drive] unless options[:config_drive].nil?
+          data['server']['user_data'] = options[:user_data] unless options[:user_data].nil?
           data['server']['networks'] = options[:networks] || [
             { :uuid => '00000000-0000-0000-0000-000000000000' },
             { :uuid => '11111111-1111-1111-1111-111111111111' }


### PR DESCRIPTION
I tried to follow the style of this patch:
https://github.com/xtoddx/fog/commit/24e4bae57fafe2f846c06554d4cf4b790466ecba

So you can actually submit user_data encoded or not

resolve #2824
