### PR TITLE
[google|monitoring] Add support for Google Cloud Monitoring

### DIFF
--- a/lib/fog/bin/google.rb
+++ b/lib/fog/bin/google.rb
@@ -4,6 +4,8 @@ module Google # deviates from other bin stuff to accomodate gem
       case key
       when :compute
         Fog::Compute::Google
+      when :monitoring
+        Fog::Google::Monitoring
       when :storage
         Fog::Storage::Google
       when :sql
@@ -22,6 +24,8 @@ module Google # deviates from other bin stuff to accomodate gem
         when :compute
           Fog::Logger.warning("Google[:compute] is not recommended, use Compute[:google] for portability")
           Fog::Compute.new(:provider => 'Google')
+        when :monitoring
+          Fog::Google::Monitoring.new
         when :sql
           Fog::Google::SQL.new
         else

--- a/lib/fog/google.rb
+++ b/lib/fog/google.rb
@@ -1,3 +1,4 @@
 require 'fog/google/compute'
+require 'fog/google/monitoring'
 require 'fog/google/storage'
 require 'fog/google/sql'

--- a/lib/fog/google/core.rb
+++ b/lib/fog/google/core.rb
@@ -5,9 +5,10 @@ module Fog
   module Google
     extend Fog::Provider
 
-    service(:compute, 'Compute')
-    service(:storage, 'Storage')
-    service(:sql,     'SQL')
+    service(:compute,    'Compute')
+    service(:monitoring, 'Monitoring')
+    service(:storage,    'Storage')
+    service(:sql,        'SQL')
 
     class Mock
       def self.etag

--- a/lib/fog/google/examples/monitoring/metric_descriptors.rb
+++ b/lib/fog/google/examples/monitoring/metric_descriptors.rb
@@ -1,0 +1,11 @@
+def test
+  connection = Fog::Google::Monitoring.new
+
+  puts 'Listing all MetricDescriptors...'
+  puts '--------------------------------'
+  connection.metric_descriptors
+
+  puts 'Listing all MetricDescriptors related to Google Compute Engine...'
+  puts '-----------------------------------------------------------------'
+  connection.metric_descriptors.all(:query => 'compute')
+end

--- a/lib/fog/google/examples/monitoring/timeseries_collection.rb
+++ b/lib/fog/google/examples/monitoring/timeseries_collection.rb
@@ -1,0 +1,15 @@
+def test
+  connection = Fog::Google::Monitoring.new
+
+  puts 'Listing all Timeseries for the metric compute.googleapis.com/instance/uptime...'
+  puts '-------------------------------------------------------------------------------'
+  connection.timeseries_collection.all('compute.googleapis.com/instance/uptime',
+                                       DateTime.now.rfc3339)
+
+  puts 'Listing all Timeseries for the metric compute.googleapis.com/instance/uptime &'
+  puts 'the region us-central1...'
+  puts '------------------------------------------------------------------------------'
+  connection.timeseries_collection.all('compute.googleapis.com/instance/uptime',
+                                       DateTime.now.rfc3339,
+                                       :labels => 'cloud.googleapis.com/location=~us-central1.*')
+end

--- a/lib/fog/google/examples/monitoring/timeseries_descriptors.rb
+++ b/lib/fog/google/examples/monitoring/timeseries_descriptors.rb
@@ -1,0 +1,15 @@
+def test
+  connection = Fog::Google::Monitoring.new
+
+  puts 'Listing all TimeseriesDescriptors for the metric compute.googleapis.com/instance/uptime...'
+  puts '------------------------------------------------------------------------------------------'
+  connection.timeseries_descriptors.all('compute.googleapis.com/instance/uptime',
+                                        DateTime.now.rfc3339)
+
+  puts 'Listing all TimeseriesDescriptors for the metric compute.googleapis.com/instance/uptime &'
+  puts 'the region us-central1...'
+  puts '-----------------------------------------------------------------------------------------'
+  connection.timeseries_descriptors.all('compute.googleapis.com/instance/uptime',
+                                        DateTime.now.rfc3339,
+                                        :labels => 'cloud.googleapis.com/location=~us-central1.*')
+end

