### PR TITLE
Lock down `rainbow` gem to 1.8.7 compatible

### DIFF
--- a/gemfiles/Gemfile-ruby-1.8.7
+++ b/gemfiles/Gemfile-ruby-1.8.7
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem 'nokogiri', '~>1.5.11'
 gem 'mime-types', '~>1.16'
+gem 'rainbow', '~> 1.99.2'
 
 group :development, :test do
   # This is here because gemspec doesn't support require: false


### PR DESCRIPTION
Seems `rainbow-v2.0` has dropped support for Ruby 1.8.7 so I've added a version constraint to the 1.8.7 Gemfile.

Locally everything is passing again.
