### PR TITLE
[Brightbox] Test error when required args missing

### DIFF
--- a/providers/brightbox/spec/fog/compute/brightbox_spec.rb
+++ b/providers/brightbox/spec/fog/compute/brightbox_spec.rb
@@ -2,36 +2,48 @@ require "minitest/autorun"
 require "fog/brightbox"
 
 describe Fog::Compute::Brightbox do
-  before do
-    @arguments = {
-      :brightbox_auth_url => "http://localhost",
-      :brightbox_api_url => "http://localhost",
-      :brightbox_client_id => "",
-      :brightbox_secret => "",
-      :brightbox_username => "",
-      :brightbox_password => "",
-      :brightbox_account => ""
-    }
+  describe "when global config is available" do
+    before do
+      @arguments = {
+        :brightbox_auth_url => "http://localhost",
+        :brightbox_api_url => "http://localhost",
+        :brightbox_client_id => "",
+        :brightbox_secret => "",
+        :brightbox_username => "",
+        :brightbox_password => "",
+        :brightbox_account => ""
+      }
 
-    @credential_guard = Minitest::Mock.new
-    def @credential_guard.reject
-      {}
+      @credential_guard = Minitest::Mock.new
+      def @credential_guard.reject
+        {}
+      end
+
+      Fog.stub :credentials, @credential_guard do
+        @service = Fog::Compute::Brightbox.new(@arguments)
+      end
     end
 
-    Fog.stub :credentials, @credential_guard do
-      @service = Fog::Compute::Brightbox.new(@arguments)
+    it "responds to #request" do
+      assert_respond_to @service, :request
+    end
+
+    it "responds to #request_access_token" do
+      assert_respond_to @service, :request_access_token
+    end
+
+    it "responds to #wrapped_request" do
+      assert_respond_to @service, :wrapped_request
     end
   end
 
-  it "responds to #request" do
-    assert_respond_to @service, :request
-  end
-
-  it "responds to #request_access_token" do
-    assert_respond_to @service, :request_access_token
-  end
-
-  it "responds to #wrapped_request" do
-    assert_respond_to @service, :wrapped_request
+  describe "when created without required arguments" do
+    it "raises an error" do
+      Fog.stub :credentials, {} do
+        assert_raises ArgumentError do
+          Fog::Compute::Brightbox.new({})
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
This adds a test to confirm existing behaviour that ArgumentError is
raised when `brightbox_client_id` or `brightbox_secret` is omitted.
