### PR TITLE
Fixing missing uniq_id for Fog::Rackspace::LoadBalancers::Mock

### DIFF
--- a/lib/fog/rackspace/load_balancers.rb
+++ b/lib/fog/rackspace/load_balancers.rb
@@ -99,10 +99,6 @@ module Fog
           @rackspace_username = options[:rackspace_username]
           @rackspace_auth_url = options[:rackspace_auth_url]
         end
-
-        def uniq_id
-          rand(999999).to_s.center(6, rand(9).to_s).to_i
-        end
       end
 
       class Real < Fog::Rackspace::Service

--- a/lib/fog/rackspace/mock_data.rb
+++ b/lib/fog/rackspace/mock_data.rb
@@ -1,9 +1,9 @@
 module Fog
   module Rackspace
     module MockData
-      
+
       NOT_FOUND_ID = "NOT-FOUND"
-      
+
       def data
         @@data ||= Hash.new do |hash, key|
           hash[key] = begin
@@ -194,7 +194,7 @@ module Fog
               #Autoscale
               :autoscale_groups => {}
             }
-            
+
             # seed with initial data
             mock_data[:flavors][flavor_id] = flavor
             mock_data[:images][image_id] = image
@@ -231,6 +231,10 @@ module Fog
 
       def self.zulu_time
         Time.now.strftime("%Y-%m-%dT%H:%M:%SZ")
+      end
+
+      def self.uniq_id
+        rand(999999).to_s.center(6, rand(9).to_s).to_i
       end
     end
   end

--- a/lib/fog/rackspace/requests/load_balancers/create_load_balancer.rb
+++ b/lib/fog/rackspace/requests/load_balancers/create_load_balancer.rb
@@ -27,11 +27,11 @@ module Fog
 
       class Mock
         def create_load_balancer(name, protocol, port, virtual_ips, nodes, options = {})
-          data = {"loadBalancer"=>{"name"=>name, "id"=>uniq_id, "protocol"=>protocol, "port"=>port, "algorithm"=>"RANDOM", "status"=>"BUILD",
+          data = {"loadBalancer"=>{"name"=>name, "id"=>MockData.uniq_id, "protocol"=>protocol, "port"=>port, "algorithm"=>"RANDOM", "status"=>"BUILD",
                                    "cluster"=>{"name"=>"my-cluster.rackspace.net"}, "timeout"=>30, "created"=>{"time"=> MockData.zulu_time},
                                    "updated"=>{"time"=>MockData.zulu_time }, "halfClosed"=>false, "connectionLogging"=>{"enabled"=>false}, "contentCaching"=>{"enabled"=>false}}}
-          data["virtual_ips"] = virtual_ips.collect {|n| {"virtualIps"=>[{"address"=> MockData.ipv4_address, "id"=>uniq_id, "type"=>n[:type], "ipVersion"=>"IPV4"}, {"address"=> MockData.ipv6_address, "id"=> Fog::Mock.random_numbers(4), "type"=>"PUBLIC", "ipVersion"=>"IPV6"}], "sourceAddresses"=>{"ipv6Public"=> MockData.ipv6_address, "ipv4Servicenet"=>MockData.ipv4_address, "ipv4Public"=>MockData.ipv4_address}}
-          data["nodes"] = nodes.collect {|n| {"address"=>n[:address], "id"=>uniq_id, "type"=>"PRIMARY", "port"=>n[:port], "status"=>"ONLINE", "condition"=>"ENABLED", "weight"=>1}}}
+          data["virtual_ips"] = virtual_ips.collect {|n| {"virtualIps"=>[{"address"=> MockData.ipv4_address, "id"=>MockData.uniq_id, "type"=>n[:type], "ipVersion"=>"IPV4"}, {"address"=> MockData.ipv6_address, "id"=> Fog::Mock.random_numbers(4), "type"=>"PUBLIC", "ipVersion"=>"IPV6"}], "sourceAddresses"=>{"ipv6Public"=> MockData.ipv6_address, "ipv4Servicenet"=>MockData.ipv4_address, "ipv4Public"=>MockData.ipv4_address}}
+          data["nodes"] = nodes.collect {|n| {"address"=>n[:address], "id"=>MockData.uniq_id, "type"=>"PRIMARY", "port"=>n[:port], "status"=>"ONLINE", "condition"=>"ENABLED", "weight"=>1}}}
           Excon::Response.new(:body => data, :status => 202)
         end
       end


### PR DESCRIPTION
I found this issue when trying to mock create_load_balancer method for Rackspace. uniq_id was missing, added just 6 digit generator, and now works fine. 
