### PR TITLE
[rackspace|compute_v2] Escape flavor_id and image_id

### DIFF
--- a/lib/fog/rackspace/requests/compute_v2/get_flavor.rb
+++ b/lib/fog/rackspace/requests/compute_v2/get_flavor.rb
@@ -23,7 +23,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method => 'GET',
-            :path => "flavors/#{flavor_id}"
+            :path => "flavors/#{Fog::Rackspace.escape(flavor_id)}"
           )
         end
       end

--- a/lib/fog/rackspace/requests/compute_v2/get_image.rb
+++ b/lib/fog/rackspace/requests/compute_v2/get_image.rb
@@ -27,7 +27,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method => 'GET',
-            :path => "images/#{image_id}"
+            :path => "images/#{Fog::Rackspace.escape(image_id)}"
           )
         end
       end


### PR DESCRIPTION
Updating `flavors.get` and `image.get` to escape ids.
