### PR TITLE
[rackspace] updating authentication endpoints

### DIFF
--- a/lib/fog/rackspace/core.rb
+++ b/lib/fog/rackspace/core.rb
@@ -101,7 +101,7 @@ module Fog
 
     def self.authenticate(options, connection_options = {})
       rackspace_auth_url = options[:rackspace_auth_url]
-      rackspace_auth_url ||= options[:rackspace_endpoint] == Fog::Compute::RackspaceV2::LON_ENDPOINT ? "lon.auth.api.rackspacecloud.com" : "auth.api.rackspacecloud.com"
+      rackspace_auth_url ||= options[:rackspace_endpoint] == Fog::Compute::RackspaceV2::LON_ENDPOINT ? UK_AUTH_ENDPOINT : US_AUTH_ENDPOINT
       url = rackspace_auth_url.match(/^https?:/) ? \
                 rackspace_auth_url : 'https://' + rackspace_auth_url
       uri = URI.parse(url)

--- a/tests/rackspace/cdn_tests.rb
+++ b/tests/rackspace/cdn_tests.rb
@@ -132,7 +132,7 @@ Shindo.tests('Fog::CDN::Rackspace', ['rackspace']) do
     
   begin      
     tests('publish_container').succeeds do
-      returns(nil, "CDN is not enabled") { container_meta_attributes['X-CDN-Enabled'] }
+      returns("False", "CDN is not enabled") { container_meta_attributes['X-CDN-Enabled'] }
       urls = @cdn.publish_container @directory
       returns(true, "hash contains expected urls") { Fog::CDN::Rackspace::Base::URI_HEADERS.values.all? { |url_type| urls[url_type] } }
       returns("True", "CDN is enabled") { container_meta_attributes['X-Cdn-Enabled'] }        


### PR DESCRIPTION
Updating authentication endpoints.

This should address the following [stack overflow](http://stackoverflow.com/questions/23184560/when-saving-a-file-to-rackspace-cloudfiles-using-paperclip-fog-a-timeout-occurs/23222021?noredirect=1#comment35555691_23222021) issue.
