### PR TITLE
[google|compute] Added read metadata from file functionality

### DIFF
--- a/lib/fog/google/models/compute/server.rb
+++ b/lib/fog/google/models/compute/server.rb
@@ -15,6 +15,7 @@ module Fog
         attribute :disks
         attribute :machine_type, :aliases => 'machineType'
         attribute :metadata
+        attribute :metadata_from_file
         attribute :network_interfaces, :aliases => 'networkInterfaces'
         attribute :scheduling
         attribute :self_link, :aliases => 'selfLink'
@@ -216,6 +217,7 @@ module Fog
               'externalIp' => external_ip,
               'disks' => disks,
               'metadata' => metadata,
+              'metadata_from_file' => metadata_from_file,
               'serviceAccounts' => service_accounts,
               'tags' => tags,
               'auto_restart' => auto_restart,

--- a/lib/fog/google/requests/compute/insert_server.rb
+++ b/lib/fog/google/requests/compute/insert_server.rb
@@ -114,6 +114,13 @@ module Fog
           { "items" => metadata.map {|k,v| {"key" => k, "value" => v}} }
         end
 
+        def read_metadata_from_file(metadata)
+          metadata.merge!(metadata) {|k,v| File.open(v,"r") do |f|
+            f.read
+          end
+          }
+        end
+
         def insert_server(server_name, zone_name, options={}, *deprecated_args)
           if deprecated_args.length > 0 or not options.is_a? Hash
             raise ArgumentError.new 'Too many parameters specified. This may be the cause of code written for an outdated'\
@@ -177,6 +184,15 @@ module Fog
             raise ArgumentError.new "Empty value for field 'disks'. Boot disk must be specified"
           end
           body_object['disks'] = handle_disks(options)
+          
+          file_meta = read_metadata_from_file options ['metadata_from_file'] if options['metadata_from_file']
+          if file_meta then
+            if options['metadata'] then
+              options['metadata'].merge! file_meta
+            else
+              options['metadata'] = file_meta
+            end
+          end
 
           options['metadata'] = format_metadata options['metadata'] if options['metadata']
 


### PR DESCRIPTION
The patch adds the ability to read metadata from files allowing users to specify startup scripts or arbitrary metadata for instances in separate files.
