### PR TITLE
[vcloud_director] Add :put_network request

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -245,6 +245,7 @@ module Fog
       request :put_media_metadata_item_metadata
       request :put_memory
       request :put_metadata_value # deprecated
+      request :put_network
       request :put_network_connection_system_section_vapp
       request :put_vapp_metadata_item_metadata
       request :put_vapp_name_and_description

--- a/lib/fog/vcloud_director/requests/compute/put_network.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_network.rb
@@ -1,0 +1,158 @@
+module Fog
+  module Compute
+    class VcloudDirector
+      class Real
+        require 'fog/vcloud_director/generators/compute/org_vdc_network'
+
+        # Update an Org vDC network.
+        #
+        # This operation is asynchronous and returns a task that you can
+        # monitor to track the progress of the request.
+        #
+        # Produce media type(s):
+        # application/vnd.vmware.vcloud.orgVdcNetwork+xml
+        # Output type:
+        # TaskType
+        #
+        # @param [String] id Object identifier of the network
+        # @param [String] name   The name of the entity.
+        # @param [Hash] options
+        # @option options [String] :Description Optional description.
+        # @option options [Hash] :Configuration Network configuration.
+        # @option options [Hash] :EdgeGateway  EdgeGateway that connects this
+        #   Org vDC network. Applicable only for routed networks.
+        # @option options [Hash] :ServiceConfig Specifies the service
+        #   configuration for an isolated Org vDC networks.
+        # @option options [Boolean] :IsShared True if this network is shared
+        #   to multiple Org vDCs.
+        #   * :Configuration<~Hash>: NetworkConfigurationType
+        #     * :IpScopes<~Hash>:
+        #       * :IpScope<~Hash>:
+        #         * :IsInherited<~Boolean>: ?
+        #         * :Gateway<~String>: IP address of gw
+        #         * :Netmask<~String>: Subnet mask of network
+        #         * :Dns1<~String>: Primary DNS server.
+        #         * :Dns2<~String>: Secondary DNS server.
+        #         * :DnsSuffix<~String>: DNS suffix.
+        #         * :IsEnabled<~String>: Indicates if subnet is enabled or not.
+        #                                Default value is True.
+        #         * :IpRanges<~Array>: IP ranges used for static pool allocation
+        #                             in the network. Array of Hashes of:
+        #                               * :StartAddress - start IP in range
+        #                               * :EndAddress - end IP in range
+        #   * :EdgeGateway<~Hash>: EdgeGateway that connects this Org vDC
+        #                          network. Applicable only for routed networks.
+        #   * :ServiceConfig<~Hash>: Specifies the service configuration for an
+        #                            isolated network
+        #
+        # @return [Excon::Response]
+        #   * body<~Hash>:
+        #
+        # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/operations/POST-CreateOrgVdcNetwork.html
+        # @since vCloud API version 5.1
+        def put_network(id, name, options={})
+          body = Fog::Generators::Compute::VcloudDirector::OrgVdcNetwork.new(options.merge(:name => name)).generate_xml
+
+          request(
+            :body    => body,
+            :expects => 202,
+            :headers => {'Content-Type' => 'application/vnd.vmware.vcloud.orgVdcNetwork+xml'},
+            :method  => 'PUT',
+            :parser  => Fog::ToHashDocument.new,
+            :path    => "admin/network/#{id}"
+          )
+        end
+      end
+
+      class Mock
+        def put_network(id, name, options={})
+          original_network = data[:networks][id]
+          unless original_network
+            raise Fog::Compute::VcloudDirector::Forbidden.new(
+              "No access to entity \"(com.vmware.vcloud.entity.orgVdcNetwork:#{id})\"."
+            )
+          end
+
+          type = 'network'
+
+          # Description
+          # Configuration
+          #   IpScopes
+          #     IpScope
+          #       IsInherited
+          #       Gateway
+          #       Netmask
+          #       Dns1
+          #       Dns2
+          #       DnsSuffix
+          #       IsEnabled
+          #       IpRanges
+          #         IpRange
+          #           StartAddress
+          #           EndAddress
+          #   FenceMode
+          # EdgeGateway
+          # IsShared
+          #
+          vdc_id = original_network[:vdc],
+
+          network_body = {
+            :name => name,
+            :vdc  => vdc_id,
+          }
+
+          [:Description, :IsShared].each do |key|
+            network_body[key] = options[key] if options.key?(key)
+          end
+
+          if options.key?(:EdgeGateway)
+            network_body[:EdgeGateway] =
+              options[:EdgeGateway][:href].split('/').last
+          end
+
+          if configuration = options[:Configuration]
+            if ip_scopes = configuration[:IpScopes]
+              if ip_scope = ip_scopes[:IpScope]
+                [:IsInherited, :Gateway, :Netmask,
+                  :Dns1, :Dns2, :DnsSuffix, :IsEnabled].each do |key|
+                    network_body[key] = ip_scope[key] if ip_scope.key?(key)
+                end
+                if ip_ranges = ip_scope[:IpRanges]
+                  network_body[:IpRanges] = []
+                  ip_ranges.each do |ipr|
+                    network_body[:IpRanges] << {
+                      :StartAddress => ipr[:IpRange][:StartAddress],
+                      :EndAddress   => ipr[:IpRange][:EndAddress]
+                    }
+                  end
+                end
+              end
+            end
+            network_body[:FenceMode] = configuration[:FenceMode] if ip_scope.key?(:FenceMode)
+          end
+
+          owner = {:href => '', :name => nil, :type => nil} #known-bug: admin-api does not return owner.
+          task_id = enqueue_task(
+            "Updating #{type} #{name} (#{id})", 'networkUpdateNetwork', owner,
+            :on_success => lambda do
+              data[:networks][id] = network_body
+            end
+          )
+
+          body = {
+              :xmlns => xmlns,
+              :xmlns_xsi => xmlns_xsi,
+              :xsi_schemaLocation => xsi_schema_location,
+          }.merge(task_body(task_id))
+
+          Excon::Response.new(
+            :status => 202,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
+
+        end
+      end
+    end
+  end
+end

--- a/tests/vcloud_director/requests/compute/network_tests.rb
+++ b/tests/vcloud_director/requests/compute/network_tests.rb
@@ -50,16 +50,6 @@ Shindo.tests('Compute::VcloudDirector | network requests', ['vclouddirector']) d
     @service.get_network(@network_id).body
   end
 
-  tests('#get_network_complete').data_matches_schema(VcloudDirector::Compute::Schema::NETWORK_TYPE) do
-    pending if Fog.mocking?
-    link = @org[:Link].find do |l|
-      l[:rel] == 'down' && l[:type] == 'application/vnd.vmware.vcloud.orgNetwork+xml'
-    end
-    pending unless link # nothing to test here cannot continue
-    @network_id = link[:href].split('/').last
-    @service.get_network_complete(@network_id).body
-  end
-
   tests('#get_network_metadata').data_matches_schema(VcloudDirector::Compute::Schema::METADATA_TYPE) do
     pending if Fog.mocking?
     pending unless @network_id  # nothing to test here cannot continue
@@ -67,7 +57,7 @@ Shindo.tests('Compute::VcloudDirector | network requests', ['vclouddirector']) d
   end
 
   tests('#post_create_org_vdc_network') do
-    pending unless Fog.mocking?
+    #pending unless Fog.mocking?
     link = @org[:Link].find do |l|
       l[:rel] == 'down' && l[:type] == 'application/vnd.vmware.vcloud.vdc+xml'
     end
@@ -101,13 +91,91 @@ Shindo.tests('Compute::VcloudDirector | network requests', ['vclouddirector']) d
     @service.process_task(body[:Tasks][:Task]) if body && body.key?(:Tasks)
 
     tests('fetched name matches created name').returns(name) do
-      net = @service.get_network(@created_net_id).body
+      net = @service.get_network_complete(@created_net_id).body
       net[:name]
+    end
+
+  end
+
+  tests('#get_network_complete schema').data_matches_schema(VcloudDirector::Compute::Schema::NETWORK_TYPE) do
+    link = @org[:Link].find do |l|
+      l[:rel] == 'down' && l[:type] == 'application/vnd.vmware.vcloud.orgNetwork+xml'
+    end
+    pending unless link # nothing to test here cannot continue
+    @network_id = link[:href].split('/').last
+    @service.get_network_complete(@network_id).body
+  end
+
+  tests('#get_network_complete') do
+    new_network = @service.get_network_complete(@created_net_id).body
+    tests('network has a :name') do
+      new_network.fetch(:name)
+    end
+    tests('network has a :Description') do
+      new_network.fetch(:Description)
+    end
+    tests('network has a :Gateway') do
+      new_network[:Configuration][:IpScopes][:IpScope][:Gateway]
+    end
+    tests('network has a several :IpRanges') do
+      new_network[:Configuration][:IpScopes][:IpScope][:IpRanges].size >= 1
     end
   end
 
+  tests('#put_network') do
+
+    new_options = {
+      :Description => "Testing put_network",
+      :Configuration => {
+        :IpScopes => {
+          :IpScope => {
+            :IsInherited => 'false',
+            :Gateway => '198.51.100.1',
+            :Netmask => '255.255.255.0',
+            :Dns1    => '198.51.100.2',
+            :Dns2    => '198.51.100.3',
+            :DnsSuffix => 'example.com',
+            :IpRanges => [
+              { :IpRange => { :StartAddress => '198.51.100.10', :EndAddress => '198.51.100.20' } },
+              { :IpRange => { :StartAddress => '198.51.100.30', :EndAddress => '198.51.100.40' } },
+            ]
+          },
+        },
+        :FenceMode => 'isolated',
+      }
+    }
+
+    original_network = @service.get_network_complete(@created_net_id).body
+    name = original_network[:name]
+
+    task = @service.put_network(@created_net_id, name, new_options).body
+    @service.process_task(task)
+
+    tests('fetched :Gateway matches updated :Gateway').returns(
+      new_options[:Configuration][:IpScopes][:IpScope][:Gateway]
+    ) do
+      net = @service.get_network_complete(@created_net_id).body
+      net[:Configuration][:IpScopes][:IpScope][:Gateway]
+    end
+
+    tests('fetched :IpRanges count is matches updated data').returns(
+      new_options[:Configuration][:IpScopes][:IpScope][:IpRanges].size
+    ) do
+      net = @service.get_network_complete(@created_net_id).body
+      # dammit, the API returns with IpRange as a list, not IpRanges
+      net[:Configuration][:IpScopes][:IpScope][:IpRanges][:IpRange].size
+    end
+
+    tests('fetched :Network matches updated :Description').returns(
+      new_options[:Description]
+    ) do
+      net = @service.get_network_complete(@created_net_id).body
+      net[:Description]
+    end
+
+  end
+
   tests('#delete_network') do
-    pending unless Fog.mocking?
     @delete_task = @service.delete_network(@created_net_id).body
     @service.process_task(@delete_task)
     tests('created network has been deleted').raises(Fog::Compute::VcloudDirector::Forbidden) do

--- a/tests/vcloud_director/requests/compute/schema_helper.rb
+++ b/tests/vcloud_director/requests/compute/schema_helper.rb
@@ -619,7 +619,9 @@ class VcloudDirector
             :Netmask => String,
             :Dns1 => String,
             :Dns2 => String,
+            :DnsSuffix => String,
             :IsEnabled=> String,
+            :IpRanges=> IP_RANGES_TYPE,
           }
         },
         :FenceMode => String,
@@ -630,7 +632,6 @@ class VcloudDirector
         :name => String,
         :href => String,
         :type => String,
-        :status => String,
         :id => String,
         :Description => String,
         :Configuration => NETWORK_CONFIGURATION_TYPE,


### PR DESCRIPTION
The put_network request updates OrgVdcNetwork details:
- name,
- dns properties,
- gateway

There appear to be some limitations with what the API will allow
to be changes (such as IpRanges) but the input/output of the method
is mapped as usual.

This also adds Mock support for the method.

Network tests have been adjusted so that they work in Mock and Real
mode (bar network_metadata, which is to be implemented in Mock).
