### PR TITLE
[GH-2932] Disable brittle test

### DIFF
--- a/tests/aws/requests/compute/security_group_tests.rb
+++ b/tests/aws/requests/compute/security_group_tests.rb
@@ -1,4 +1,7 @@
 Shindo.tests('Fog::Compute[:aws] | security group requests', ['aws']) do
+  # See https://github.com/fog/fog/issues/2932hj0
+  pending
+
   @create_security_group_format = {
     'requestId' => String,
     'groupId'   => String,


### PR DESCRIPTION
The AWS security group tests have been very unstable with 2 failures on
Travis per build. The majority is the mocked version of
`describe_security_groups` not working.

We have decided to disable it until someone makes time to figure out the
bug since it is affecting every build.

See https://travis-ci.org/fog/fog/jobs/25614603#L1105
