### PR TITLE
[rackspace|loadbalancers] Populate virtual ip and ipVersion

### DIFF
--- a/lib/fog/rackspace/models/load_balancers/load_balancer.rb
+++ b/lib/fog/rackspace/models/load_balancers/load_balancer.rb
@@ -85,11 +85,13 @@ module Fog
         end
 
         def virtual_ips
-          @virtual_ips ||= begin
-            Fog::Rackspace::LoadBalancers::VirtualIps.new({
+          if @virtual_ips.nil?
+            @virtual_ips = Fog::Rackspace::LoadBalancers::VirtualIps.new({
               :service => service,
               :load_balancer => self})
+            @virtual_ips.clear unless persisted?
           end
+          @virtual_ips
         end
 
         def virtual_ips=(new_virtual_ips=[])
@@ -231,7 +233,7 @@ module Fog
           options[:algorithm] = algorithm if algorithm
           options[:timeout] = timeout if timeout
 
-          data = service.create_load_balancer(name, protocol, port, virtual_ips_hash, nodes_hash, options)
+          data = service.create_load_balancer(name, protocol, port, virtual_ips, nodes_hash, options)
           merge_attributes(data.body['loadBalancer'])
         end
 
@@ -247,12 +249,6 @@ module Fog
 
           #TODO - Should this bubble down to nodes? Without tracking changes this would be very inefficient.
           # For now, individual nodes will have to be saved individually after saving an LB
-        end
-
-        def virtual_ips_hash
-          virtual_ips.map do |virtual_ip|
-            { :type => virtual_ip.type }
-          end
         end
 
         def nodes_hash

--- a/lib/fog/rackspace/requests/load_balancers/create_load_balancer.rb
+++ b/lib/fog/rackspace/requests/load_balancers/create_load_balancer.rb
@@ -30,7 +30,7 @@ module Fog
           data = {"loadBalancer"=>{"name"=>name, "id"=>uniq_id, "protocol"=>protocol, "port"=>port, "algorithm"=>"RANDOM", "status"=>"BUILD",
                                    "cluster"=>{"name"=>"my-cluster.rackspace.net"}, "timeout"=>30, "created"=>{"time"=> MockData.zulu_time},
                                    "updated"=>{"time"=>MockData.zulu_time }, "halfClosed"=>false, "connectionLogging"=>{"enabled"=>false}, "contentCaching"=>{"enabled"=>false}}}
-          data["virtual_ips"] = virtual_ips.map {|n| {"virtualIps"=>[{"address"=> MockData.ipv4_address, "id"=>uniq_id, "type"=>n[:type], "ipVersion"=>"IPV4"}, {"address"=> MockData.ipv6_address, "id"=> Fog::Mock.random_numbers(4), "type"=>"PUBLIC", "ipVersion"=>"IPV6"}], "sourceAddresses"=>{"ipv6Public"=> MockData.ipv6_address, "ipv4Servicenet"=>MockData.ipv4_address, "ipv4Public"=>MockData.ipv4_address}}
+          data["virtual_ips"] = virtual_ips.map {|n| {"virtualIps"=>[{"address"=> MockData.ipv4_address, "id"=>uniq_id, "type"=>n.type, "ipVersion"=>"IPV4"}, {"address"=> MockData.ipv6_address, "id"=> Fog::Mock.random_numbers(4), "type"=>"PUBLIC", "ipVersion"=>"IPV6"}], "sourceAddresses"=>{"ipv6Public"=> MockData.ipv6_address, "ipv4Servicenet"=>MockData.ipv4_address, "ipv4Public"=>MockData.ipv4_address}}
           data["nodes"] = nodes.map {|n| {"address"=>n[:address], "id"=>uniq_id, "type"=>"PRIMARY", "port"=>n[:port], "status"=>"ONLINE", "condition"=>"ENABLED", "weight"=>1}}}
           Excon::Response.new(:body => data, :status => 202)
         end


### PR DESCRIPTION
he id, and ipVersion were not being populated when making a create load balancer call. Fixes #3008
