### PR TITLE
[google|compute] Fix operations scopes for compute engine

### DIFF
--- a/lib/fog/google/models/compute/forwarding_rule.rb
+++ b/lib/fog/google/models/compute/forwarding_rule.rb
@@ -30,7 +30,7 @@ module Fog
           }
 
           data = service.insert_forwarding_rule(name, region, options).body
-          operation = Fog::Compute::Google::Operations.new(:service => service).get(data['name'], data['zone'])
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data['name'], nil, data['region'])
           operation.wait_for { !pending? }
           reload
         end

--- a/lib/fog/google/models/compute/target_pool.rb
+++ b/lib/fog/google/models/compute/target_pool.rb
@@ -32,7 +32,7 @@ module Fog
           }
 
           data = service.insert_target_pool(name, region, options).body
-          operation = Fog::Compute::Google::Operations.new(:service => service).get(data['name'], data['zone'])
+          operation = Fog::Compute::Google::Operations.new(:service => service).get(data['name'], nil, data['region'])
           operation.wait_for { !pending? }
           reload
         end


### PR DESCRIPTION
@icco, @erjohnso
Fix for scoping issues for operations.get on forwarding rules and target pools.
