### PR TITLE
add ability to replace existing Dyn records

### DIFF
--- a/lib/fog/dynect/models/dns/record.rb
+++ b/lib/fog/dynect/models/dns/record.rb
@@ -19,7 +19,7 @@ module Fog
           true
         end
 
-        def save
+        def save(replace=false)
           requires :name, :type, :rdata, :zone
 
           options = {
@@ -27,7 +27,11 @@ module Fog
           }
           options.delete_if {|key, value| value.nil?}
 
-          data = service.post_record(type, zone.identity, name, rdata, options).body['data']
+          if replace
+            data = service.put_record(type, zone.identity, name, rdata, options).body['data']
+          else
+            data = service.post_record(type, zone.identity, name, rdata, options).body['data']
+          end
           # avoid overwriting zone object with zone string
           data = data.reject {|key, value| key == 'zone'}
           merge_attributes(data)


### PR DESCRIPTION
Add the ability to replace existing records, instead of just throwing Excon::Errors::BadRequest.
