### PR TITLE
rename Fog::Compute::OpenStack::Tenants#find_by_id to #get for consisten...

### DIFF
--- a/lib/fog/openstack/models/compute/tenants.rb
+++ b/lib/fog/openstack/models/compute/tenants.rb
@@ -15,9 +15,11 @@ module Fog
           service.list_usages(start_date, end_date, details).body['tenant_usages']
         end
 
-        def find_by_id(id)
+        def get(id)
           self.find {|tenant| tenant.id == id}
         end
+        alias_method :find_by_id, :get
+
       end # class Tenants
     end # class OpenStack
   end # module Compute


### PR DESCRIPTION
Make Tenants more consistent with the rest of the Compute classes, which all have #get methods, not #find_by_id.  I've also created an alias to #find_by_id to preserve backward compatibility.
