### PR TITLE
[Google|Storage] remove :url param from get_service request for google storage

### DIFF
--- a/lib/fog/google/requests/storage/get_service.rb
+++ b/lib/fog/google/requests/storage/get_service.rb
@@ -22,8 +22,7 @@ module Fog
             :host     => @host,
             :idempotent => true,
             :method   => 'GET',
-            :parser   => Fog::Parsers::Storage::Google::GetService.new,
-            :url      => @host
+            :parser   => Fog::Parsers::Storage::Google::GetService.new
           })
         end
       end


### PR DESCRIPTION
The format of `request` method was slightly changed by this [commit](https://github.com/fog/fog/commit/e3299982ee882c5789e54401dd56f2dd892185eb). Still in  [storage/get_service.rb](https://github.com/fog/fog/blob/master/lib/fog/google/requests/storage/get_service.rb) we [place](https://github.com/fog/fog/blob/master/lib/fog/google/requests/storage/get_service.rb#L26) `url` option. This cause Excon warning message every time you initialize Google Storage object. Here is an output from my console:

```
[excon][WARNING] Invalid Excon request keys: :url
/Users/allomov/.rvm/gems/ruby-2.1.1/gems/excon-0.37.0/lib/excon/connection.rb:393:in `validate_params'
/Users/allomov/.rvm/gems/ruby-2.1.1/gems/excon-0.37.0/lib/excon/connection.rb:229:in `request'
/Users/allomov/work/github/fog/lib/fog/xml/sax_parser_connection.rb:35:in `request'
/Users/allomov/work/github/fog/lib/fog/xml.rb:21:in `request'
/Users/allomov/work/github/fog/lib/fog/google/storage.rb:296:in `request'
/Users/allomov/work/github/fog/lib/fog/google/requests/storage/get_service.rb:19:in `get_service'
/Users/allomov/work/github/fog/lib/fog/google/models/storage/directories.rb:11:in `all'
/Users/allomov/.rvm/gems/ruby-2.1.1/gems/fog-core-1.22.0/lib/fog/core/collection.rb:139:in `lazy_load'
/Users/allomov/.rvm/gems/ruby-2.1.1/gems/fog-core-1.22.0/lib/fog/core/collection.rb:15:in `first'
fog_clean_gce.rb:30:in `<main>'
```
