### PR TITLE
[dynect|dns] dramatically improve speed ...

### DIFF
--- a/lib/fog/dynect/models/dns/records.rb
+++ b/lib/fog/dynect/models/dns/records.rb
@@ -12,22 +12,17 @@ module Fog
         def all(options = {})
           requires :zone
           data = []
-          service.get_all_records(zone.domain, options).body['data'].each do |url|
-            (_, _, t, _, fqdn, id) = url.split('/')
-            type = t.gsub(/Record$/, '')
-
-            # leave out the default, read only records
-            # by putting this here we don't make the secondary request for these records
-            next if ['NS', 'SOA'].include?(type)
-
-            record = service.get_record(type, zone.domain, fqdn, 'record_id' => id).body['data']
-
-            data << {
-              :identity => record['record_id'],
-              :fqdn => record['fqdn'],
-              :type => record['record_type'],
-              :rdata => record['rdata']
-            }
+          service.get_all_records(zone.domain, options).body['data'].each do |records|
+            (type, list) = records
+            next if %w{soa_records ns_records}.include?(type)
+            list.each do |record|
+              data << {
+                :identity => record['record_id'],
+                :fqdn => record['fqdn'],
+                :type => record['record_type'],
+                :rdata => record['rdata']
+              }
+            end
           end
 
           load(data)
@@ -36,19 +31,12 @@ module Fog
         def get(record_id)
           requires :zone
 
-          list = service.get_all_records(zone.domain, {}).body['data']
-          url = list.find { |e| e =~ /\/#{record_id}$/ }
-          return unless url
-          (_, _, t, _, fqdn, id) = url.split('/')
-          type = t.gsub(/Record$/, '')
-          record = service.get_record(type, zone.domain, fqdn, 'record_id' => id).body['data']
+          # there isn't a way to look up by just id
+          # must have type and domain for 'get_record' request
+          # so we pick it from the list returned by 'all'
 
-          new({
-            :identity => record['record_id'],
-            :fqdn => record['fqdn'],
-            :type => record['record_type'],
-            :rdata => record['rdata']
-          })
+          list = all
+          list.detect {|e| e.id == record_id}
         end
 
         def new(attributes = {})

--- a/lib/fog/dynect/requests/dns/get_all_records.rb
+++ b/lib/fog/dynect/requests/dns/get_all_records.rb
@@ -15,7 +15,8 @@ module Fog
             :expects  => 200,
             :idempotent => true,
             :method   => :get,
-            :path     => ['AllRecord', zone, requested_fqdn].compact.join('/')
+            :path     => ['AllRecord', zone, requested_fqdn].compact.join('/'),
+            :query    => {'detail' => 'Y'} # return full records, instead of just resource URLs
           )
         end
       end


### PR DESCRIPTION
... of 'get_all_records' request and 'records.all' method.

previously 4 minutes on a domain with many records (266), now around 5 seconds on same domain.
this is enabled by a parameter to the 'get_all_records' request, detail=y. Which returns full records, rather than resource URLs.
