### PR TITLE
AWS RDS - Fix EngineVersion for PendingModifiedValues (plus minor cleanup)

### DIFF
--- a/lib/fog/aws/parsers/rds/db_parser.rb
+++ b/lib/fog/aws/parsers/rds/db_parser.rb
@@ -48,8 +48,7 @@ module Fog
 
             when 'LatestRestorableTime', 'InstanceCreateTime'
               @db_instance[name] = Time.parse value
-            when 'Engine',
-              'DBInstanceStatus', 'DBInstanceIdentifier', 'EngineVersion',
+            when 'Engine', 'DBInstanceStatus', 'DBInstanceIdentifier', 
               'PreferredBackupWindow', 'PreferredMaintenanceWindow',
               'AvailabilityZone', 'MasterUsername', 'DBName', 'LicenseModel',
               'DBSubnetGroupName'
@@ -77,7 +76,8 @@ module Fog
               else
                 @db_instance[name] = value.to_i
               end
-            when 'DBInstanceClass', 'EngineVersion', 'MasterUserPassword', 'MultiAZ'
+            when 'DBInstanceClass', 'EngineVersion', 'MasterUserPassword', 
+                'MultiAZ', 'Iops', 'AllocatedStorage'
               if @in_pending_modified_values
                 @pending_modified_values[name] = value
               else
@@ -100,18 +100,6 @@ module Fog
               @vpc_security_group = {}
             when 'VpcSecurityGroupId'
               @vpc_security_group[name] = value
-            when 'Iops'
-              if @in_pending_modified_values
-                @pending_modified_values[name] = value.to_i
-              else
-                @db_instance[name] = value.to_i
-              end
-            when 'AllocatedStorage'
-              if @in_pending_modified_values
-                @pending_modified_values[name] = value.to_i
-              else
-                @db_instance[name] = value.to_i
-              end
 
             when 'Status'
               # Unfortunately, status is used in VpcSecurityGroupMemebership and


### PR DESCRIPTION
Changes handling of 'EngineVersion' in the RDS DB parser so that it will correctly appear in the PendingModifiedValues hash. (Note the differences in Fog's response versus the proper one from Amazon.) Previously, 'EngineVersion' was appearing in two places in the response parser code; the second occurrence would never be processed.

I also moved 'Iops' and 'AllocatedStorage' to be handled by the same code block, to reduce code duplication.

Current response from Amazon via command line:
"PendingModifiedValues": {
                "DBInstanceClass": "db.t1.micro", 
                "EngineVersion": "5.6.17"
            } 

Fog's, before this change:
"PendingModifiedValues": {
                "DBInstanceClass": "db.t1.micro"
            }
