### PR TITLE
[vsphere] Remove the relative_path attribute.

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -154,7 +154,6 @@ module Fog
             attrs['mac_addresses'] = Proc.new {vm_mob_ref.macs rescue nil}
             # Rescue nil to catch testing while vm_mob_ref isn't reaL??
             attrs['path'] = "/"+attrs['parent'].path.map(&:last).join('/') rescue nil
-            attrs['relative_path'] = (attrs['path'].split('/').reject {|e| e.empty?} - ["Datacenters", attrs['datacenter'], "vm"]).join("/") rescue nil
           end
         end
         # returns the parent object based on a type

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -32,7 +32,6 @@ module Fog
         attribute :connection_state
         attribute :mo_ref
         attribute :path
-        attribute :relative_path
         attribute :memory_mb
         attribute :cpus
         attribute :corespersocket
@@ -122,7 +121,7 @@ module Fog
         #   * See more options in vm_clone request/compute/vm_clone.rb
         #
         def clone(options = {})
-          requires :name, :datacenter, :relative_path
+          requires :name, :datacenter, :path
 
           # Convert symbols to strings
           req_options = options.reduce({}) { |hsh, (k,v)| hsh[k.to_s] = v; hsh }
@@ -245,6 +244,12 @@ module Fog
             self.attributes.delete(attr)
           end
           super
+        end
+
+        def relative_path
+          requires :path, :datacenter
+
+          (path.split('/').reject {|e| e.empty?} - ["Datacenters", datacenter, "vm"]).join("/")
         end
 
         private


### PR DESCRIPTION
The Vsphere::Server.relative_path attribute depends on having
initialized the <server>.datacenter field (which is lazy loaded).
When the relative_path is computed from the attributes returned by
the underlying rbvmomi call, it is actually an absolute path to the
instance (that is, it includes the Datacenter). However, the path is
meant to be relative to the Datacenter.

The patch proposes the following solution:
- remove the relative_path attribute
- add a Vsphere::Server.relative_path method

This works well with the lazy initialization and restores
functionality to methods that rely on the path actually being relative
to the Datacenter.

Fixes: #3041
