### PR TITLE
[google|compute] added centos, opensuse images

### DIFF
--- a/lib/fog/google/models/compute/images.rb
+++ b/lib/fog/google/models/compute/images.rb
@@ -12,8 +12,10 @@ module Fog
         # https://developers.google.com/compute/docs/premium-operating-systems
         GLOBAL_PROJECTS = [
           'centos-cloud',
+          'coreos-cloud',
           'debian-cloud',
           'google-containers',
+          'opensuse-cloud',
           'rhel-cloud',
           'suse-cloud'
         ]


### PR DESCRIPTION
@icco - added new projects to the list for CoreOS and Open Suse.  These are publicly available images now, https://developers.google.com/compute/docs/operating-systems.
