### PR TITLE
XenServer - attr_reader for Compute > connection > credentials

### DIFF
--- a/lib/fog/xenserver/compute.rb
+++ b/lib/fog/xenserver/compute.rb
@@ -113,6 +113,9 @@ module Fog
       request :snapshot_revert
 
       class Real
+          
+        attr_reader :connection
+
         def initialize(options={})
           @host        = options[:xenserver_url]
           @username    = options[:xenserver_username]

--- a/lib/fog/xenserver/core.rb
+++ b/lib/fog/xenserver/core.rb
@@ -13,6 +13,8 @@ module Fog
 
     class Connection
       require 'xmlrpc/client'
+      
+      attr_reader :credentials
 
       def initialize(host, timeout)
         @factory = XMLRPC::Client.new(host, '/')


### PR DESCRIPTION
This would implements #2940

To open a console RFB stream you need the console URL and the session_id. The session_id it's the connection value stored in credentials.