--- a/lib/fog/google/models/monitoring/metric_descriptor.rb
+++ b/lib/fog/google/models/monitoring/metric_descriptor.rb
@@ -1,0 +1,20 @@
+require 'fog/core/model'
+
+module Fog
+  module Google
+    class Monitoring
+      ##
+      # A metricDescriptor defines the name, label keys, and data type of a particular metric.
+      #
+      # @see https://developers.google.com/cloud-monitoring/v2beta1/metricDescriptors
+      class MetricDescriptor < Fog::Model
+        identity :name
+
+        attribute :description
+        attribute :labels
+        attribute :project
+        attribute :type_descriptor, :aliases => 'typeDescriptor'
+      end
+    end
+  end
+end

--- a/lib/fog/google/models/monitoring/metric_descriptors.rb
+++ b/lib/fog/google/models/monitoring/metric_descriptors.rb
@@ -1,0 +1,28 @@
+require 'fog/core/collection'
+require 'fog/google/models/monitoring/metric_descriptor'
+
+module Fog
+  module Google
+    class Monitoring
+      class MetricDescriptors < Fog::Collection
+        model Fog::Google::Monitoring::MetricDescriptor
+
+        ##
+        # Lists all Metric Descriptors.
+        #
+        # @param [Hash] options Optional query parameters.
+        # @option options [String] count Maximum number of time series descriptors per page. Used for pagination.
+        # @option options [String] page_token The pagination token, which is used to page through large result sets.
+        # @option options [String] query The query used to search against existing metrics. Separate keywords with a space;
+        #   the service joins all keywords with AND, meaning that all keywords must match for a metric to be returned.
+        #   If this field is omitted, all metrics are returned. If an empty string is passed with this field,
+        #   no metrics are returned.
+        # @return [Array<Fog::Google::Monitoring::MetricDescriptor>] List of Metric Descriptors.
+        def all(options = {})
+          data = service.list_metric_descriptors(options).body['metrics'] || []
+          load(data)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/models/monitoring/timeseries.rb
+++ b/lib/fog/google/models/monitoring/timeseries.rb
@@ -1,0 +1,17 @@
+require 'fog/core/model'
+
+module Fog
+  module Google
+    class Monitoring
+      ##
+      # A time series is a collection of data points that represents the value of a metric of a project over time.
+      #
+      # @see https://developers.google.com/cloud-monitoring/v2beta1/timeseries
+      class Timeseries < Fog::Model
+        identity :time_series_desc, :aliases => 'timeseriesDesc'
+
+        attribute :points
+      end
+    end
+  end
+end

--- a/lib/fog/google/models/monitoring/timeseries_collection.rb
+++ b/lib/fog/google/models/monitoring/timeseries_collection.rb
@@ -1,0 +1,31 @@
+require 'fog/core/collection'
+require 'fog/google/models/monitoring/timeseries'
+
+module Fog
+  module Google
+    class Monitoring
+      class TimeseriesCollection < Fog::Collection
+        model Fog::Google::Monitoring::Timeseries
+
+        ##
+        # Lists all Timeseries.
+        #
+        # @param [String] metric The name of the metric (Metric names are protocol-free URLs).
+        # @param [String] youngest End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
+        # @param [Hash] options Optional query parameters.
+        # @option options [String] count Maximum number of time series descriptors per page. Used for pagination.
+        # @option options [String] labels A collection of labels for the matching time series.
+        # @option options [String] oldest Start of the time interval (exclusive), which is expressed as an RFC 3339
+        #   timestamp.
+        # @options options [String] page_token The pagination token, which is used to page through large result sets.
+        # @options options [String] timespan Length of the time interval to query, which is an alternative way to
+        #   declare the interval.
+        # @return [Array<Fog::Google::Monitoring::Timeseries>] List of Timeseries.
+        def all(metric, youngest, options = {})
+          data = service.list_timeseries(metric, youngest, options).body['timeseries'] || []
+          load(data)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/models/monitoring/timeseries_descriptor.rb
+++ b/lib/fog/google/models/monitoring/timeseries_descriptor.rb
@@ -1,0 +1,20 @@
+require 'fog/core/model'
+
+module Fog
+  module Google
+    class Monitoring
+      ##
+      # A time series is a collection of data points that represents the value of a metric of a project over time.
+      # The metric is described by the time-series descriptor. Each time-series descriptor is uniquely identified by
+      # its metric name and a set of labels.
+      #
+      # @see https://developers.google.com/cloud-monitoring/v2beta1/timeseriesDescriptors
+      class TimeseriesDescriptor < Fog::Model
+        identity :metric
+
+        attribute :labels
+        attribute :project
+      end
+    end
+  end
+end

