### PR TITLE
. fix ruby-libvirt library require name (libvirt)

### DIFF
--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -61,7 +61,7 @@ end
 
 # mark libvirt tests pending if not setup
 begin
-  require('ruby-libvirt')
+  require('libvirt')
 rescue LoadError
   Formatador.display_line("[yellow]Skipping tests for [bold]libvirt[/] [yellow]due to missing `ruby-libvirt` gem.[/]")
   Thread.current[:tags] << '-libvirt'


### PR DESCRIPTION
Because `tests/helper.rb` requires `ruby-libvirt` by the wrong library name (`libvirt`), provider specific tests are not run.
Fixes #2858
