### PR TITLE
[google|compute] Complete Operations support

### DIFF
--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -983,7 +983,7 @@ module Fog
         # result = Google::APIClient::Result
         # returns Excon::Response
         def build_response(result)
-          build_excon_response(result.body.nil? ? nil : Fog::JSON.decode(result.body), result.status)
+          build_excon_response(result.body.nil? || result.body.empty? ? nil : Fog::JSON.decode(result.body), result.status)
         end
       end
 

--- a/lib/fog/google/models/compute/operation.rb
+++ b/lib/fog/google/models/compute/operation.rb
@@ -8,13 +8,27 @@ module Fog
 
         identity :name
 
-        attribute :kind, :aliases => 'kind'
-        attribute :id, :aliases => 'id'
+        attribute :kind
+        attribute :id
+        attribute :client_operation_id, :aliases => 'clientOperationId'
         attribute :creation_timestamp, :aliases => 'creationTimestamp'
-        attribute :zone_name, :aliases => 'zone'
-        attribute :region_name, :aliases => 'region'
-        attribute :status, :aliases => 'status'
+        attribute :end_time, :aliases => 'endTime'
+        attribute :error
+        attribute :http_error_message, :aliases => 'httpErrorMessage'
+        attribute :http_error_status_code, :aliases => 'httpErrorStatusCode'
+        attribute :insert_time, :aliases => 'insertTime'
+        attribute :operation_type, :aliases => 'operationType'
+        attribute :progress
+        attribute :region
         attribute :self_link, :aliases => 'selfLink'
+        attribute :start_time, :aliases => 'startTime'
+        attribute :status
+        attribute :status_message, :aliases => 'statusMessage'
+        attribute :target_id, :aliases => 'targetId'
+        attribute :target_link, :aliases => 'targetLink'
+        attribute :user
+        attribute :warnings
+        attribute :zone
 
         def ready?
           self.status == DONE_STATE
@@ -22,6 +36,27 @@ module Fog
 
         def pending?
           self.status == PENDING_STATE
+        end
+
+        def region_name
+          region.nil? ? nil : region.split('/')[-1]
+        end
+
+        def zone_name
+          zone.nil? ? nil : zone.split('/')[-1]
+        end
+
+        def destroy
+          requires :identity
+
+          if zone
+            service.delete_zone_operation(zone, identity)
+          elsif region
+            service.delete_region_operation(region, identity)
+          else
+            service.delete_global_operation(identity)
+          end
+          true
         end
 
         def reload

--- a/lib/fog/google/models/compute/operations.rb
+++ b/lib/fog/google/models/compute/operations.rb
@@ -9,8 +9,18 @@ module Fog
 
         model Fog::Compute::Google::Operation
 
+        def all(filters = {})
+          if filters['zone']
+            data = service.list_zone_operations(filters['zone']).body
+          elsif filters['region']
+            data = service.list_region_operations(filters['region']).body
+          else
+            data = service.list_global_operations.body
+          end
+          load(data['items'] || [])
+        end
+
         def get(identity, zone=nil, region=nil)
-          puts "Getting operation #{identity} zone=#{zone} region=#{region}"
           if not zone.nil?
             response = service.get_zone_operation(zone, identity)
           elsif not region.nil?
@@ -20,6 +30,8 @@ module Fog
           end
           return nil if response.nil?
           new(response.body)
+        rescue Fog::Errors::NotFound
+          nil
         end
 
       end


### PR DESCRIPTION
- Add missing Operation attributes
- Remove unnecessary attribute aliases
- Add "zone_name" attribute for backward compatibility
- Add "destroy" method for an Operation
- Add "all" method for Operations
- Fix a bug when building an empty response (ie on delete operations)
- Return nil on NotFound Operations (behave like other fog resources)
