### PR TITLE
[vcloud_director] fix progress reporting of tasks without a progress value

### DIFF
--- a/lib/fog/vcloud_director/models/compute/tasks.rb
+++ b/lib/fog/vcloud_director/models/compute/tasks.rb
@@ -14,6 +14,7 @@ module Fog
           data = service.get_task(id).body
           return nil unless data
           data[:id] = data[:href].split('/').last
+          data[:progress] ||= 0
           new(data)
         end
 


### PR DESCRIPTION
Set progress to 0 in tasks that do not have progress which prevents the rendering of the progress of these tasks failing with a nil error.

According to vcloud api: "Read-only indicator of task progress as an approximate percentage between 0 and 100. Not available for all tasks." (i.e. optional)

http://pubs.vmware.com/vcd-55/index.jsp?topic=%2Fcom.vmware.vcloud.api.reference.doc_55%2Fdoc%2Ftypes%2FTaskType.html
