### PR TITLE
[Rackspace] Fix #2835

### DIFF
--- a/lib/fog/rackspace/auto_scale.rb
+++ b/lib/fog/rackspace/auto_scale.rb
@@ -96,7 +96,7 @@ module Fog
 
             authenticate
 
-            @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @options[:persistent], @options[:connection_options])
+            @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @options[:persistent], @options[:connection_options])
           end
 
           def request(params, parse_json = true, &block)

--- a/lib/fog/rackspace/block_storage.rb
+++ b/lib/fog/rackspace/block_storage.rb
@@ -82,7 +82,7 @@ module Fog
           deprecation_warnings(options)
 
           @persistent = options[:persistent] || false
-          @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
         end
 
         def request(params, parse_json = true)

--- a/lib/fog/rackspace/cdn.rb
+++ b/lib/fog/rackspace/cdn.rb
@@ -143,7 +143,7 @@ module Fog
           @persistent = options[:persistent] || false
 
           if endpoint_uri
-            @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+            @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
             @enabled = true
           end
         end

--- a/lib/fog/rackspace/compute.rb
+++ b/lib/fog/rackspace/compute.rb
@@ -197,7 +197,7 @@ module Fog
           authenticate
           Excon.defaults[:ssl_verify_peer] = false if service_net?
           @persistent = options[:persistent] || false
-          @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
         end
 
         def reload

--- a/lib/fog/rackspace/compute_v2.rb
+++ b/lib/fog/rackspace/compute_v2.rb
@@ -158,7 +158,7 @@ module Fog
           deprecation_warnings(options)
 
           @persistent = options[:persistent] || false
-          @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
         end
 
         def request(params, parse_json = true)

--- a/lib/fog/rackspace/core.rb
+++ b/lib/fog/rackspace/core.rb
@@ -4,6 +4,7 @@ require 'fog/rackspace/mock_data'
 require 'fog/rackspace/service'
 require 'fog/rackspace/errors'
 
+
 module Fog
   module Rackspace
     extend Fog::Provider
@@ -104,7 +105,7 @@ module Fog
       url = rackspace_auth_url.match(/^https?:/) ? \
                 rackspace_auth_url : 'https://' + rackspace_auth_url
       uri = URI.parse(url)
-      connection = Fog::XML::Connection.new(url, false, connection_options)
+      connection = Fog::Core::Connection.new(url, false, connection_options)
       @rackspace_api_key  = options[:rackspace_api_key]
       @rackspace_username = options[:rackspace_username]
       response = connection.request({

--- a/lib/fog/rackspace/databases.rb
+++ b/lib/fog/rackspace/databases.rb
@@ -82,7 +82,7 @@ module Fog
           deprecation_warnings(options)
 
           @persistent = options[:persistent] || false
-          @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
         end
 
         def request(params, parse_json = true)

--- a/lib/fog/rackspace/dns.rb
+++ b/lib/fog/rackspace/dns.rb
@@ -101,7 +101,7 @@ module Fog
           deprecation_warnings(options)
 
           @persistent = options[:persistent] || false
-          @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
         end
 
         def endpoint_uri(service_endpoint_url=nil)

--- a/lib/fog/rackspace/identity.rb
+++ b/lib/fog/rackspace/identity.rb
@@ -74,7 +74,7 @@ module Fog
 
         def initialize(options={})
           apply_options(options)
-          @connection = Fog::XML::Connection.new(@uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(@uri.to_s, @persistent, @connection_options)
 
           authenticate
         end

--- a/lib/fog/rackspace/load_balancers.rb
+++ b/lib/fog/rackspace/load_balancers.rb
@@ -119,7 +119,7 @@ module Fog
           deprecation_warnings(options)
 
           @persistent = options[:persistent] || false
-          @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
         end
 
         def request(params, parse_json = true)

--- a/lib/fog/rackspace/monitoring.rb
+++ b/lib/fog/rackspace/monitoring.rb
@@ -140,7 +140,7 @@ module Fog
           authenticate
 
           @persistent = options[:persistent] || false
-          @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
         end
 
         def reload

--- a/lib/fog/rackspace/queues.rb
+++ b/lib/fog/rackspace/queues.rb
@@ -378,7 +378,7 @@ module Fog
           authenticate
 
           @persistent = options[:persistent] || false
-          @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
         end
 
         def request(params, parse_json = true, &block)

--- a/lib/fog/rackspace/storage.rb
+++ b/lib/fog/rackspace/storage.rb
@@ -419,7 +419,7 @@ module Fog
           authenticate
           @persistent = options[:persistent] || false
           Excon.defaults[:ssl_verify_peer] = false if service_net?
-          @connection = Fog::XML::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
+          @connection = Fog::Core::Connection.new(endpoint_uri.to_s, @persistent, @connection_options)
         end
 
         # Using SSL?


### PR DESCRIPTION
Replaces Fog::XML::Connection with Fog::Core::Connection so as to use 
JSON again instead of wrongly using XML.

This should also allow the Rackspace provider to once again work
independently via "require 'fog/rackspace'"