--- a/lib/fog/google/models/monitoring/timeseries_descriptors.rb
+++ b/lib/fog/google/models/monitoring/timeseries_descriptors.rb
@@ -1,0 +1,31 @@
+require 'fog/core/collection'
+require 'fog/google/models/monitoring/timeseries_descriptor'
+
+module Fog
+  module Google
+    class Monitoring
+      class TimeseriesDescriptors < Fog::Collection
+        model Fog::Google::Monitoring::TimeseriesDescriptor
+
+        ##
+        # Lists all Timeseries Descriptors.
+        #
+        # @param [String] metric The name of the metric (Metric names are protocol-free URLs).
+        # @param [String] youngest End of the time interval (inclusive), which is expressed as an RFC 3339 timestamp.
+        # @param [Hash] options Optional query parameters.
+        # @option options [String] count Maximum number of time series descriptors per page. Used for pagination.
+        # @option options [String] labels A collection of labels for the matching time series.
+        # @option options [String] oldest Start of the time interval (exclusive), which is expressed as an RFC 3339
+        #   timestamp.
+        # @options options [String] page_token The pagination token, which is used to page through large result sets.
+        # @options options [String] timespan Length of the time interval to query, which is an alternative way to
+        #   declare the interval.
+        # @return [Array<Fog::Google::Monitoring::TimeseriesDescriptor>] List of Timeseries Descriptors.
+        def all(metric, youngest, options = {})
+          data = service.list_timeseries_descriptors(metric, youngest, options).body['timeseries'] || []
+          load(data)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -1,0 +1,89 @@
+require 'fog/google/core'
+
+module Fog
+  module Google
+    class Monitoring < Fog::Service
+      requires :google_project
+      recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
+                 :app_name, :app_version
+
+      GOOGLE_MONITORING_API_VERSION    = 'v2beta1'
+      GOOGLE_MONITORING_BASE_URL       = 'https://www.googleapis.com/cloudmonitoring/'
+      GOOGLE_MONITORING_API_SCOPE_URLS = %w(https://www.googleapis.com/auth/monitoring.readonly)
+
+      ##
+      # MODELS
+      model_path 'fog/google/models/monitoring'
+
+      # Timeseries
+      model :timeseries
+      collection :timeseries_collection
+
+      # TimeseriesDescriptors
+      model :timeseries_descriptor
+      collection :timeseries_descriptors
+
+      # MetricDescriptors
+      model :metric_descriptor
+      collection :metric_descriptors
+
+      ##
+      # REQUESTS
+      request_path 'fog/google/requests/monitoring'
+
+      # Timeseries
+      request :list_timeseries
+
+      # TimeseriesDescriptors
+      request :list_timeseries_descriptors
+
+      # MetricDescriptors
+      request :list_metric_descriptors
+
+      class Mock
+        include Fog::Google::Shared
+
+        def initialize(options)
+          shared_initialize(options[:google_project], GOOGLE_MONITORING_API_VERSION, GOOGLE_MONITORING_BASE_URL)
+        end
+
+        def self.data
+          @data ||= Hash.new do |hash, key|
+            hash[key] = {
+              :timeseries => {},
+              :timeseries_descriptors => {},
+              :metric_descriptors => {},
+            }
+          end
+        end
+
+        def self.reset
+          @data = nil
+        end
+
+        def data
+          self.class.data[project]
+        end
+
+        def reset_data
+          self.class.data.delete(project)
+        end
+      end
+
+      class Real
+        include Fog::Google::Shared
+
+        attr_accessor :client
+        attr_reader :monitoring
+
+        def initialize(options)
+          shared_initialize(options[:google_project], GOOGLE_MONITORING_API_VERSION, GOOGLE_MONITORING_BASE_URL)
+          options.merge!(:google_api_scope_url => GOOGLE_MONITORING_API_SCOPE_URLS.join(' '))
+
+          @client = initialize_google_client(options)
+          @monitoring = @client.discovered_api('cloudmonitoring', api_version)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/monitoring/list_metric_descriptors.rb
+++ b/lib/fog/google/requests/monitoring/list_metric_descriptors.rb
@@ -1,0 +1,191 @@
+module Fog
+  module Google
+    class Monitoring
+      ##
+      # List metric descriptors that match the query. If the query is not set, then all of the metric descriptors
+      # will be returned.
+      #
+      # @see https://developers.google.com/cloud-monitoring/v2beta1/metricDescriptors/list
+      class Real
+        def list_metric_descriptors(options = {})
+          api_method = @monitoring.metric_descriptors.list
+          parameters = {
+            'project' => @project,
+          }
+
+          parameters['count'] = options[:count] if options.key?(:count)
+          parameters['pageToken'] = options[:page_token] if options.key?(:page_token)
+          parameters['query'] = options[:query] if options.key?(:query)
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def list_metric_descriptors(options = {})
+          body = {
+            'kind' => 'cloudmonitoring#listMetricDescriptorsResponse',
+            'metrics' => [
+              { 'name' => 'compute.googleapis.com/instance/cpu/reserved_cores',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'gauge', 'valueType' => 'double' },
+                'description' => 'Number of cores reserved on the host of the instance.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/cpu/usage_time',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'double' },
+                'description' => 'Delta CPU usage time. Units are seconds. You can get the per-core CPU utilization ratio by performing a rate operation on a point: doubleValue/(end-start), then divide by compute.googleapis.com/instance/cpu/reserved_cores at the corresponding end timestamp.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/disk/read_bytes_count',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'compute.googleapis.com/device_name' },
+                  { 'key' => 'compute.googleapis.com/device_type' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'int64' },
+                'description' => 'Delta count of bytes read from disk.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/disk/read_ops_count',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'compute.googleapis.com/device_name' },
+                  { 'key' => 'compute.googleapis.com/device_type' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'int64' },
+                'description' => 'Delta count of disk read IO operations.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/disk/write_bytes_count',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'compute.googleapis.com/device_name' },
+                  { 'key' => 'compute.googleapis.com/device_type' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => '"compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'int64' },
+                'description' => 'Delta count of bytes written to disk.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/disk/write_ops_count',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'compute.googleapis.com/device_name' },
+                  { 'key' => '"compute.googleapis.com/device_type' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'int64' },
+                'description' => 'Delta count of disk write IO operations.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/network/received_bytes_count',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'compute.googleapis.com/loadbalanced' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'int64' },
+                'description' => 'Delta count of bytes received from network.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/network/received_packets_count',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'compute.googleapis.com/loadbalanced' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'int64' },
+                'description' => 'Delta count of packets received from network.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/network/sent_bytes_count',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'compute.googleapis.com/loadbalanced' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'int64' },
+                'description' => 'Delta count of bytes sent over network.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/network/sent_packets_count',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'compute.googleapis.com/loadbalanced' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'int64' },
+                'description' => 'Delta count of packets sent over network.'
+              },
+              {
+                'name' => 'compute.googleapis.com/instance/uptime',
+                'project' => @project,
+                'labels' => [
+                  { 'key' => 'compute.googleapis.com/instance_name' },
+                  { 'key' => 'cloud.googleapis.com/location' },
+                  { 'key' => 'compute.googleapis.com/resource_id' },
+                  { 'key' => 'compute.googleapis.com/resource_type' },
+                  { 'key' => 'cloud.googleapis.com/service' }
+                ],
+                'typeDescriptor' => { 'metricType' => 'delta', 'valueType' => 'double' },
+                'description' => 'Indicates the VM running time in seconds.'
+              },
+            ]
+          }
+
+          build_excon_response(body)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/monitoring/list_timeseries.rb
+++ b/lib/fog/google/requests/monitoring/list_timeseries.rb
@@ -1,0 +1,68 @@
+module Fog
+  module Google
+    class Monitoring
+      ##
+      # List the data points of the time series that match the metric and labels values and that have data points
+      # in the interval
+      #
+      # https://developers.google.com/cloud-monitoring/v2beta1/timeseries
+      class Real
+        def list_timeseries(metric, youngest, options = {})
+          api_method = @monitoring.timeseries.list
+          parameters = {
+            'project' => @project,
+            'metric' => metric,
+            'youngest' => youngest,
+          }
+
+          parameters['count'] = options[:count] if options.key?(:count)
+          parameters['labels'] = options[:labels] if options.key?(:labels)
+          parameters['oldest'] = options[:oldest] if options.key?(:oldest)
+          parameters['pageToken'] = options[:page_token] if options.key?(:page_token)
+          parameters['timespan'] = options[:timespan] if options.key?(:timespan)
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def list_timeseries(metric, youngest, options = {})
+          body = {
+            'kind' => 'cloudmonitoring#listTimeseriesResponse',
+            'youngest' => youngest,
+            'oldest' => youngest,
+            'timeseries' => [
+              {
+                'timeseriesDesc' => {
+                  'project' => @project,
+                  'metric' => metric,
+                  'labels' => {
+                    'cloud.googleapis.com/service' => 'compute.googleapis.com',
+                    'compute.googleapis.com/resource_type' => 'instance',
+                    'cloud.googleapis.com/location' => 'us-central1-a',
+                    'compute.googleapis.com/resource_id' => Fog::Mock.random_numbers(20).to_s,
+                    'compute.googleapis.com/instance_name' => Fog::Mock.random_hex(40),
+                  },
+                },
+                'points' => [
+                  {
+                    'start' => '2014-07-17T20:06:58.000Z',
+                    'end' => '2014-07-17T20:07:58.000Z',
+                    'doubleValue' => 60.0
+                  },
+                  {
+                    'start' => '2014-07-17T20:05:58.000Z',
+                    'end' => '2014-07-17T20:06:58.000Z',
+                    'doubleValue' => 60.0
+                  },
+                ],
+              }
+            ]
+          }
+
+          build_excon_response(body)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/monitoring/list_timeseries_descriptors.rb
+++ b/lib/fog/google/requests/monitoring/list_timeseries_descriptors.rb
@@ -1,0 +1,87 @@
+module Fog
+  module Google
+    class Monitoring
+      ##
+      # List the descriptors of the time series that match the metric and labels values and that have data points
+      # in the interval.
+      #
+      # @see https://developers.google.com/cloud-monitoring/v2beta1/timeseriesDescriptors/list
+      class Real
+        def list_timeseries_descriptors(metric, youngest, options = {})
+          api_method = @monitoring.timeseries_descriptors.list
+          parameters = {
+            'project' => @project,
+            'metric' => metric,
+            'youngest' => youngest,
+          }
+
+          parameters['count'] = options[:count] if options.key?(:count)
+          parameters['labels'] = options[:labels] if options.key?(:labels)
+          parameters['oldest'] = options[:oldest] if options.key?(:oldest)
+          parameters['pageToken'] = options[:page_token] if options.key?(:page_token)
+          parameters['timespan'] = options[:timespan] if options.key?(:timespan)
+
+          request(api_method, parameters)
+        end
+      end
+
+      class Mock
+        def list_timeseries_descriptors(metric, youngest, options = {})
+          body = {
+            'kind' => 'cloudmonitoring#listTimeseriesDescriptorsResponse',
+            'youngest' => youngest,
+            'oldest' => youngest,
+            'timeseries' => [
+              {
+                'project' => @project,
+                'metric' => metric,
+                'labels' => {
+                  'cloud.googleapis.com/service' => 'compute.googleapis.com',
+                  'compute.googleapis.com/resource_type' => 'instance',
+                  'cloud.googleapis.com/location' => 'us-central1-a',
+                  'compute.googleapis.com/resource_id' => Fog::Mock.random_numbers(20).to_s,
+                  'compute.googleapis.com/instance_name' => Fog::Mock.random_hex(40),
+                },
+              },
+              {
+                'project' => @project,
+                'metric' => metric,
+                'labels' => {
+                  'cloud.googleapis.com/service' => 'compute.googleapis.com',
+                  'compute.googleapis.com/resource_type' => 'instance',
+                  'cloud.googleapis.com/location' => 'us-central1-a',
+                  'compute.googleapis.com/resource_id' => Fog::Mock.random_numbers(20).to_s,
+                  'compute.googleapis.com/instance_name' => Fog::Mock.random_hex(40),
+                 },
+              },
+              {
+                'project' => @project,
+                'metric' => metric,
+                'labels' => {
+                  'cloud.googleapis.com/service' => 'compute.googleapis.com',
+                  'compute.googleapis.com/resource_type' => 'instance',
+                  'cloud.googleapis.com/location' => 'us-central1-a',
+                  'compute.googleapis.com/resource_id' => Fog::Mock.random_numbers(20).to_s,
+                  'compute.googleapis.com/instance_name' => Fog::Mock.random_hex(40),
+                 },
+              },
+              {
+                'project' => @project,
+                'metric' => metric,
+                'labels' => {
+                  'cloud.googleapis.com/service' => 'compute.googleapis.com',
+                  'compute.googleapis.com/resource_type' => 'instance',
+                  'cloud.googleapis.com/location' => 'us-central1-a',
+                  'compute.googleapis.com/resource_id' => Fog::Mock.random_numbers(20).to_s,
+                  'compute.googleapis.com/instance_name' => Fog::Mock.random_hex(40),
+                 },
+              },
+            ]
+          }
+
+          build_excon_response(body)
+        end
+      end
+    end
+  end
+end

