### PR TITLE
[google|compute] Improve Server support

### DIFF
--- a/lib/fog/google/models/compute/server.rb
+++ b/lib/fog/google/models/compute/server.rb
@@ -221,7 +221,8 @@ module Fog
               'serviceAccounts' => service_accounts,
               'tags' => tags,
               'auto_restart' => auto_restart,
-              'on_host_maintenance' => on_host_maintenance
+              'on_host_maintenance' => on_host_maintenance,
+              'can_ip_forward' => can_ip_forward
           }.delete_if {|key, value| value.nil?}
 
           if service_accounts
@@ -234,10 +235,10 @@ module Fog
             }]
           end
 
-          service.insert_server(name, zone_name, options)
-          data = service.backoff_if_unfound {service.get_server(self.name, self.zone_name).body}
-
-          service.servers.merge_attributes(data)
+          data = service.insert_server(name, zone_name, options)
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data.body['name'], data.body['zone'])
+          operation.wait_for { !pending? }
+          reload
         end
 
       end

--- a/lib/fog/google/requests/compute/insert_server.rb
+++ b/lib/fog/google/requests/compute/insert_server.rb
@@ -142,12 +142,14 @@ module Fog
           # leave natIP undefined to use an IP from a shared ephemeral IP address pool
           if options.has_key? 'externalIp'
             access_config['natIP'] = options.delete 'externalIp'
+            # If set to 'false', that would mean user does no want to allocate an external IP
+            access_config = nil if access_config['natIP'] == false
           end
 
           networkInterfaces = []
           if ! network.nil?
             networkInterface = { 'network' => @api_url + @project + "/global/networks/#{network}" }
-            networkInterface['accessConfigs'] = [access_config]
+            networkInterface['accessConfigs'] = [access_config] if access_config
             networkInterfaces <<  networkInterface
           end
 
@@ -165,6 +167,11 @@ module Fog
                     ohm.upcase == "MIGRATE" && "MIGRATE") || "TERMINATE"
           end
           body_object['scheduling'] = scheduling
+
+          # @see https://developers.google.com/compute/docs/networking#canipforward
+          if options.has_key? 'can_ip_forward'
+            body_object['canIpForward'] = options.delete 'can_ip_forward'
+          end
 
           # TODO: add other networks
           body_object['networkInterfaces'] = networkInterfaces


### PR DESCRIPTION
- Allow can_ip_forward option when creating a server
- Allow not to allocate an external IP when creating a server
- Use "Operation" instead of the "backoff_if_unfound" method when creating a server
