### PR TITLE
Clean up Excon::Errors::SocketError::EOFError warning in vcloud_director

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -369,7 +369,7 @@ module Fog
         def request(params)
           begin
             do_request(params)
-          rescue Excon::Errors::SocketError::EOFError
+          rescue EOFError
             # This error can occur if Vcloud receives a request from a network
             # it deems to be unauthorized; no HTTP response is sent, but the
             # connection is sent a signal to terminate early.


### PR DESCRIPTION
Every time I make a connection with the vcloud_director provider I get this warning:

/Users/mray/.chgems/vchs/.gem/ruby/2.1.2/gems/fog-1.23.0/lib/fog/vcloud_director/compute.rb:372: warning: toplevel constant EOFError referenced by Excon::Errors::SocketError::EOFError
