### PR TITLE
remove :host from request parameters, stopping excon errors with Elastic Beanstalk

### DIFF
--- a/lib/fog/aws/beanstalk.rb
+++ b/lib/fog/aws/beanstalk.rb
@@ -124,7 +124,6 @@ module Fog
                 :expects    => 200,
                 :headers    => { 'Content-Type' => 'application/x-www-form-urlencoded' },
                 :idempotent => idempotent,
-                :host       => @host,
                 :method     => 'POST',
                 :parser     => parser
             })


### PR DESCRIPTION
`beanstalk.rb` still contains a host parameter in this `#request` method, which throws an excon error when using the Elastic Beanstalk classes in Compute.. Removing it - as has been done in other points of the fog codebase - fixes that error.
