### PR TITLE
Ruby 1.8.7 Sanity check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+## 1.22.1 05/29/2014
+*Hash* ca603769c940481885d60cda68288eb124c49cd6
+
+Statistic     | Value
+------------- | --------:
+Collaborators | 30
+Downloads     | 5483958
+Forks         | 1181
+Open Issues   | 180
+Watchers      | 3056
+
+**MVP!** Ferran Rodenas
+
+#### [GH-2873]
+*   Ensure fog is using fog-core 1.22+. thanks Paul Thornthwaite
+
+#### [google|compute]
+*   Add Region tests. thanks Ferran Rodenas
+*   Update Images support. thanks Ferran Rodenas
+*   Update Servers support. thanks Ferran Rodenas
+*   Improve Disks support. thanks Ferran Rodenas
+*   Update Addresses suport. thanks Ferran Rodenas
+
+#### [misc]
+*   Enabled :path_style for Google Cloud Storage for allowing CNAME buckets. thanks Romain Haenni
+
+
 ## 1.22.0 04/17/2014
 *Hash* 6d2c2d0575f9f7337bd01d17428dc12b7105329a
 

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -6,8 +6,8 @@ Gem::Specification.new do |s|
   ## If your rubyforge_project name is different, then edit it and comment out
   ## the sub! line in the Rakefile
   s.name              = 'fog'
-  s.version           = '1.22.0'
-  s.date              = '2014-04-17'
+  s.version           = '1.22.1'
+  s.date              = '2014-05-29'
   s.rubyforge_project = 'fog'
 
   ## Make sure your summary is short. The description may be as long


### PR DESCRIPTION
Okay. Travis is showing errors on MRI 1.8.7 at the point we wanted to make a `fog-v1.22.1` release...

https://travis-ci.org/fog/fog/builds/26281145

However Bundler is not detecting `celluloid` as a dependency, it passes locally for myself on MRI 1.8.7 and also on JRuby 1.8.7 on Travis.

This branch merges in the tag of the commit released as the `fog-1.22.1` gem to master and lo! it works!
