### PR TITLE
Allow vApp Template Instantiation without network_id

### DIFF
--- a/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
+++ b/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
@@ -36,8 +36,7 @@ module Fog
         def populate_uris(options = {})
           options[:vdc_id] || raise("vdc_id option is required")
           options[:vdc_uri] =  vdc_end_point(options[:vdc_id])
-          options[:network_id] || raise("network_id option is required")
-          options[:network_uri] = network_end_point(options[:network_id])
+          options[:network_uri] = network_end_point(options[:network_id]) if options[:network_id]
           options[:template_uri] = vapp_template_end_point(options[:template_id]) || raise("template_id option is required")
           options
         end


### PR DESCRIPTION
network_id should not be required in order to instantiate a vApp from template.
