### PR TITLE
[#3048] Lock down rest-client version

### DIFF
--- a/gemfiles/Gemfile-ruby-1.8.7
+++ b/gemfiles/Gemfile-ruby-1.8.7
@@ -2,6 +2,7 @@ source "https://rubygems.org"
 
 gem 'nokogiri', '~>1.5.11'
 gem 'mime-types', '~>1.16'
+gem 'rest-client', '~> 1.6.7'
 
 group :development, :test do
   # This is here because gemspec doesn't support require: false


### PR DESCRIPTION
New versions have dropped 1.8.7 support and they are getting picked up
by Travis.
