### PR TITLE
Support modify subnet attribute for AWS VPC

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -133,6 +133,7 @@ module Fog
       request :modify_instance_attribute
       request :modify_network_interface_attribute
       request :modify_snapshot_attribute
+      request :modify_subnet_attribute
       request :modify_volume_attribute
       request :modify_vpc_attribute
       request :purchase_reserved_instances_offering
@@ -397,7 +398,7 @@ module Fog
           @region                 = options[:region] ||= 'us-east-1'
           @instrumentor           = options[:instrumentor]
           @instrumentor_name      = options[:instrumentor_name] || 'fog.aws.compute'
-          @version                = options[:version]     ||  '2014-05-01'
+          @version                = options[:version]     ||  '2014-06-15'
 
           validate_aws_region @region
 

--- a/lib/fog/aws/models/compute/subnet.rb
+++ b/lib/fog/aws/models/compute/subnet.rb
@@ -11,6 +11,7 @@ module Fog
         attribute :available_ip_address_count,  :aliases => 'availableIpAddressCount'
         attribute :availability_zone,           :aliases => 'availabilityZone'
         attribute :tag_set,                     :aliases => 'tagSet'
+        attribute :map_public_ip_on_launch,     :aliases => 'mapPublicIpOnLaunch'
 
         def ready?
           requires :state

--- a/lib/fog/aws/parsers/compute/describe_subnets.rb
+++ b/lib/fog/aws/parsers/compute/describe_subnets.rb
@@ -32,6 +32,8 @@ module Fog
               case name
               when 'subnetId', 'state', 'vpcId', 'cidrBlock', 'availableIpAddressCount', 'availabilityZone'
                 @subnet[name] = value
+              when 'mapPublicIpOnLaunch'
+                @subnet[name] = value == 'true' ? true : false
               when 'item'
                 @response['subnetSet'] << @subnet
                 @subnet = { 'tagSet' => {} }

--- a/lib/fog/aws/parsers/compute/modify_subnet_attribute.rb
+++ b/lib/fog/aws/parsers/compute/modify_subnet_attribute.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Parsers
+    module Compute
+      module AWS
+        class ModifySubnetAttribute < Fog::Parsers::Base
+          def reset
+            @response = {  }
+          end
+
+
+          def end_element(name)
+            case name
+            when 'return'
+              @response[name] = value == 'true' ? true : false
+            when 'requestId'
+              @response[name] = value
+            end
+          
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/aws/requests/compute/create_vpc.rb
+++ b/lib/fog/aws/requests/compute/create_vpc.rb
@@ -49,7 +49,8 @@ module Fog
                 'dhcpOptionsId'      => Fog::AWS::Mock.request_id,
                 'tagSet'             => {},
                 'enableDnsSupport'   => true,
-                'enableDnsHostnames' => false
+                'enableDnsHostnames' => false,
+                'mapPublicIpOnLaunch'=> false
               }
               self.data[:vpcs].push(vpc)
 

--- a/lib/fog/aws/requests/compute/modify_subnet_attribute.rb
+++ b/lib/fog/aws/requests/compute/modify_subnet_attribute.rb
@@ -1,0 +1,58 @@
+module Fog
+  module Compute
+    class AWS
+      class Real
+        require 'fog/aws/parsers/compute/modify_subnet_attribute'
+
+        # Modifies a subnet attribute.
+        #
+        # ==== Parameters
+        # * SubnetId<~String> - The id of the subnet to modify
+        # * options<~Hash>:
+        #   * MapPublicIpOnLaunch<~Boolean> - Modifies the public IP addressing behavior for the subnet. 
+        #     Specify true to indicate that instances launched into the specified subnet should be assigned a public IP address. 
+        #     If set to true, the instance receives a public IP address only if the instance is launched with a single, 
+        #     new network interface with the device index of 0.
+        #
+        # === Returns
+        # * response<~Excon::Response>:
+        # * body<~Hash>:
+        # * 'requestId'<~String> - Id of request
+        # * 'return'<~Boolean> - Returns true if the request succeeds. Otherwise, returns an error.
+        # http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-ModifySubnetAttribute.html
+        def modify_subnet_attribute(subnet_id, options = {})
+          params = {}
+          params['MapPublicIpOnLaunch.Value'] = options.delete 'MapPublicIpOnLaunch' if options['MapPublicIpOnLaunch']
+          request({
+            'Action' => 'ModifySubnetAttribute',
+            'SubnetId' => subnet_id,
+            :parser => Fog::Parsers::Compute::AWS::ModifySubnetAttribute.new
+          }.merge(params))
+        end
+      end
+
+      class Mock
+        def modify_subnet_attribute(subnet_id, options={})
+          Excon::Response.new.tap do |response|
+            subnet = self.data[:subnets].detect { |v| v['subnetId'] == subnet_id }            
+            if subnet
+              subnet['mapPublicIpOnLaunch'] = options['MapPublicIpOnLaunch']
+
+              response.status = 200
+              
+              response.body = {
+                'requestId' => Fog::AWS::Mock.request_id,
+                'return'    => true
+              }
+            else
+              response.status = 404
+              response.body = {
+                'Code' => 'InvalidParameterValue'
+              }
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/tests/aws/requests/compute/subnet_tests.rb
+++ b/tests/aws/requests/compute/subnet_tests.rb
@@ -20,6 +20,11 @@ Shindo.tests('Fog::Compute[:aws] | subnet requests', ['aws']) do
     'requestId' => String
   }
 
+  @modify_subnet_format = {
+    'requestId' => String,
+    'return' => Fog::Boolean
+  }
+  
   @vpc_network = '10.0.10.0/24'
   @vpc=Fog::Compute[:aws].vpcs.create('cidr_block' => @vpc_network)
   @vpc_id = @vpc.id
@@ -32,6 +37,10 @@ Shindo.tests('Fog::Compute[:aws] | subnet requests', ['aws']) do
       data = Fog::Compute[:aws].create_subnet(@vpc_id, @subnet_network).body
       @subnet_id = data['subnet']['subnetId']
       data
+    end
+
+    tests("modify_subnet('#{@subnet_id}'").formats(@modify_subnet_format) do
+      Fog::Compute[:aws].modify_subnet_attribute(@subnet_id, 'MapPublicIpOnLaunch' => true).body
     end
 
     @vpc2=Fog::Compute[:aws].vpcs.create('cidr_block' => @vpc_network)


### PR DESCRIPTION
The only thing modify subnet attribute can modify is the MapPublicIpOnLaunch flag.

I chose to have the option passed be  `MapPublicIpOnLaunch` rather than `MapPublicIpOnLaunch.Value` - although that's the parameter name the api actually required it felt a bit over the top so i thought it was ok to  handle that for callers of the request
