### PR TITLE
[google|compute] Bring Flavors model and related requests up to feature parity

### DIFF
--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -14,6 +14,7 @@ module Fog
       request :list_firewalls
       request :list_images
       request :list_machine_types
+      request :list_aggregated_machine_types
       request :list_networks
       request :list_zones
       request :list_global_operations

--- a/lib/fog/google/models/compute/flavor.rb
+++ b/lib/fog/google/models/compute/flavor.rb
@@ -8,16 +8,27 @@ module Fog
 
         identity :name
 
+        attribute :kind
+        attribute :id
+        attribute :creation_timestamp, :aliases => 'creationTimestamp'
+        attribute :deprecated
         attribute :description
         attribute :guest_cpus, :aliases => 'guestCpus'
-        attribute :memory_mb, :aliases => 'memoryMb'
         attribute :image_space_gb, :aliases => 'imageSpaceGb'
-        attribute :maximum_persistent_disks,
-          :aliases => 'maximumPersistentDisks'
-        attribute :maximum_persistent_disks_size,
-          :aliases => 'maximumPersistentDisksSizeGb'
+        attribute :maximum_persistent_disks, :aliases => 'maximumPersistentDisks'
+        attribute :maximum_persistent_disks_size, :aliases => 'maximumPersistentDisksSizeGb'
+        attribute :memory_mb, :aliases => 'memoryMb'
+        attribute :scratch_disks, aliases => 'scratchDisks'
         attribute :self_link, :aliases => 'selfLink'
+        attribute :zone
 
+        def reload
+          requires :identity, :zone
+
+          data = collection.get(identity, self.zone)
+          merge_attributes(data.attributes)
+          self
+        end
       end
 
     end

--- a/lib/fog/google/models/compute/flavors.rb
+++ b/lib/fog/google/models/compute/flavors.rb
@@ -9,14 +9,20 @@ module Fog
 
         model Fog::Compute::Google::Flavor
 
-        def all
-          zone = service.list_zones.body['items'].first
-          data = connection.list_machine_types(zone['name']).body["items"]
+        def all(filters = {})
+          if filters[:zone]
+            data = service.list_machine_types(filters[:zone]).body["items"]
+          else
+            data = []
+            service.list_aggregated_machine_types.body['items'].each_value do |zone|
+              data.concat(zone['machineTypes']) if zone['machineTypes']
+            end
+          end
           load(data)
         end
 
         def get(identity, zone_name = nil)
-          data = connection.get_machine_type(identity, zone_name).body
+          data = service.get_machine_type(identity, zone_name).body
           new(data)
         rescue Fog::Errors::NotFound
           nil

--- a/lib/fog/google/requests/compute/list_aggregated_machine_types.rb
+++ b/lib/fog/google/requests/compute/list_aggregated_machine_types.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Compute
+    class Google
+
+      class Mock
+        def list_aggregated_machine_types
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def list_aggregated_machine_types
+          api_method = @compute.machine_types.aggregated_list
+          parameters = {
+            'project' => @project,
+          }
+
+          result = self.build_result(api_method, parameters)
+          response = self.build_response(result)
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
- Add full "Machine Type" properties
- Replace deprecated "connection" for "service"
- Add "list_aggregated_machine_types" request
- Modify "all" method to return the full list of machine types (instead
  of the ones from the first zone)