--- a/tests/google/models/monitoring/metric_descriptors_tests.rb
+++ b/tests/google/models/monitoring/metric_descriptors_tests.rb
@@ -1,0 +1,12 @@
+Shindo.tests('Fog::Google[:monitoring] | metric_descriptors model', ['google']) do
+  @metric_descriptors = Fog::Google[:monitoring].metric_descriptors
+
+  tests('success') do
+
+    tests('#all').succeeds do
+      @metric_descriptors.all
+    end
+
+  end
+
+end

--- a/tests/google/models/monitoring/timeseries_collection_tests.rb
+++ b/tests/google/models/monitoring/timeseries_collection_tests.rb
@@ -1,0 +1,12 @@
+Shindo.tests('Fog::Google[:monitoring] | timeseries_collection model', ['google']) do
+  @timeseries_collection = Fog::Google[:monitoring].timeseries_collection
+
+  tests('success') do
+
+    tests('#all').succeeds do
+      @timeseries_collection.all('compute.googleapis.com/instance/uptime', Time.now.strftime("%Y-%m-%dT%H:%M:%S%:z"))
+    end
+
+  end
+
+end

--- a/tests/google/models/monitoring/timeseries_descriptors_tests.rb
+++ b/tests/google/models/monitoring/timeseries_descriptors_tests.rb
@@ -1,0 +1,13 @@
+Shindo.tests('Fog::Google[:monitoring] | timeseries_descriptors model', ['google']) do
+  @timeseries_descriptors = Fog::Google[:monitoring].timeseries_descriptors
+
+  tests('success') do
+
+    tests('#all').succeeds do
+      @timeseries_descriptors.all('compute.googleapis.com/instance/uptime',
+                                  Time.now.strftime("%Y-%m-%dT%H:%M:%S%:z"))
+    end
+
+  end
+
+end

