### PR TITLE
allow files in personality to have symbol keys

### DIFF
--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -38,8 +38,8 @@ module Fog
             data['server']['personality'] = []
             for file in options['personality']
               data['server']['personality'] << {
-                'contents'  => Base64.encode64(file['contents']),
-                'path'      => file['path']
+                'contents'  => Base64.encode64(file['contents'] || file[:contents]),
+                'path'      => file['path'] || file[:path]
               }
             end
           end


### PR DESCRIPTION
Allow users to supply symbol keys for :contents and :path in the personality list.
