### PR TITLE
[stormondemand|dns] fixing typo in require statement

### DIFF
--- a/lib/fog/storm_on_demand/models/dns/reverses.rb
+++ b/lib/fog/storm_on_demand/models/dns/reverses.rb
@@ -1,4 +1,4 @@
-require 'fog/core/colletion'
+require 'fog/core/collection'
 require 'fog/storm_on_demand/models/dns/reverse'
 
 module Fog


### PR DESCRIPTION
This PR fixes a typo in a require statement.
