### PR TITLE
[google|compute] Add disk_size_gb to 'Image' model

### DIFF
--- a/lib/fog/google/models/compute/image.rb
+++ b/lib/fog/google/models/compute/image.rb
@@ -12,6 +12,7 @@ module Fog
         attribute :creation_timestamp, :aliases => 'creationTimestamp'
         attribute :deprecated
         attribute :description
+        attribute :disk_size_gb, :aliases => 'diskSizeGb'
         attribute :self_link, :aliases => 'selfLink'
         attribute :source_type, :aliases => 'sourceType'
         attribute :status


### PR DESCRIPTION
Added new field to Image model, named diskSizeGb, which shows the
size of the image when it is restored to a persistent disk, in GB.
