### PR TITLE
[core] fixing broken build

### DIFF
--- a/lib/fog/rackspace/models/queues/message.rb
+++ b/lib/fog/rackspace/models/queues/message.rb
@@ -32,8 +32,8 @@ module Fog
         def identity
           return nil unless href
 
-          match = href.match(/\A.*\/queues\/[a-zA-Z0-9_-]{0,64}\/messages\/(?<id>.+?)(?:\?|\z)/i)
-          match ? match['id'] : nil
+          match = href.match(/(\/(\w+))*\??/)
+          match ? match[-1] : nil
         end
         alias :id :identity
 


### PR DESCRIPTION
PR 2820 uses a regular expression that is not supported in ruby 1.8.7. This reverts that PR.
