### PR TITLE
[aws|elb] add support for ELB connection draining

### DIFF
--- a/lib/fog/aws/models/elb/load_balancer.rb
+++ b/lib/fog/aws/models/elb/load_balancer.rb
@@ -35,6 +35,23 @@ module Fog
           super
         end
 
+        def connection_draining?
+          requires :id
+          service.describe_load_balancer_attributes(id).body['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['ConnectionDraining']['Enabled']
+        end
+
+        def connection_draining_timeout
+          requires :id
+          service.describe_load_balancer_attributes(id).body['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['ConnectionDraining']['Timeout']
+        end
+
+        def set_connection_draining(enabled, timeout=nil)
+          requires :id
+          attrs = {'Enabled' => enabled}
+          attrs['Timeout'] = timeout if timeout
+          service.modify_load_balancer_attributes(id, 'ConnectionDraining' => attrs)
+        end
+
         def cross_zone_load_balancing?
           requires :id
           service.describe_load_balancer_attributes(id).body['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['CrossZoneLoadBalancing']['Enabled']

--- a/lib/fog/aws/parsers/elb/describe_load_balancer_attributes.rb
+++ b/lib/fog/aws/parsers/elb/describe_load_balancer_attributes.rb
@@ -13,6 +13,8 @@ module Fog
           def start_element(name, attrs = [])
             super
             case name
+            when 'ConnectionDraining'
+              @connection_draining = {}
             when 'CrossZoneLoadBalancing'
               @cross_zone_load_balancing = {}
             end
@@ -23,7 +25,16 @@ module Fog
             when 'Enabled'
               if @cross_zone_load_balancing
                 @cross_zone_load_balancing['Enabled'] = value == 'true' ? true : false
+              elsif @connection_draining
+                @connection_draining['Enabled'] = value == 'true' ? true : false
               end
+            when 'Timeout'
+              if @connection_draining
+                @connection_draining['Timeout'] = value.to_i
+              end
+            when 'ConnectionDraining'
+              @response['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['ConnectionDraining'] = @connection_draining
+              @connection_draining = nil
             when 'CrossZoneLoadBalancing'
               @response['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['CrossZoneLoadBalancing'] = @cross_zone_load_balancing
               @cross_zone_load_balancing = nil

--- a/lib/fog/aws/requests/elb/create_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer.rb
@@ -122,7 +122,10 @@ module Fog
             },
             'Instances' => [],
             'ListenerDescriptions' => listeners,
-            'LoadBalancerAttributes' => {'CrossZoneLoadBalancing' => {'Enabled' => false}},
+            'LoadBalancerAttributes' => {
+              'ConnectionDraining' => {'Enabled' => false, 'Timeout' => 300},
+              'CrossZoneLoadBalancing' => {'Enabled' => false}
+            },
             'LoadBalancerName' => lb_name,
             'Policies' => {
               'AppCookieStickinessPolicies' => [],

--- a/lib/fog/aws/requests/elb/describe_load_balancer_attributes.rb
+++ b/lib/fog/aws/requests/elb/describe_load_balancer_attributes.rb
@@ -17,6 +17,9 @@ module Fog
         #       * 'RequestId'<~String> - Id of request
         #     * 'DescribeLoadBalancerAttributesResult'<~Hash>:
         #       * 'LoadBalancerAttributes'<~Hash>
+        #         * 'ConnectionDraining'<~Hash>
+        #           * 'Enabled'<~Boolean> - whether connection draining is enabled
+        #           * 'Timeout'<~Integer> - max time (in seconds) to keep existing conns open before deregistering instances.
         #         * 'CrossZoneLoadBalancing'<~Hash>
         #           * 'Enabled'<~Boolean> - whether crosszone load balancing is enabled
         def describe_load_balancer_attributes(lb_name)

--- a/lib/fog/aws/requests/elb/modify_load_balancer_attributes.rb
+++ b/lib/fog/aws/requests/elb/modify_load_balancer_attributes.rb
@@ -8,13 +8,16 @@ module Fog
 
         # Sets attributes of the load balancer
         #
-        # Currently the only attribute that can be set is whether CrossZoneLoadBalancing
-        # is enabled
+        # Currently the only attributes that can be set are whether CrossZoneLoadBalancing
+        # or ConnectionDraining are enabled. You can also set the Timeout for ConnectionDraining.
         #
         # http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_ModifyLoadBalancerAttributes.html
         # ==== Parameters
         # * lb_name<~String> - Name of the ELB
         # * options<~Hash>
+        #   * 'ConnectionDraining'<~Hash>:
+        #     * 'Enabled'<~Boolean> whether to enable connection draining
+        #     * 'Timeout'<~Integer> max time to keep existing conns open before deregistering instances
         #   * 'CrossZoneLoadBalancing'<~Hash>:
         #     * 'Enabled'<~Boolean> whether to enable cross zone load balancing
         #
@@ -38,7 +41,7 @@ module Fog
         def modify_load_balancer_attributes(lb_name, attributes)
           raise Fog::AWS::ELB::NotFound unless load_balancer = self.data[:load_balancers][lb_name]
 
-          if attributes['CrossZoneLoadBalancing']
+          if attributes['CrossZoneLoadBalancing'] || attributes['ConnectionDraining']
             load_balancer['LoadBalancerAttributes'].merge! attributes
           end
 

--- a/tests/aws/models/elb/model_tests.rb
+++ b/tests/aws/models/elb/model_tests.rb
@@ -194,6 +194,14 @@ Shindo.tests('AWS::ELB | models', ['aws', 'elb']) do
       returns(@availability_zones) { elb.availability_zones.sort }
     end
 
+    tests('connection_draining') do
+      returns(false) { elb.connection_draining? }
+      returns(300) { elb.connection_draining_timeout }
+      elb.set_connection_draining(true, 60)
+      returns(true) { elb.connection_draining? }
+      returns(60) { elb.connection_draining_timeout }
+    end
+
     tests('cross_zone_load_balancing') do
       returns(false) {elb.cross_zone_load_balancing?}
       elb.cross_zone_load_balancing = true

--- a/tests/aws/requests/elb/load_balancer_tests.rb
+++ b/tests/aws/requests/elb/load_balancer_tests.rb
@@ -37,9 +37,23 @@ Shindo.tests('AWS::ELB | load_balancer_tests', ['aws', 'elb']) do
     end
 
     tests("modify_load_balancer_attributes") do
-      Fog::AWS[:elb].modify_load_balancer_attributes(@load_balancer_id, 'CrossZoneLoadBalancing' => {'Enabled' => true}).body
-      response = Fog::AWS[:elb].describe_load_balancer_attributes(@load_balancer_id).body
-      response['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['CrossZoneLoadBalancing']['Enabled'] == true
+      attributes = {
+        'ConnectionDraining' => {'Enabled' => true, 'Timeout' => 600},
+        'CrossZoneLoadBalancing' => {'Enabled' => true}
+      }
+      Fog::AWS[:elb].modify_load_balancer_attributes(@load_balancer_id, attributes).body
+      response = Fog::AWS[:elb].describe_load_balancer_attributes(@load_balancer_id).
+        body['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']
+
+      tests("ConnectionDraining is enabled") do
+        response['ConnectionDraining']['Enabled'] == true
+      end
+      tests("ConnectionDraining has a 600 second Timeout").returns(600) do
+        response['ConnectionDraining']['Timeout']
+      end
+      tests("CrossZoneLoadBalancing is enabled") do
+        response['CrossZoneLoadBalancing']['Enabled'] == true
+      end
     end
 
     tests("#configure_health_check").formats(AWS::ELB::Formats::CONFIGURE_HEALTH_CHECK) do


### PR DESCRIPTION
Add support for ELB connection draining: http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/config-conn-drain.html

This allows you to view whether Connection Draining is enabled or disabled, and also to view the Timeout setting. You can also toggle the feature on/off, and change its Timeout setting.

The relevant tests pass locally for `FOG_MOCK=true`. I tried running them with mocking disabled, but ran into the following issue:

```
  AWS::ELB | policy_tests (aws, elb) +++++++++++++++++++  
  AWS::ELB | models (aws, elb) +++++++++++++++++          
          /Users/bgentry/Code/fog/tests/aws/models/elb/model_tests.rb
            with vpc
            create
            success
            AWS::ELB | models (aws, elb)
          undefined method `ec2_compatibility_mode' for #<Fog::Compute::AWS::Real:0x007ff08eba0618> (NoMethodError)
            /Users/bgentry/Code/fog/tests/aws/models/elb/model_tests.rb:61:in `block (4 levels) in <top (required)>'
            /usr/local/opt/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/shindo-0.3.8/lib/shindo.rb:79:in `instance_eval'
            /usr/local/opt/rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/shindo-0.3.8/lib/shindo.rb:79:in `tests'
            /Users/bgentry/Code/fog/tests/aws/models/elb/model_tests.rb:60:in `block (3 levels) in <top (required)>'
```

When I added a stub for that method to `Fog::Compute::AWS::Real`, I still had some very strange results from unrelated tests. Maybe it's because I have an old (non-VPC default) AWS account? Maybe somebody else can run those tests with `FOG_MOCK=false` ?

/cc @mikehale @pedro
