### PR TITLE
Issue 3011: Create volume in specific availability zone.

### DIFF
--- a/lib/fog/openstack/requests/compute/create_volume.rb
+++ b/lib/fog/openstack/requests/compute/create_volume.rb
@@ -11,7 +11,7 @@ module Fog
             }
           }
 
-          vanilla_options = ['snapshot_id']
+          vanilla_options = ['snapshot_id', 'availability_zone']
           vanilla_options.select{|o| options[o]}.each do |key|
             data['volume'][key] = options[key]
           end

--- a/lib/fog/openstack/requests/volume/create_volume.rb
+++ b/lib/fog/openstack/requests/volume/create_volume.rb
@@ -12,7 +12,7 @@ module Fog
           }
 
           vanilla_options = [:snapshot_id, :imageRef, :volume_type,
-            :source_volid]
+            :source_volid, :availability_zone]
           vanilla_options.select{|o| options[o]}.each do |key|
             data['volume'][key] = options[key]
           end


### PR DESCRIPTION
Previously the value of the availability_zone attribute was ignored when creating OpenStack volumes.
