### PR TITLE
AWS: Move PrivateIpAddress to the NetworkInterface structure if it exists

### DIFF
--- a/lib/fog/aws/models/compute/server.rb
+++ b/lib/fog/aws/models/compute/server.rb
@@ -189,6 +189,10 @@ module Fog
                 options["NetworkInterface.0.SecurityGroupId.0"] = options['SecurityGroupId']
               end
               options.delete('SecurityGroupId')              
+              if private_ip_address
+                options.delete('PrivateIpAddress')
+                options['NetworkInterface.0.PrivateIpAddress'] = private_ip_address
+              end
             end
           else
             options.delete('SubnetId')


### PR DESCRIPTION
When trying to associate a specific private ip address and a (non-elastic) public ip address, AWS requires the PrivateIpAddress value to be under the NetworkInterface structure.

Similar to the fix for: https://github.com/aws/aws-cli/issues/520
