### PR TITLE
Typo in fog.io link

### DIFF
--- a/lib/fog/vcloud/examples/README.md
+++ b/lib/fog/vcloud/examples/README.md
@@ -2,7 +2,7 @@
 _contributor @singhgarima_
 
 For more information about fog [README](/README.md), or visit their website
-[fog.io](www.fog.io).
+[fog.io](http://fog.io).
 
 ## Vcloud API
 


### PR DESCRIPTION
fixed a type in the link to fog.io
