### PR TITLE
remove leading slash from Rackspace compute_v2 request paths

### DIFF
--- a/lib/fog/rackspace/requests/compute_v2/create_virtual_interface.rb
+++ b/lib/fog/rackspace/requests/compute_v2/create_virtual_interface.rb
@@ -20,7 +20,7 @@ module Fog
           request(
             :expects => [200],
             :method => 'POST',
-            :path => "/servers/#{server_id}/os-virtual-interfacesv2",
+            :path => "servers/#{server_id}/os-virtual-interfacesv2",
             :body => Fog::JSON.encode(data)
           )
         end

--- a/lib/fog/rackspace/requests/compute_v2/delete_metadata_item.rb
+++ b/lib/fog/rackspace/requests/compute_v2/delete_metadata_item.rb
@@ -16,7 +16,7 @@ module Fog
           request(
             :expects => 204,
             :method => 'DELETE',
-            :path => "/#{collection}/#{obj_id}/metadata/#{key}"
+            :path => "#{collection}/#{obj_id}/metadata/#{key}"
           )
         end
       end

--- a/lib/fog/rackspace/requests/compute_v2/delete_virtual_interface.rb
+++ b/lib/fog/rackspace/requests/compute_v2/delete_virtual_interface.rb
@@ -14,7 +14,7 @@ module Fog
           request(
             :expects => [200],
             :method => 'DELETE',
-            :path => "/servers/#{server_id}/os-virtual-interfacesv2/#{interface_id}"
+            :path => "servers/#{server_id}/os-virtual-interfacesv2/#{interface_id}"
           )
         end
       end

--- a/lib/fog/rackspace/requests/compute_v2/get_metadata_item.rb
+++ b/lib/fog/rackspace/requests/compute_v2/get_metadata_item.rb
@@ -18,7 +18,7 @@ module Fog
           request(
             :expects => 200,
             :method => 'GET',
-            :path => "/#{collection}/#{obj_id}/metadata/#{key}"
+            :path => "#{collection}/#{obj_id}/metadata/#{key}"
           )
         end
       end

--- a/lib/fog/rackspace/requests/compute_v2/list_keypairs.rb
+++ b/lib/fog/rackspace/requests/compute_v2/list_keypairs.rb
@@ -19,7 +19,7 @@ module Fog
           request(
             :method   => 'GET',
             :expects  => 200,
-            :path     => '/os-keypairs'
+            :path     => 'os-keypairs'
           )
         end
       end

--- a/lib/fog/rackspace/requests/compute_v2/list_metadata.rb
+++ b/lib/fog/rackspace/requests/compute_v2/list_metadata.rb
@@ -17,7 +17,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method => 'GET',
-            :path => "/#{collection}/#{obj_id}/metadata"
+            :path => "#{collection}/#{obj_id}/metadata"
           )
         end
       end

--- a/lib/fog/rackspace/requests/compute_v2/list_virtual_interfaces.rb
+++ b/lib/fog/rackspace/requests/compute_v2/list_virtual_interfaces.rb
@@ -13,7 +13,7 @@ module Fog
           request(
             :expects => [200],
             :method => 'GET',
-            :path => "/servers/#{server_id}/os-virtual-interfacesv2"
+            :path => "servers/#{server_id}/os-virtual-interfacesv2"
           )
         end
       end

--- a/lib/fog/rackspace/requests/compute_v2/set_metadata.rb
+++ b/lib/fog/rackspace/requests/compute_v2/set_metadata.rb
@@ -18,7 +18,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method => 'PUT',
-            :path => "/#{collection}/#{obj_id}/metadata",
+            :path => "#{collection}/#{obj_id}/metadata",
             :body => Fog::JSON.encode('metadata' => metadata)
           )
         end

--- a/lib/fog/rackspace/requests/compute_v2/set_metadata_item.rb
+++ b/lib/fog/rackspace/requests/compute_v2/set_metadata_item.rb
@@ -19,7 +19,7 @@ module Fog
           request(
             :expects => 200,
             :method => 'PUT',
-            :path => "/#{collection}/#{obj_id}/metadata/#{key}",
+            :path => "#{collection}/#{obj_id}/metadata/#{key}",
             :body => Fog::JSON.encode('meta' => { key => value })
           )
         end

--- a/lib/fog/rackspace/requests/compute_v2/update_metadata.rb
+++ b/lib/fog/rackspace/requests/compute_v2/update_metadata.rb
@@ -18,7 +18,7 @@ module Fog
           request(
             :expects => [200, 203],
             :method => 'POST',
-            :path => "/#{collection}/#{obj_id}/metadata",
+            :path => "#{collection}/#{obj_id}/metadata",
             :body => Fog::JSON.encode('metadata' => metadata)
           )
         end


### PR DESCRIPTION
This is a minor issue; the leading slash would create a double slash in the resulting path.
![capture](https://cloud.githubusercontent.com/assets/1262042/3741365/1ae13ac2-175f-11e4-8a73-a172d879fda2.png)
