### PR TITLE
[google|storage] Enabled :path_style for Google Cloud Storage for allowing CNAME buckets

### DIFF
--- a/lib/fog/google/storage.rb
+++ b/lib/fog/google/storage.rb
@@ -5,7 +5,7 @@ module Fog
     class Google < Fog::Service
 
       requires :google_storage_access_key_id, :google_storage_secret_access_key
-      recognizes :host, :port, :scheme, :persistent
+      recognizes :host, :port, :scheme, :persistent, :path_style
 
       model_path 'fog/google/models/storage'
       collection  :directories
@@ -63,7 +63,7 @@ module Fog
 
         def request_params(params)
           subdomain = params[:host].split(".#{@host}").first
-          unless subdomain =~ /^(?!goog)(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
+          if @path_style or subdomain !~ /^(?!goog)(?:[a-z]|\d(?!\d{0,2}(?:\.\d{1,3}){3}$))(?:[a-z0-9]|\.(?![\.\-])|\-(?![\.])){1,61}[a-z0-9]$/
             if subdomain =~ /_/
               # https://github.com/fog/fog/pull/1258#issuecomment-10248620.
               Fog::Logger.warning("fog: the specified google storage bucket name (#{subdomain}) is not DNS compliant (only characters a through z, digits 0 through 9, and the hyphen).")
@@ -74,8 +74,9 @@ module Fog
               # - Bucket names cannot be represented as an IP address in dotted-decimal notation (for example, 192.168.5.4).
               # - Bucket names cannot begin with the "goog" prefix.
               # - Also, for DNS compliance, you should not have a period adjacent to another period or dash. For example, ".." or "-." or ".-" are not acceptable.
-              Fog::Logger.warning("fog: the specified google storage bucket name (#{subdomain}) is not a valid dns name.  See: https://developers.google.com/storage/docs/bucketnaming")
+              Fog::Logger.warning("fog: the specified google storage bucket name (#{subdomain}) is not a valid dns name.  See: https://developers.google.com/storage/docs/bucketnaming") unless @path_style
             end
+        
             params[:host] = params[:host].split("#{subdomain}.")[-1]
             if params[:path]
               params[:path] = "#{subdomain}/#{params[:path]}"
@@ -226,6 +227,7 @@ module Fog
           @persistent = options.fetch(:persistent, true)
           @port       = options[:port]        || 443
           @scheme     = options[:scheme]      || 'https'
+          @path_style = options[:path_style]  || false
         end
 
         def reload


### PR DESCRIPTION
e.g. paperclip configuration:

``` ruby
config.paperclip_defaults = {
      storage: :fog,
      fog_credentials: {
        provider: provider,
        google_storage_access_key_id: access_key_id,
        google_storage_secret_access_key: secret_access_key,
        path_style: true
      },
      fog_public: true,
      fog_directory: host,
      fog_host: 'http://' + host
    }
```
