### PR TITLE
[aws/security_group] Support mock of group from another account

### DIFF
--- a/lib/fog/aws/requests/compute/authorize_security_group_ingress.rb
+++ b/lib/fog/aws/requests/compute/authorize_security_group_ingress.rb
@@ -185,7 +185,7 @@ module Fog
                     security_group = if group_name = authorized_group['GroupName']
                                        self.data[:security_groups][group_name] || {}
                                      elsif group_id = authorized_group['GroupId']
-                                       self.data[:security_groups].values.find { |sg| sg['groupId'] == group_id }
+                                       self.data[:security_groups].values.find { |sg| sg['groupId'] == group_id } || {}
                                      end
 
                     {'groupName' => authorized_group['GroupName'] || security_group["groupName"], 'userId' => authorized_group['UserId'] || self.data[:owner_id], 'groupId' => authorized_group["GroupId"] || security_group['groupId']}
@@ -199,7 +199,7 @@ module Fog
                     security_group = if group_name = authorized_group['GroupName']
                                        self.data[:security_groups][group_name] || {}
                                      elsif group_id = authorized_group['GroupId']
-                                       self.data[:security_groups].values.find { |sg| sg['groupId'] == group_id }
+                                       self.data[:security_groups].values.find { |sg| sg['groupId'] == group_id } || {}
                                      end
 
                     {'groupName' => authorized_group['GroupName'] || security_group["groupName"], 'userId' => authorized_group['UserId'] || self.data[:owner_id], 'groupId' => authorized_group["GroupId"] || security_group['groupId']}

--- a/tests/aws/models/compute/security_group_tests.rb
+++ b/tests/aws/models/compute/security_group_tests.rb
@@ -8,6 +8,9 @@ Shindo.tests("Fog::Compute[:aws] | security_group", ['aws']) do
     @other_group = Fog::Compute[:aws].security_groups.create(:name => 'fog other group', :description => 'another fog group')
     @other_group.reload
 
+    @other_user_id = Fog::AWS::Mock.owner_id
+    @other_users_group_id = Fog::AWS::Mock.security_group_id
+
     test("authorize access by another security group") do
       @group.authorize_group_and_owner(@other_group.name)
       @group.reload
@@ -35,7 +38,8 @@ Shindo.tests("Fog::Compute[:aws] | security_group", ['aws']) do
     group_forms = [
       "#{@other_group.owner_id}:#{@other_group.group_id}", # deprecated form
       @other_group.group_id,
-      {@other_group.owner_id => @other_group.group_id}
+      {@other_group.owner_id => @other_group.group_id},
+      {@other_user_id => @other_users_group_id}
     ]
 
     group_forms.each do |group_arg|


### PR DESCRIPTION
It is possible to have a security group rule refer to group that is a
different account, by UserId and GroupId or GroupName. If a GroupName is
not supplied, the security group mocking implementation searches for the
security group that matches the supplied GroupId. This commit allows for
a default GroupName of nil if it is not supplied.
