### PR TITLE
Pagination on Rackspace DNS records

### DIFF
--- a/lib/fog/rackspace/models/dns/records.rb
+++ b/lib/fog/rackspace/models/dns/records.rb
@@ -8,6 +8,7 @@ module Fog
       class Records < Fog::Collection
 
         attribute :zone
+        attribute :total_entries, :aliases => 'totalEntries'
 
         model Fog::DNS::Rackspace::Record
 
@@ -17,18 +18,25 @@ module Fog
           load(data.body['records'])
         end
 
-        def all!
+        alias :each_record_this_page :each
+        def each
           requires :zone
-          data = []
-          total_entries = nil
 
+          return self unless block_given?
+
+          entries = 0
           begin
-            resp = service.list_records(zone.id, :offset => data.size).body
-            total_entries ||= resp['totalEntries']
-            data += resp['records']
-          end while data.size < total_entries
+            body = service.list_records(zone.id, :offset => entries).body
+            entries += body['records'].size
 
-          load(data)
+            self.merge_attributes(body)
+
+            subset = dup.load(body['records'])
+            subset.each_record_this_page {|record| yield record }
+
+          end while entries < total_entries
+
+          self
         end
 
         def get(record_id)


### PR DESCRIPTION
This issue has popped up numerous times for Rackspace DNS _zones_, but was never corrected for _records_.

This issue #1172 is identical, but was closed referencing #1535, which is pagination for _zones_.

The max records per zone (by default) with Rackspace is 500, and the page limit is 100 by default.  Since the max records is relatively low, I've added a quick fix with the #all! method for our pipeline as this is a very crucial feature.

I hope to refine this into an #each method with test coverage, but I needed a quick fix for now, and wanted to make the issue known.
