### PR TITLE
Fix #2892: "rake travis" fails with can't modify frozen String

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -214,7 +214,7 @@ require "tasks/github_release_task"
 Fog::Rake::GithubReleaseTask.new
 
 task :coveralls_push_workaround do
-  use_coveralls = (Gem::Version.new(RUBY_VERSION) > Gem::Version.new('1.9.2'))
+  use_coveralls = (Gem::Version.new(String.new(RUBY_VERSION)) > Gem::Version.new('1.9.2'))
   if (ENV['COVERAGE'] != 'false') && use_coveralls
     require 'coveralls/rake/task'
     Coveralls::RakeTask.new


### PR DESCRIPTION
Make an unfrozen copy of RUBY_VERSION so that rubygems version can
strip! it.
