### PR TITLE
Add the DisableApiTermination flag to the AWS Server model, so it can be...

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -17,6 +17,7 @@ module Fog
         attribute :block_device_mapping,     :aliases => 'blockDeviceMapping'
         attribute :network_interfaces,       :aliases => 'networkInterfaces'
         attribute :client_token,             :aliases => 'clientToken'
+        attribute :disable_api_termination,  :aliases => 'disableApiTermination'
         attribute :dns_name,                 :aliases => 'dnsName'
         attribute :ebs_optimized,            :aliases => 'ebsOptimized'
         attribute :groups
@@ -148,6 +149,7 @@ module Fog
             'BlockDeviceMapping'          => block_device_mapping,
             'NetworkInterfaces'           => network_interfaces,
             'ClientToken'                 => client_token,
+            'DisableApiTermination'       => disable_api_termination,
             'EbsOptimized'                => ebs_optimized,
             'IamInstanceProfile.Arn'      => @iam_instance_profile_arn,
             'IamInstanceProfile.Name'     => @iam_instance_profile_name,


### PR DESCRIPTION
... sent on instance creation

From RunInstances documentation (http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-RunInstances.html)

"DisableApiTermination
If you set this parameter to true, you can't terminate the instance using the Amazon EC2 console, CLI, or API; otherwise, you can. If you set this parameter to true and then later want to be able to terminate the instance, you must first change the value of the disableApiTermination attribute to false using ModifyInstanceAttribute. Alternatively, if you set InstanceInitiatedShutdownBehavior to terminate, you can terminate the instance by running the shutdown command from the instance.

Type: Boolean

Default: false

Required: No"
