### PR TITLE
[vcloud_director] Fix VM Customization 400 

### DIFF
--- a/lib/fog/vcloud_director/parsers/compute/vm_customization.rb
+++ b/lib/fog/vcloud_director/parsers/compute/vm_customization.rb
@@ -34,6 +34,7 @@ module Fog
               @response[:admin_password] = value
             when 'AdminPasswordEnabled'
               @response[:admin_password_enabled] = (value == "true")
+              @response[:admin_password] = '' unless @response[:admin_password_enabled]
             when 'AdminPasswordAuto'
               @response[:admin_password_auto] = (value == "true")
             when 'ResetPasswordRequired'


### PR DESCRIPTION
The AdminPassword XML element isn't present unless AdminPasswordEnabled but the API on the other end expects it to be set.