### PR TITLE
[Google | refactor] Remove backoff_if_unfound method from google compute service

### DIFF
--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -178,23 +178,6 @@ module Fog
           response
         end
 
-        def backoff_if_unfound(&block)
-          retries_remaining = 10
-          sleep_time = 0.1
-          begin
-            result = block.call
-          rescue Exception => msg
-            if msg.to_s.include? 'was not found' and retries_remaining > 0
-              retries_remaining -= 1
-              sleep sleep_time
-              sleep_time *= 1.6
-              retry
-            else
-              raise msg
-            end
-          end
-          result
-        end
       end
 
       class Mock

--- a/lib/fog/google/models/compute/forwarding_rule.rb
+++ b/lib/fog/google/models/compute/forwarding_rule.rb
@@ -29,10 +29,10 @@ module Fog
             'target' => target
           }
 
-          service.insert_forwarding_rule(name, region, options).body
-          data = service.backoff_if_unfound {service.get_forwarding_rule(name, region).body}
-          merge_attributes(data)
-          self
+          data = service.insert_forwarding_rule(name, region, options).body
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data['name'], data['zone'])
+          operation.wait_for { !pending? }
+          reload
         end
 
         def set_target new_target

--- a/lib/fog/google/models/compute/http_health_check.rb
+++ b/lib/fog/google/models/compute/http_health_check.rb
@@ -33,9 +33,10 @@ module Fog
             'healthyThreshold' => healthy_threshold || 2,
           }
 
-          service.insert_http_health_check(name, options).body
-          data = service.backoff_if_unfound {service.get_http_health_check(name).body}
-          merge_attributes(data)
+          data = service.insert_http_health_check(name, options).body
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data['name'], data['zone'])
+          operation.wait_for { !pending? }
+          reload
         end
 
         def destroy(async=true)

--- a/lib/fog/google/models/compute/target_pool.rb
+++ b/lib/fog/google/models/compute/target_pool.rb
@@ -31,10 +31,10 @@ module Fog
             'backupPool' => backup_pool
           }
 
-          service.insert_target_pool(name, region, options).body
-          data = service.backoff_if_unfound {service.get_target_pool(name, region).body}
-          merge_attributes(data)
-          self
+          data = service.insert_target_pool(name, region, options).body
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data['name'], data['zone'])
+          operation.wait_for { !pending? }
+          reload
         end
 
         def destroy(async=true)


### PR DESCRIPTION
The better way to wait until resource is created is to check if operation object that is return by API call is ready. Since we use this approach in other places, I've decided to remove usage `backoff_if_unfound`. Also `backoff_if_unfound` was complication and wasn't tested.

It could be a better way of getting `operation` object, but I've done it this way using other models as an example.

I've run manually mock and live tests (live tests was take from #2995): all tests passed.
