### PR TITLE
Added fix to allow progress bar to appear on VCD5.5

### DIFF
--- a/lib/fog/vcloud_director/models/compute/task.rb
+++ b/lib/fog/vcloud_director/models/compute/task.rb
@@ -37,6 +37,7 @@ module Fog
 
         def non_running?
           if @service.show_progress? && (@last_progress ||= 0) < 100
+            progress ||= 0
             if status == 'running'
               Formatador.redisplay_progressbar(progress, 100, :label => operation_name, :started_at => start_time)
               @last_progress = progress


### PR DESCRIPTION
The progress parameter is no longer present for task api calls
in VCD5.5, and so if progressbars are visible a Nil exception is
generated.

This ensures that progress is set and the execution flow can continue
