### PR TITLE
including source_volid data in request for cloning

### DIFF
--- a/lib/fog/rackspace/requests/block_storage/create_volume.rb
+++ b/lib/fog/rackspace/requests/block_storage/create_volume.rb
@@ -41,6 +41,7 @@ module Fog
           data['volume']['volume_type'] = options[:volume_type] unless options[:volume_type].nil?
           data['volume']['availability_zone'] = options[:availability_zone] unless options[:availability_zone].nil?
           data['volume']['snapshot_id'] = options[:snapshot_id] unless options[:snapshot_id].nil?
+          data['volume']['source_volid'] = options[:source_volid] unless options[:source_volid].nil?
 
           request(
             :body => Fog::JSON.encode(data),


### PR DESCRIPTION
It would be useful to automate cloning of volumes. It's simply allowing another data point through the request. 'source_volid' is supported in Rackspace API. http://docs.rackspace.com/cbs/api/v1.0/cbs-devguide/content/POST_createVolume_v1__tenant_id__volumes_volumes.html