### PR TITLE
Update links to DigitalOcean SSH-key docs

### DIFF
--- a/lib/fog/digitalocean/requests/compute/destroy_ssh_key.rb
+++ b/lib/fog/digitalocean/requests/compute/destroy_ssh_key.rb
@@ -5,7 +5,7 @@ module Fog
         #
         # Delete a SSH public key from your account
         #
-        # @see https://www.developers.digitalocean.com/ssh-keys
+        # @see https://developers.digitalocean.com/ssh-keys
         #
         def destroy_ssh_key(id)
           request(

--- a/lib/fog/digitalocean/requests/compute/get_ssh_key.rb
+++ b/lib/fog/digitalocean/requests/compute/get_ssh_key.rb
@@ -6,7 +6,7 @@ module Fog
         # This method shows a specific public SSH key in your account
         # that can be added to a droplet.
         #
-        # @see https://www.developers.digitalocean.com/ssh-keys
+        # @see https://developers.digitalocean.com/ssh-keys
         #
         def get_ssh_key(id)
           request(
@@ -24,7 +24,7 @@ module Fog
           response.body = {
             "status" => "OK",
             # key listing does not return ssh_pub_key
-            # https://www.developers.digitalocean.com/ssh-keys
+            # https://developers.digitalocean.com/ssh-keys
             "ssh_key"  => self.data[:ssh_keys].find { |k| k['id'] == id }
           }
           response


### PR DESCRIPTION
Update links from https://www.digitalocean.com/api#ssh_keys to https://developers.digitalocean.com/ssh-keys
