### PR TITLE
Support Rackspace next link in user list

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -168,6 +168,7 @@
 * David Prater <dprater@cisco.com>
 * David Wittman <david@wittman.com>
 * Decklin Foster <decklin@red-bean.com>
+* Déja Augustine <daaugustine@gmail.com>
 * Diego Desani <diego@newservers.com>
 * Dmitry Dedov <dmitry.dedov@tut.by>
 * Dmitry Gutov <dgutov@yandex.ru>

--- a/lib/fog/rackspace/requests/databases/list_users.rb
+++ b/lib/fog/rackspace/requests/databases/list_users.rb
@@ -1,13 +1,34 @@
+require 'uri'
+
 module Fog
   module Rackspace
     class Databases
       class Real
-        def list_users(instance_id)
-          request(
+
+        def list_users(instance_id, prev=nil, path=nil)
+          path ||= "instances/#{instance_id}/users"
+
+          out = request(
             :expects => 200,
             :method => 'GET',
-            :path => "instances/#{instance_id}/users"
+            :path => path
           )
+
+          if prev && prev.data && out.data
+            prev.data[:body]['users'].concat(out.data[:body]['users'])
+            out.data[:body]['users'] = prev.data[:body]['users']
+          end
+
+          if out.body['links']
+            out.body['links'].each do |l|
+              if l['rel'] == "next"
+                uri = URI(l['href'])
+                out = list_users(instance_id, out, "instances/#{instance_id}/users?#{uri.query}")
+              end
+            end
+          end
+
+          out
         end
       end
     end


### PR DESCRIPTION
This is a fix for issue https://github.com/fog/fog/issues/2960 allowing for more than 20 cloud database instance users to be returned by the API