--- a/tests/google/requests/monitoring/metric_descriptor_tests.rb
+++ b/tests/google/requests/monitoring/metric_descriptor_tests.rb
@@ -1,0 +1,25 @@
+Shindo.tests('Fog::Google[:monitoring] | metric_descriptor requests', ['google']) do
+  @monitoring = Fog::Google[:monitoring]
+
+  @get_metric_descriptor_format = {
+    'name' => String,
+    'description' => String,
+    'labels' => Array,
+    'project' => String,
+    'typeDescriptor' => Hash,
+  }
+
+  @list_metric_descriptors_format = {
+    'kind' => String,
+    'metrics' => [@get_metric_descriptor_format],
+  }
+
+  tests('success') do
+
+    tests('#list_metric_descriptors').formats(@list_metric_descriptors_format) do
+      @monitoring.list_metric_descriptors.body
+    end
+
+  end
+
+end

--- a/tests/google/requests/monitoring/timeseries_collection_tests.rb
+++ b/tests/google/requests/monitoring/timeseries_collection_tests.rb
@@ -1,0 +1,25 @@
+Shindo.tests('Fog::Google[:monitoring] | timeseries_collection requests', ['google']) do
+  @monitoring = Fog::Google[:monitoring]
+
+  @get_timeseries_format = {
+    'timeseriesDesc' => Hash,
+    'points' => Array,
+  }
+
+  @list_timeseries_format = {
+    'kind' => String,
+    'youngest' => String,
+    'oldest' => String,
+    'timeseries' => [@get_timeseries_format],
+  }
+
+  tests('success') do
+
+    tests('#list_timeseries').formats(@list_timeseries_format) do
+      @monitoring.list_timeseries('compute.googleapis.com/instance/uptime',
+                                  Time.now.strftime("%Y-%m-%dT%H:%M:%S%:z")).body
+    end
+
+  end
+
+end

