### PR TITLE
Support for required EvaluateTargetHealth for ALIAS records

### DIFF
--- a/lib/fog/aws/dns.rb
+++ b/lib/fog/aws/dns.rb
@@ -96,7 +96,7 @@ module Fog
           @persistent = options.fetch(:persistent, true)
           @port       = options[:port]        || 443
           @scheme     = options[:scheme]      || 'https'
-          @version    = options[:version]     || '2012-02-29'
+          @version    = options[:version]     || '2013-04-01'
 
           @connection = Fog::XML::Connection.new("#{@scheme}://#{@host}:#{@port}#{@path}", @persistent, @connection_options)
         end

--- a/lib/fog/aws/requests/dns/change_resource_record_sets.rb
+++ b/lib/fog/aws/requests/dns/change_resource_record_sets.rb
@@ -21,6 +21,7 @@ module Fog
         #     * alias_target<~Hash> - Information about the domain to which you are redirecting traffic (Alias record sets only)
         #       * dns_name<~String> - The Elastic Load Balancing domain to which you want to reroute traffic
         #       * hosted_zone_id<~String> - The ID of the hosted zone that contains the Elastic Load Balancing domain to which you want to reroute traffic
+        #       * evaluate_target_health<~Boolean> - Applies only to alias, weighted alias, latency alias, and failover alias resource record sets: If you set the value of EvaluateTargetHealth to true, the alias resource record sets inherit the health of the referenced resource record sets.
         # ==== Returns
         # * response<~Excon::Response>:
         #   * body<~Hash>:
@@ -106,7 +107,9 @@ module Fog
                 # Accept either underscore or camel case for hash keys.
                 dns_name = change_item[:alias_target][:dns_name] || change_item[:alias_target][:DNSName]
                 hosted_zone_id = change_item[:alias_target][:hosted_zone_id] || change_item[:alias_target][:HostedZoneId] || AWS.hosted_zone_for_alias_target(dns_name)
-                alias_target_tag += %Q{<AliasTarget><HostedZoneId>#{hosted_zone_id}</HostedZoneId><DNSName>#{dns_name}</DNSName></AliasTarget>}
+                evaluate_target_health = change_item[:alias_target][:evaluate_target_health] || change_item[:alias_target][:EvaluateTargetHealth] || false
+                evaluate_target_health_xml = !evaluate_target_health.nil? ? %Q{<EvaluateTargetHealth>#{evaluate_target_health}</EvaluateTargetHealth>} : ''
+                alias_target_tag += %Q{<AliasTarget><HostedZoneId>#{hosted_zone_id}</HostedZoneId><DNSName>#{dns_name}</DNSName>#{evaluate_target_health_xml}</AliasTarget>}
               end
 
               change_tags = %Q{<Change>#{action_tag}<ResourceRecordSet>#{name_tag}#{type_tag}#{set_identifier_tag}#{weight_tag}#{region_tag}#{ttl_tag}#{resource_tag}#{alias_target_tag}</ResourceRecordSet></Change>}

--- a/tests/aws/requests/dns/dns_tests.rb
+++ b/tests/aws/requests/dns/dns_tests.rb
@@ -180,8 +180,9 @@ Shindo.tests('Fog::DNS[:aws] | DNS requests', ['aws', 'dns']) do
       # create an ALIAS record
       host = @domain_name
       alias_target = {
-        :hosted_zone_id => hosted_zone_id,
-        :dns_name       => dns_name
+        :hosted_zone_id         => hosted_zone_id,
+        :dns_name               => dns_name,
+        :evaluate_target_health => false
       }
       resource_record = { :name => host, :type => 'A', :alias_target => alias_target }
       resource_record_set = resource_record.merge(:action => 'CREATE')
@@ -245,7 +246,7 @@ Shindo.tests('Fog::DNS[:aws] | DNS requests', ['aws', 'dns']) do
       response = @r53_connection.create_hosted_zone('invalid-domain')
     end
 
-    tests('get hosted zone using invalid ID').raises(Excon::Errors::Forbidden) do
+    tests('get hosted zone using invalid ID').raises(Excon::Errors::NotFound) do
       pending if Fog.mocking?
       zone_id = 'dummy-id'
       response = @r53_connection.get_hosted_zone(zone_id)


### PR DESCRIPTION
Note an error was being raised when using the old API about EvaluateTargetHealth being missing.

```
Excon::Errors::BadRequest: Expected(200) <=> Actual(400 Bad Request)
  response => #<Excon::Response:0x007fde3baf66a0 @data={:body=>"<?xml version=\"1.0\"?>\n<ErrorResponse xmlns=\"https://route53.amazonaws.com/doc/2013-04-01/\"><Error><Type>Sender</Type><Code>InvalidInput</Code><Message>Invalid XML ; cvc-complex-type.2.4.b: The content of element 'AliasTarget' is not complete. One of '{&quot;https://route53.amazonaws.com/doc/2013-04-01/&quot;:EvaluateTargetHealth}' is expected.</Message></Error><RequestId>f141b55c-f726-11e3-b2ac-73337c63db62</RequestId></ErrorResponse>", :headers=>{"x-amzn-RequestId"=>"f141b55c-f726-11e3-b2ac-73337c63db62", "Content-Type"=>"text/xml", "Content-Length"=>"438", "Date"=>"Wed, 18 Jun 2014 20:27:17 GMT"}, :status=>400, :remote_ip=>"72.21.214.31", :local_port=>60240, :local_address=>"192.168.1.85"}, @body="<?xml version=\"1.0\"?>\n<ErrorResponse xmlns=\"https://route53.amazonaws.com/doc/2013-04-01/\"><Error><Type>Sender</Type><Code>InvalidInput</Code><Message>Invalid XML ; cvc-complex-type.2.4.b: The content of element 'AliasTarget' is not complete. One of '{&quot;https://route53.amazonaws.com/doc/2013-04-01/&quot;:EvaluateTargetHealth}' is expected.</Message></Error><RequestId>f141b55c-f726-11e3-b2ac-73337c63db62</RequestId></ErrorResponse>", @headers={"x-amzn-RequestId"=>"f141b55c-f726-11e3-b2ac-73337c63db62", "Content-Type"=>"text/xml", "Content-Length"=>"438", "Date"=>"Wed, 18 Jun 2014 20:27:17 GMT"}, @status=400, @remote_ip="72.21.214.31", @local_port=60240, @local_address="192.168.1.85">
    from /gems/ruby-2.0.0-p353/gems/excon-0.37.0/lib/excon/middlewares/expects.rb:6:in `response_call'
    from /gems/ruby-2.0.0-p353/gems/excon-0.37.0/lib/excon/middlewares/response_parser.rb:26:in `response_call'
    from /gems/ruby-2.0.0-p353/gems/excon-0.37.0/lib/excon/connection.rb:402:in `response'
    from /gems/ruby-2.0.0-p353/gems/excon-0.37.0/lib/excon/connection.rb:272:in `request'
    from /gems/ruby-2.0.0-p353/gems/fog-1.22.1/lib/fog/xml/sax_parser_connection.rb:35:in `request'
    from /gems/ruby-2.0.0-p353/gems/fog-1.22.1/lib/fog/xml.rb:21:in `request'
    from /gems/ruby-2.0.0-p353/gems/fog-1.22.1/lib/fog/aws/dns.rb:126:in `request'
    from /gems/ruby-2.0.0-p353/gems/fog-1.22.1/lib/fog/aws/requests/dns/change_resource_record_sets.rb:120:in `change_resource_record_sets'
```
