### PR TITLE
[google|compute] Modify Snapshots

### DIFF
--- a/lib/fog/google/models/compute/snapshot.rb
+++ b/lib/fog/google/models/compute/snapshot.rb
@@ -16,14 +16,29 @@ module Fog
         attribute :source_disk_id    , :aliases => 'sourceDiskId'
         attribute :description
         attribute :status
+        attribute :id
+        attribute :storage_bytes        , :aliases => 'storageBytes'
+        attribute :storage_bytes_status , :aliases => 'storageBytesStatus'
 
-        def reload
-          requires :name
+        CREATING_STATE  = 'CREATING'
+        DELETING_STATE  = 'DELETING'
+        FAILED_STATE    = 'FAILED'
+        READY_STATE     = 'READY'
+        UPLOADING_STATE = 'UPLOADING'
 
-          data = service.get_snapshot(name, self.service.project).body
+        def destroy(async=true)
+          requires :identity
 
-          self.merge_attributes(data)
-          self
+          data = service.delete_snapshot(identity)
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body['name'])
+          unless async
+            operation.wait_for { ready? }
+          end
+          operation
+        end
+
+        def ready?
+          self.status == READY_STATE
         end
 
         def resource_url

--- a/lib/fog/google/models/compute/snapshots.rb
+++ b/lib/fog/google/models/compute/snapshots.rb
@@ -10,15 +10,17 @@ module Fog
         model Fog::Compute::Google::Snapshot
 
         def all
-          data = service.list_snapshots(self.service.project)
+          data = service.list_snapshots
           snapshots = data.body['items'] || []
           load(snapshots)
         end
 
         def get(snap_id)
-          response = service.get_snapshot(snap_id, self.service.project)
+          response = service.get_snapshot(snap_id)
           return nil if response.nil?
           new(response.body)
+        rescue Fog::Errors::NotFound
+          nil
         end
 
       end

--- a/lib/fog/google/requests/compute/delete_snapshot.rb
+++ b/lib/fog/google/requests/compute/delete_snapshot.rb
@@ -4,7 +4,7 @@ module Fog
 
       class Mock
 
-        def delete_snapshot(snapshot_name, zone_name)
+        def delete_snapshot(snapshot_name)
           Fog::Mock.not_implemented
         end
 
@@ -12,16 +12,11 @@ module Fog
 
       class Real
 
-        def delete_snapshot(snapshot_name, zone_name)
-          if zone_name.start_with? 'http'
-            zone_name = zone_name.split('/')[-1]
-          end
-
+        def delete_snapshot(snapshot_name)
           api_method = @compute.snapshots.delete
           parameters = {
             'project' => @project,
             'snapshot' => snapshot_name,
-            'zone' => zone_name,
           }
 
           result = self.build_result(api_method, parameters)


### PR DESCRIPTION
- Add missing "Snapshot" properties
- Fix "delete" request, as "Snapshots" doesn't require a zone
- Added "destroy" and "ready?" methods to model
- Removed "project" param
- Removed custom "reload" method in favour of the standard fog method
