### PR TITLE
[openstack | server] start/stop/pause/suspend actions

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -65,6 +65,8 @@ module Fog
       request :unpause_server
       request :suspend_server
       request :resume_server
+      request :start_server
+      request :stop_server
       request :rescue_server
       request :change_server_password
       request :add_fixed_ip

--- a/lib/fog/openstack/examples/compute/basics.rb
+++ b/lib/fog/openstack/examples/compute/basics.rb
@@ -32,27 +32,6 @@ floating_ips.each do |address|
 end
 vm.destroy
 
-# Power operations helper
-
-# vm.start / vm.stop / vm.pause should work after this
-class Server < Fog::Compute::Server
-  def start
-    if state.downcase == 'paused'
-      service.unpause_server(id) # resumes from frozen VM state
-    else
-      service.resume_server(id)  # resumes from hibernation
-    end
-  end
-
-  def stop
-    service.suspend_server(id) # hibernates the VM at hypervisor-level
-  end
-
-  def pause
-    service.pause_server(id)   # stores VM state in RAM
-  end
-end
-
 # Images available at tenant
 image_names = compute_client.images.map { |image| image['name'] }
 

--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -223,6 +223,34 @@ module Fog
           true
         end
 
+        def stop
+          requires :id
+          service.stop_server(id)
+        end
+
+        def pause
+          requires :id
+          service.pause_server(id)
+        end
+
+        def suspend
+          requires :id
+          service.suspend_server(id)
+        end
+
+        def start
+          requires :id
+
+          case state.downcase
+          when 'paused'
+            service.unpause_server(id)
+          when 'suspended'
+            service.resume_server(id)
+          else
+            service.start_server(id)
+          end
+        end
+
         def create_image(name, metadata={})
           requires :id
           service.create_image(id, name, metadata)

--- a/lib/fog/openstack/requests/compute/start_server.rb
+++ b/lib/fog/openstack/requests/compute/start_server.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        # Start the server.
+        #
+        # === Parameters
+        # * server_id <~String> - The ID of the server to be started.
+        # === Returns
+        # * success <~Boolean>
+        def start_server(server_id)
+          body = { 'os-start' => nil }
+          server_action(server_id, body).status == 202
+        end # def start_server
+      end # class Real
+
+      class Mock
+        def start_server(server_id)
+          true
+        end # def start_server
+      end # class Mock
+    end # class OpenStack
+  end # module Compute
+end # module Fog

--- a/lib/fog/openstack/requests/compute/stop_server.rb
+++ b/lib/fog/openstack/requests/compute/stop_server.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        # Stop the server.
+        #
+        # === Parameters
+        # * server_id <~String> - The ID of the server to be stopped.
+        # === Returns
+        # * success <~Boolean>
+        def stop_server(server_id)
+          body = { 'os-stop' => nil }
+          server_action(server_id, body).status == 202
+        end # def stop_server
+      end # class Real
+
+      class Mock
+        def stop_server(server_id)
+          true
+        end # def stop_server
+      end # class Mock
+    end # class OpenStack
+  end # module Compute
+end # module Fog

--- a/tests/openstack/requests/compute/server_tests.rb
+++ b/tests/openstack/requests/compute/server_tests.rb
@@ -164,6 +164,18 @@ Shindo.tests('Fog::Compute[:openstack] | server requests', ['openstack']) do
 
     Fog::Compute[:openstack].servers.get(@server_id).wait_for { ready? } if not Fog.mocking?
 
+    #STOP
+    tests("#stop_server(#{@server_id})").succeeds do
+      Fog::Compute[:openstack].stop_server(@server_id)
+    end
+
+    #START
+    tests("#start_server(#{@server_id})").succeeds do
+      Fog::Compute[:openstack].start_server(@server_id)
+    end
+
+    Fog::Compute[:openstack].servers.get(@server_id).wait_for { ready? } if not Fog.mocking?
+
     #DELETE
     tests("#delete_server(#{@server_id})").succeeds do
       Fog::Compute[:openstack].delete_server(@server_id)
@@ -195,6 +207,15 @@ Shindo.tests('Fog::Compute[:openstack] | server requests', ['openstack']) do
       Fog::Compute[:openstack].reboot_server(0)
     end
 
+    tests('#start_server(0)').raises(Fog::Compute::OpenStack::NotFound) do
+      pending if Fog.mocking?
+      Fog::Compute[:openstack].start_server(0)
+    end
+
+    tests('#stop_server(0)').raises(Fog::Compute::OpenStack::NotFound) do
+      pending if Fog.mocking?
+      Fog::Compute[:openstack].stop_server(0)
+    end
   end
 
 end


### PR DESCRIPTION
2 new requests for openstack compute added:

``` ruby
request :start_server
request :stop_server
```

what is more new methods added into openstack compute server model:

``` ruby
module Fog
  module Compute
    class OpenStack
      class Server < Fog::Compute::Server
         ...
        def stop ... end
        def pause ... end
        def suspend ... end
        def start ... end
    end
  end
end
```
