### PR TITLE
[zerigo] Fix Invalid Excon request warning

### DIFF
--- a/lib/fog/zerigo/dns.rb
+++ b/lib/fog/zerigo/dns.rb
@@ -100,7 +100,7 @@ module Fog
           end
 
           begin
-            response = @connection.request(params.merge!({:host => @host}))
+            response = @connection.request(params)
           rescue Excon::Errors::HTTPStatusError => error
             raise case error
             when Excon::Errors::NotFound


### PR DESCRIPTION
This was triggering the warning:
`[excon][WARNING] Invalid Excon request keys: :host`

Followed by a stacktrace. Looking at [fog#2292](https://github.com/fog/fog/pull/2292) and the related
issues this seems like the right fix and seems to work fine.
