### PR TITLE
Fix describe_internet_gateways calls for >1 igw

### DIFF
--- a/lib/fog/aws/parsers/compute/describe_internet_gateways.rb
+++ b/lib/fog/aws/parsers/compute/describe_internet_gateways.rb
@@ -47,8 +47,7 @@ module Fog
                 @internet_gateway[name] = value
               when 'item'
                 @response['internetGatewaySet'] << @internet_gateway
-                @internet_gateway = { 'tagSet' => {} }
-                @internet_gateway = { 'attachmentSet' => {} }
+                @internet_gateway = { 'attachmentSet' => {}, 'tagSet' => {} }
               when 'requestId'
                 @response[name] = value
               end


### PR DESCRIPTION
@internet_gateway was incorrectly reset after the first
InternetGatewaySet item.  On encountering a second, we end up
attempting to dereference nil as a hash, causing the parser to
blow up with an unintuitive error.

Fixes #2920