--- a/tests/google/requests/monitoring/timeseries_descriptor_tests.rb
+++ b/tests/google/requests/monitoring/timeseries_descriptor_tests.rb
@@ -1,0 +1,26 @@
+Shindo.tests('Fog::Google[:monitoring] | timeseries_descriptor requests', ['google']) do
+  @monitoring = Fog::Google[:monitoring]
+
+  @get_timeseries_descriptor_format = {
+    'metric' => String,
+    'project' => String,
+    'labels' => Hash,
+  }
+
+  @list_timeseries_descriptors_format = {
+    'kind' => String,
+    'youngest' => String,
+    'oldest' => String,
+    'timeseries' => [@get_timeseries_descriptor_format],
+  }
+
+  tests('success') do
+
+    tests('#list_timeseries_descriptors').formats(@list_timeseries_descriptors_format) do
+      @monitoring.list_timeseries_descriptors('compute.googleapis.com/instance/uptime',
+                                              Time.now.strftime("%Y-%m-%dT%H:%M:%S%:z")).body
+    end
+
+  end
+
+end


### PR DESCRIPTION
This commit adds the initial support for [Google Cloud Monitoring](https://developers.google.com/cloud-monitoring/)
- Add models, requests, tests & examples for Timeseries
- Add models, requests, tests & examples for TimeseriesDescriptors
- Add models, requests, tests & examples for MetricDescriptors
