### PR TITLE
[openstack|volume] update volume to pass availability zone on volume create

### DIFF
--- a/lib/fog/openstack/requests/volume/create_volume.rb
+++ b/lib/fog/openstack/requests/volume/create_volume.rb
@@ -11,11 +11,14 @@ module Fog
             }
           }
 
-          vanilla_options = [:snapshot_id, :imageRef, :volume_type,
-            :source_volid]
-          vanilla_options.select{|o| options[o]}.each do |key|
-            data['volume'][key] = options[key]
+          optional_keys = [:snapshot_id, :imageRef, :volume_type, :source_volid, :availability_zone]
+          optional_keys.each do |key|
+            if options[key]
+              request_key = Fog::VolumeOpenStack::Volume.aliases[key]
+              data['volume'][request_key] = options[key]
+            end
           end
+
           request(
             :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],


### PR DESCRIPTION
This PR is an attempt to fix issue https://github.com/fog/fog/issues/3011.

Create volume requests should now pass `availability_zone` as well as `source_volid`.