### PR TITLE
[google|compute] Refactor Compute to use the new Shared module

### DIFF
--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -6,6 +6,12 @@ module Fog
       requires :google_project
       recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string, :google_client
 
+      GOOGLE_COMPUTE_API_VERSION     = 'v1'
+      GOOGLE_COMPUTE_BASE_URL        = 'https://www.googleapis.com/compute/'
+      GOOGLE_COMPUTE_API_SCOPE_URLS  = %w(https://www.googleapis.com/auth/compute
+                                         https://www.googleapis.com/auth/devstorage.read_write)
+      GOOGLE_COMPUTE_DEFAULT_NETWORK = 'default'
+
       request_path 'fog/google/requests/compute'
       request :list_servers
       request :list_aggregated_servers
@@ -159,52 +165,11 @@ module Fog
       model :backend_service
       collection :backend_services
 
-      module Shared
-        attr_reader :project, :api_version
-
-        def shared_initialize(options = {})
-          @project = options[:google_project]
-          @api_version = 'v1'
-          base_url = 'https://www.googleapis.com/compute/'
-          @api_url = base_url + api_version + '/projects/'
-          @default_network = 'default'
-        end
-
-        def build_excon_response(body, status=200)
-          response = Excon::Response.new
-          response.body = body
-          if response.body and response.body["error"]
-            response.status = response.body["error"]["code"]
-            if response.body["error"]["errors"]
-              msg = response.body["error"]["errors"].map{|error| error["message"]}.join(", ")
-            else
-              msg = "Error [#{response.body["error"]["code"]}]: #{response.body["error"]["message"] || "GCE didn't return an error message"}"
-            end
-            case response.status
-            when 404
-              raise Fog::Errors::NotFound.new(msg)
-            else
-              raise Fog::Errors::Error.new(msg)
-            end
-          else
-            response.status = status
-          end
-          response
-        end
-
-      end
-
       class Mock
-        include Collections
-        include Shared
+        include Fog::Google::Shared
 
-        def initialize(options={})
-          shared_initialize(options)
-        end
-
-        def build_response(params={})
-          body = params[:body] || {}
-          build_excon_response(body)
+        def initialize(options)
+          shared_initialize(options[:google_project], GOOGLE_COMPUTE_API_VERSION, GOOGLE_COMPUTE_BASE_URL)
         end
 
         def self.data(api_version)
@@ -853,118 +818,17 @@ module Fog
       end
 
       class Real
-        include Collections
-        include Shared
+        include Fog::Google::Shared
 
         attr_accessor :client
-        attr_reader :compute, :api_url
+        attr_reader :compute
 
         def initialize(options)
-          # NOTE: loaded here to avoid requiring this as a core Fog dependency
-          begin
-            require 'google/api_client'
-          rescue LoadError => error
-            Fog::Logger.warning("Please install the google-api-client gem before using this provider.")
-            raise error
-          end
-          shared_initialize(options)
+          shared_initialize(options[:google_project], GOOGLE_COMPUTE_API_VERSION, GOOGLE_COMPUTE_BASE_URL)
+          options.merge!(:google_api_scope_url => GOOGLE_COMPUTE_API_SCOPE_URLS.join(' '))
 
-          if !options[:google_client].nil?
-            @client = options[:google_client]
-          end
-
-          if @client.nil?
-            if !options[:google_key_location].nil?
-              google_key = File.expand_path(options[:google_key_location])
-            elsif !options[:google_key_string].nil?
-              google_key = options[:google_key_string]
-            end
-
-            if !options[:google_client_email].nil? and !google_key.nil?
-              @client = self.new_pk12_google_client(
-                options[:google_client_email],
-                google_key,
-                options[:app_name],
-                options[:app_verion])
-            else
-              Fog::Logger.debug("Fog::Compute::Google.client has not been initialized nor are the :google_client_email and :google_key_location or :google_key_string options set, so we can not create one for you.")
-              raise ArgumentError.new("No Google API Client has been initialized.")
-            end
-          end
-
-          # We want to always mention we're using Fog.
-          if @client.user_agent.nil? or @client.user_agent.empty?
-            @client.user_agent = ""
-          elsif !@client.user_agent.include? "fog"
-            @client.user_agent += "fog/#{Fog::VERSION}"
-          end
-
+          @client = initialize_google_client(options)
           @compute = @client.discovered_api('compute', api_version)
-        end
-
-        # Public: Create a Google::APIClient with a pkcs12 key and a user email.
-        #
-        # google_client_email - an @developer.gserviceaccount.com email address to use.
-        # google_key - an absolute location to a pkcs12 key file or the content of the file itself.
-        # app_name - an optional string to set as the app name in the user agent.
-        # app_version - an optional string to set as the app version in the user agent.
-        #
-        # Returns a new Google::APIClient
-        def new_pk12_google_client(google_client_email, google_key, app_name=nil, app_version=nil)
-          # The devstorage scope is needed to be able to insert images
-          # devstorage.read_only scope is not sufficient like you'd hope
-          api_scope_url = 'https://www.googleapis.com/auth/compute https://www.googleapis.com/auth/devstorage.read_write'
-
-          user_agent = ""
-          if app_name
-            user_agent = "#{app_name}/#{app_version || '0.0.0'} "
-          end
-          user_agent += "fog/#{Fog::VERSION}"
-
-          api_client_options = {
-            # https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client.rb#L98
-            :application_name => "suppress warning",
-            # https://github.com/google/google-api-ruby-client/blob/master/lib/google/api_client.rb#L100
-            :user_agent => user_agent
-          }
-          local_client = ::Google::APIClient.new(api_client_options)
-
-          key = ::Google::APIClient::KeyUtils.load_from_pkcs12(google_key, 'notasecret')
-
-          local_client.authorization = Signet::OAuth2::Client.new({
-            :audience => 'https://accounts.google.com/o/oauth2/token',
-            :auth_provider_x509_cert_url => "https://www.googleapis.com/oauth2/v1/certs",
-            :client_x509_cert_url => "https://www.googleapis.com/robot/v1/metadata/x509/#{google_client_email}",
-            :issuer => google_client_email,
-            :scope => api_scope_url,
-            :signing_key => key,
-            :token_credential_uri => 'https://accounts.google.com/o/oauth2/token',
-          })
-
-          local_client.authorization.fetch_access_token!
-
-          return local_client
-        end
-
-        def build_result(api_method, parameters, body_object=nil)
-          if body_object
-            result = @client.execute(
-              :api_method => api_method,
-              :parameters => parameters,
-              :body_object => body_object
-            )
-          else
-            result = @client.execute(
-              :api_method => api_method,
-              :parameters => parameters
-            )
-          end
-        end
-
-        # result = Google::APIClient::Result
-        # returns Excon::Response
-        def build_response(result)
-          build_excon_response(result.body.nil? || result.body.empty? ? nil : Fog::JSON.decode(result.body), result.status)
         end
       end
 

--- a/lib/fog/google/requests/compute/add_server_access_config.rb
+++ b/lib/fog/google/requests/compute/add_server_access_config.rb
@@ -24,8 +24,7 @@ module Fog
           body_object['name'] = options[:name] ? options[:name] : 'External NAT'
           body_object['natIP'] = options[:address] if options[:address]
 
-          result = self.build_result(api_method, parameters, body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/add_target_pool_health_checks.rb
+++ b/lib/fog/google/requests/compute/add_target_pool_health_checks.rb
@@ -19,8 +19,7 @@ module Fog
             'healthChecks' => health_checks.map { |i| { 'healthCheck' => i } }
           }
 
-          result = self.build_result(api_method, parameters, body_object=body)
-          self.build_response(result)
+          request(api_method, parameters, body_object=body)
         end
       end
     end

--- a/lib/fog/google/requests/compute/add_target_pool_instances.rb
+++ b/lib/fog/google/requests/compute/add_target_pool_instances.rb
@@ -19,8 +19,7 @@ module Fog
             'instances' => instances.map { |i| { 'instance' => i } }
           }
 
-          result = self.build_result(api_method, parameters, body_object=body)
-          self.build_response(result)
+          request(api_method, parameters, body_object=body)
         end
       end
     end

--- a/lib/fog/google/requests/compute/attach_disk.rb
+++ b/lib/fog/google/requests/compute/attach_disk.rb
@@ -26,8 +26,7 @@ module Fog
             'autoDelete' => options.delete(:autoDelete),
           }
 
-          result = self.build_result(api_method, parameters, body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_address.rb
+++ b/lib/fog/google/requests/compute/delete_address.rb
@@ -16,8 +16,7 @@ module Fog
             'region' => region_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_backend_service.rb
+++ b/lib/fog/google/requests/compute/delete_backend_service.rb
@@ -15,8 +15,7 @@ module Fog
             'project' => @project,
             'backendService' => backend_service_name
           }
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_disk.rb
+++ b/lib/fog/google/requests/compute/delete_disk.rb
@@ -23,7 +23,7 @@ module Fog
           }
           self.data[:disks].delete disk_name
 
-          build_response(:body => self.data[:operations][operation])
+          build_excon_response(self.data[:operations][operation])
         end
       end
 
@@ -40,8 +40,7 @@ module Fog
             'zone' => zone_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_firewall.rb
+++ b/lib/fog/google/requests/compute/delete_firewall.rb
@@ -15,8 +15,7 @@ module Fog
             'firewall' => firewall_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_forwarding_rule.rb
+++ b/lib/fog/google/requests/compute/delete_forwarding_rule.rb
@@ -22,8 +22,7 @@ module Fog
             'region' => region_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_global_operation.rb
+++ b/lib/fog/google/requests/compute/delete_global_operation.rb
@@ -17,8 +17,7 @@ module Fog
             'operation' => operation
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_http_health_check.rb
+++ b/lib/fog/google/requests/compute/delete_http_health_check.rb
@@ -15,8 +15,7 @@ module Fog
             'httpHealthCheck' => name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_image.rb
+++ b/lib/fog/google/requests/compute/delete_image.rb
@@ -15,8 +15,7 @@ module Fog
             'image' => image_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_network.rb
+++ b/lib/fog/google/requests/compute/delete_network.rb
@@ -15,8 +15,7 @@ module Fog
             'network' => network_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_region_operation.rb
+++ b/lib/fog/google/requests/compute/delete_region_operation.rb
@@ -21,8 +21,7 @@ module Fog
             'operation' => operation
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_route.rb
+++ b/lib/fog/google/requests/compute/delete_route.rb
@@ -15,8 +15,7 @@ module Fog
             'route' => identity,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_server.rb
+++ b/lib/fog/google/requests/compute/delete_server.rb
@@ -45,7 +45,7 @@ module Fog
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone_name}/operations/#{operation}"
           }
 
-          build_response(:body => self.data[:operations][operation])
+          build_excon_response(self.data[:operations][operation])
         end
       end
 
@@ -61,8 +61,7 @@ module Fog
             'instance' => server_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_server_access_config.rb
+++ b/lib/fog/google/requests/compute/delete_server_access_config.rb
@@ -18,8 +18,7 @@ module Fog
             'accessConfig'     => options[:access_config].nil? ? 'External NAT' : options[:access_config],
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_snapshot.rb
+++ b/lib/fog/google/requests/compute/delete_snapshot.rb
@@ -15,8 +15,7 @@ module Fog
             'snapshot' => snapshot_name,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_target_pool.rb
+++ b/lib/fog/google/requests/compute/delete_target_pool.rb
@@ -22,8 +22,7 @@ module Fog
             'region' => region_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/delete_zone_operation.rb
+++ b/lib/fog/google/requests/compute/delete_zone_operation.rb
@@ -21,8 +21,7 @@ module Fog
             'operation' => operation
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/detach_disk.rb
+++ b/lib/fog/google/requests/compute/detach_disk.rb
@@ -17,8 +17,7 @@ module Fog
             'deviceName' => deviceName
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_address.rb
+++ b/lib/fog/google/requests/compute/get_address.rb
@@ -16,8 +16,7 @@ module Fog
             'region' => region_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_backend_service.rb
+++ b/lib/fog/google/requests/compute/get_backend_service.rb
@@ -14,8 +14,7 @@ module Fog
             'project' => @project,
             'backendService' => service_name
           }
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_backend_service_health.rb
+++ b/lib/fog/google/requests/compute/get_backend_service_health.rb
@@ -16,7 +16,7 @@ module Fog
           }
           health_results = backend_service.backends.map do |backend|
             body = { 'group' => backend['group'] }
-            resp = build_response(build_result(api_method, parameters, body_object= body))
+            resp = request(api_method, parameters, body_object= body)
             [backend['group'], resp.data[:body]['healthStatus']]
           end
           Hash[health_results]

--- a/lib/fog/google/requests/compute/get_disk.rb
+++ b/lib/fog/google/requests/compute/get_disk.rb
@@ -10,7 +10,7 @@ module Fog
           get_zone(zone_name)
           zone = self.data[:zones][zone_name]
           if disk.nil? or disk["zone"] != zone["selfLink"]
-            return build_response(:body => {
+            return build_excon_response({
               "error" => {
                 "errors" => [
                  {
@@ -27,7 +27,7 @@ module Fog
 
           # TODO transition the disk through the states
 
-          build_response(:body => disk)
+          build_excon_response(disk)
         end
       end
 
@@ -44,8 +44,7 @@ module Fog
             'zone' => zone_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_disk_type.rb
+++ b/lib/fog/google/requests/compute/get_disk_type.rb
@@ -6,7 +6,7 @@ module Fog
           disk_types = list_disk_types(zone).body['items']
           disk_type = disk_types.select { |dt| dt['name'] == identity } || []
           if disk_type.empty?
-            return build_response(:body => {
+            return build_excon_response({
               'error' => {
                 'errors' => [
                   {
@@ -21,7 +21,7 @@ module Fog
             })
           end
 
-          build_response(:body => disk_type.first)
+          build_excon_response(disk_type.first)
         end
       end
 
@@ -34,8 +34,7 @@ module Fog
             'diskType' => identity,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_firewall.rb
+++ b/lib/fog/google/requests/compute/get_firewall.rb
@@ -15,8 +15,7 @@ module Fog
             'firewall' => firewall_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_forwarding_rule.rb
+++ b/lib/fog/google/requests/compute/get_forwarding_rule.rb
@@ -20,8 +20,7 @@ module Fog
             'region' => region_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_global_operation.rb
+++ b/lib/fog/google/requests/compute/get_global_operation.rb
@@ -17,8 +17,7 @@ module Fog
             'operation' => operation
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_http_health_check.rb
+++ b/lib/fog/google/requests/compute/get_http_health_check.rb
@@ -15,8 +15,7 @@ module Fog
             'httpHealthCheck' => name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_image.rb
+++ b/lib/fog/google/requests/compute/get_image.rb
@@ -16,7 +16,7 @@ module Fog
               "message" => "The resource 'projects/#{project}/global/images/#{image_name}' was not found"
             }
           }
-          build_response(:body => image)
+          build_excon_response(image)
         end
       end
 
@@ -28,8 +28,7 @@ module Fog
             'project' => project,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_machine_type.rb
+++ b/lib/fog/google/requests/compute/get_machine_type.rb
@@ -18,7 +18,7 @@ module Fog
              "message" => "The resource 'projects/#{@project}/zones/#{zone_name}/machineTypes/#{machine_type_name}' was not found"
             }
           }
-          build_response(:body => machine_type)
+          build_excon_response(machine_type)
         end
       end
 
@@ -35,8 +35,7 @@ module Fog
             'machineType' => machine_type_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_network.rb
+++ b/lib/fog/google/requests/compute/get_network.rb
@@ -15,8 +15,7 @@ module Fog
             'network' => network_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_project.rb
+++ b/lib/fog/google/requests/compute/get_project.rb
@@ -14,8 +14,7 @@ module Fog
             :project => identity,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_region.rb
+++ b/lib/fog/google/requests/compute/get_region.rb
@@ -7,7 +7,7 @@ module Fog
           region = regions.body['items'].select { |region| region['name'] == identity }
 
           raise Fog::Errors::NotFound if region.nil? || region.empty?
-          build_response(:body => region.first)
+          build_excon_response(region.first)
         end
       end
 
@@ -19,8 +19,7 @@ module Fog
             'region' => identity.split('/')[-1],
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_region_operation.rb
+++ b/lib/fog/google/requests/compute/get_region_operation.rb
@@ -22,8 +22,7 @@ module Fog
             'operation' => operation
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_route.rb
+++ b/lib/fog/google/requests/compute/get_route.rb
@@ -15,8 +15,7 @@ module Fog
             'route' => identity,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_server.rb
+++ b/lib/fog/google/requests/compute/get_server.rb
@@ -7,7 +7,7 @@ module Fog
           get_zone(zone_name)
           zone = self.data[:zones][zone_name]
           if server.nil? or server["zone"] != zone["selfLink"]
-            return build_response(:body => {
+            return build_excon_response({
               "error" => {
                 "errors" => [
                  {
@@ -48,7 +48,7 @@ module Fog
             end
           end
 
-          build_response(:body => server)
+          build_excon_response(server)
         end
       end
 
@@ -67,8 +67,7 @@ module Fog
             'instance' => server_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_server_serial_port_output.rb
+++ b/lib/fog/google/requests/compute/get_server_serial_port_output.rb
@@ -16,8 +16,7 @@ module Fog
             'zone'     => zone.split('/')[-1],
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_snapshot.rb
+++ b/lib/fog/google/requests/compute/get_snapshot.rb
@@ -19,8 +19,7 @@ module Fog
             'project'  => project,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_target_pool.rb
+++ b/lib/fog/google/requests/compute/get_target_pool.rb
@@ -20,8 +20,7 @@ module Fog
             'region' => region_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_target_pool_health.rb
+++ b/lib/fog/google/requests/compute/get_target_pool_health.rb
@@ -18,7 +18,7 @@ module Fog
 
           health_results = target_pool.instances.map do |instance|
             body = { 'instance' => instance }
-            resp = build_response(build_result(api_method, parameters, body_object=body))
+            resp = request(api_method, parameters, body_object=body)
             [instance, resp.data[:body]['healthStatus']]
           end
           Hash[health_results]

--- a/lib/fog/google/requests/compute/get_zone.rb
+++ b/lib/fog/google/requests/compute/get_zone.rb
@@ -16,7 +16,7 @@ module Fog
               "message" => "The resource 'projects/#{project}/zones/#{zone_name}' was not found"
             }
           }
-          build_response(:body => zone)
+          build_excon_response(zone)
         end
       end
 
@@ -28,8 +28,7 @@ module Fog
             'zone' => zone_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/get_zone_operation.rb
+++ b/lib/fog/google/requests/compute/get_zone_operation.rb
@@ -28,7 +28,7 @@ module Fog
               }
             }
           end
-          build_response(:body => operation)
+          build_excon_response(operation)
         end
       end
 
@@ -47,8 +47,7 @@ module Fog
             'operation' => operation
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_address.rb
+++ b/lib/fog/google/requests/compute/insert_address.rb
@@ -17,8 +17,7 @@ module Fog
           body_object = { 'name' => address_name }
           body_object['description'] = options[:description] if options[:description]
 
-          result = self.build_result(api_method, parameters, body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_backend_service.rb
+++ b/lib/fog/google/requests/compute/insert_backend_service.rb
@@ -15,9 +15,8 @@ module Fog
           }
           body_object = { 'name' => backend_service_name }
           body_object.merge!(opts)
-          result = self.build_result(api_method, parameters, body_object=body_object)
 
-          response = self.build_response(result)
+          request(api_method, parameters, body_object=body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_disk.rb
+++ b/lib/fog/google/requests/compute/insert_disk.rb
@@ -60,7 +60,7 @@ module Fog
             "selfLink" => "#{object["zone"]}/operations/#{operation}"
           }
 
-          build_response(:body => self.data[:operations][operation])
+          build_excon_response(self.data[:operations][operation])
         end
       end
 
@@ -105,9 +105,7 @@ module Fog
           # Merge in any remaining options (only 'description' should remain)
           body_object.merge!(opts)
 
-          result = self.build_result(api_method, parameters,
-                                     body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_firewall.rb
+++ b/lib/fog/google/requests/compute/insert_firewall.rb
@@ -2,13 +2,13 @@ module Fog
   module Compute
     class Google
       class Mock
-        def insert_firewall(firewall_name, allowed, network = @default_network, options = {})
+        def insert_firewall(firewall_name, allowed, network = GOOGLE_COMPUTE_DEFAULT_NETWORK, options = {})
           Fog::Mock.not_implemented
         end
       end
 
       class Real
-        def insert_firewall(firewall_name, allowed, network = @default_network, options = {})
+        def insert_firewall(firewall_name, allowed, network = GOOGLE_COMPUTE_DEFAULT_NETWORK, options = {})
           unless network.start_with? 'http'
             network = "#{@api_url}#{@project}/global/networks/#{network}"
           end
@@ -35,8 +35,7 @@ module Fog
             body_object["targetTags"] = options[:target_tags]
           end
 
-          result = self.build_result(api_method, parameters, body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_forwarding_rule.rb
+++ b/lib/fog/google/requests/compute/insert_forwarding_rule.rb
@@ -17,9 +17,7 @@ module Fog
           body_object = { 'name' => forwarding_rule_name }
           body_object.merge!(opts)
 
-          result = self.build_result(api_method, parameters,
-                                     body_object=body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object=body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_http_health_check.rb
+++ b/lib/fog/google/requests/compute/insert_http_health_check.rb
@@ -17,8 +17,7 @@ module Fog
           body_object = { 'name' => name }
           body_object.merge!(opts)
 
-          result = self.build_result(api_method, parameters, body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_image.rb
+++ b/lib/fog/google/requests/compute/insert_image.rb
@@ -24,10 +24,7 @@ module Fog
           # Merge in the remaining params (only 'description' should remain)
           body_object.merge!(options)
 
-          result = self.build_result(api_method,
-                                     parameters,
-                                     body_object=body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object=body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_network.rb
+++ b/lib/fog/google/requests/compute/insert_network.rb
@@ -21,8 +21,7 @@ module Fog
           body_object['description'] = options[:description] if options[:description]
           body_object['gatewayIPv4'] = options[:gateway_ipv4] if options[:gateway_ipv4]
 
-          result = self.build_result(api_method, parameters, body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_route.rb
+++ b/lib/fog/google/requests/compute/insert_route.rb
@@ -27,8 +27,7 @@ module Fog
           body_object['nextHopGateway'] = options[:next_hop_gateway] if options[:next_hop_gateway]
           body_object['nextHopIp'] = options[:next_hop_ip] if options[:next_hop_ip]
 
-          result = self.build_result(api_method, parameters, body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_server.rb
+++ b/lib/fog/google/requests/compute/insert_server.rb
@@ -88,7 +88,7 @@ module Fog
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone_name}/operations/#{operation}"
           }
 
-          build_response(:body => self.data[:operations][operation])
+          build_excon_response(self.data[:operations][operation])
         end
       end
 
@@ -130,8 +130,8 @@ module Fog
           network = nil
           if options.key? 'network'
             network = options.delete 'network'
-          elsif @default_network
-            network = @default_network
+          else
+            network = GOOGLE_COMPUTE_DEFAULT_NETWORK
           end
 
           # ExternalIP is default value for server creation
@@ -184,9 +184,7 @@ module Fog
 
           body_object.merge!(options) # Adds in all remaining options that weren't explicitly handled.
 
-          result = self.build_result(api_method, parameters,
-                                     body_object=body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object=body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_snapshot.rb
+++ b/lib/fog/google/requests/compute/insert_snapshot.rb
@@ -32,9 +32,7 @@ module Fog
           # Merge in any remaining options (description)
           body_object.merge!(opts)
 
-          result = self.build_result(api_method, parameters,
-                                     body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/insert_target_pool.rb
+++ b/lib/fog/google/requests/compute/insert_target_pool.rb
@@ -17,9 +17,7 @@ module Fog
           body_object = { 'name' => target_pool_name }
           body_object.merge!(opts)
 
-          result = self.build_result(api_method, parameters,
-                                     body_object=body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object=body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_addresses.rb
+++ b/lib/fog/google/requests/compute/list_addresses.rb
@@ -15,8 +15,7 @@ module Fog
             'region' => region_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_aggregated_addresses.rb
+++ b/lib/fog/google/requests/compute/list_aggregated_addresses.rb
@@ -15,8 +15,7 @@ module Fog
           }
           parameters['filter'] = options[:filter] if options[:filter]
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_aggregated_disk_types.rb
+++ b/lib/fog/google/requests/compute/list_aggregated_disk_types.rb
@@ -16,7 +16,7 @@ module Fog
               disk_types_items["zones/#{zone}"] = { 'diskTypes' => disk_types }
             end
           end
-          build_response(:body => {
+          build_excon_response({
             'kind' => 'compute#diskTypeAggregatedList',
             'selfLink' => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/aggregated/diskTypes",
             'items' => disk_types_items,
@@ -32,8 +32,7 @@ module Fog
           }
           parameters['filter'] = options[:filter] if options[:filter]
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_aggregated_disks.rb
+++ b/lib/fog/google/requests/compute/list_aggregated_disks.rb
@@ -14,7 +14,7 @@ module Fog
             # Fill the zones Hash with the disks attached to each zone
             self.data[:disks].values.each { |disk| zones["zones/#{disk['zone'].split('/')[-1]}"]['disks'].concat([disk]) }
           end
-          build_response(:body => {
+          build_excon_response({
             "kind" => "compute#diskAggregatedList",
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/aggregated/disks",
             "id" => "projects/#{@project}/aggregated/disks",
@@ -32,8 +32,7 @@ module Fog
           }
           parameters['filter'] = options[:filter] if options[:filter]
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_aggregated_machine_types.rb
+++ b/lib/fog/google/requests/compute/list_aggregated_machine_types.rb
@@ -14,8 +14,7 @@ module Fog
             'project' => @project,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_aggregated_servers.rb
+++ b/lib/fog/google/requests/compute/list_aggregated_servers.rb
@@ -14,7 +14,7 @@ module Fog
             # Fill the zones Hash with the servers attached to each zone
             self.data[:servers].values.each { |server| zones["zones/#{server['zone'].split('/')[-1]}"]['instances'].concat([server]) }
           end
-          build_response(:body => {
+          build_excon_response({
             "kind" => "compute#instanceAggregatedList",
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/aggregated/instances",
             "id" => "projects/#{@project}/aggregated/instances",
@@ -32,8 +32,7 @@ module Fog
           }
           parameters['filter'] = options[:filter] if options[:filter]
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_backend_services.rb
+++ b/lib/fog/google/requests/compute/list_backend_services.rb
@@ -14,8 +14,7 @@ module Fog
             'project' => @project,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_disk_types.rb
+++ b/lib/fog/google/requests/compute/list_disk_types.rb
@@ -3,7 +3,7 @@ module Fog
     class Google
       class Mock
         def list_disk_types(zone)
-          build_response(:body => {
+          build_excon_response({
             'kind' => 'compute#diskTypeList',
             'selfLink' => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone}/diskTypes",
             'items' => [
@@ -38,8 +38,7 @@ module Fog
             'zone'    => zone.split('/')[-1],
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_disks.rb
+++ b/lib/fog/google/requests/compute/list_disks.rb
@@ -4,7 +4,7 @@ module Fog
       class Mock
         def list_disks(zone_name)
           disks = self.data[:disks].values.select{|d| d["zone"].split("/")[-1] == zone_name}
-          build_response(:body => {
+          build_excon_response({
             "kind" => "compute#diskList",
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone_name}/disks",
             "id" => "projects/#{@project}/zones/#{zone_name}/disks",
@@ -21,8 +21,7 @@ module Fog
             'zone' => zone_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_firewalls.rb
+++ b/lib/fog/google/requests/compute/list_firewalls.rb
@@ -14,8 +14,7 @@ module Fog
             'project' => @project
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_forwarding_rules.rb
+++ b/lib/fog/google/requests/compute/list_forwarding_rules.rb
@@ -4,7 +4,7 @@ module Fog
       class Mock
         def list_forwarding_rules(region_name)
           forwarding_rules = self.data[:forwarding_rules].values.select{|d| d["region"].split("/")[-1] == region_name}
-          build_response(:body => {
+          build_excon_response({
             "kind" => "compute#forwardingRuleList",
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/regions/#{region_name}/forwardingRules",
             "id" => "projects/#{@project}/regions/#{region_name}/regions",
@@ -21,8 +21,7 @@ module Fog
             'region' => region_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_global_operations.rb
+++ b/lib/fog/google/requests/compute/list_global_operations.rb
@@ -16,8 +16,7 @@ module Fog
             'project' => @project
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_http_health_checks.rb
+++ b/lib/fog/google/requests/compute/list_http_health_checks.rb
@@ -14,8 +14,7 @@ module Fog
             'project' => @project
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_images.rb
+++ b/lib/fog/google/requests/compute/list_images.rb
@@ -4,7 +4,7 @@ module Fog
       class Mock
         def list_images(project=@project)
           images = data(project)[:images].values
-          build_response(:body => {
+          build_excon_response({
             "kind" => "compute#imageList",
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{project}/global/images",
             "id" => "projects/#{project}/global/images",
@@ -21,8 +21,7 @@ module Fog
             'project' => project
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_machine_types.rb
+++ b/lib/fog/google/requests/compute/list_machine_types.rb
@@ -5,7 +5,7 @@ module Fog
         def list_machine_types(zone_name)
           get_zone(zone_name)
           machine_types = data[:machine_types][zone_name].values
-          build_response(:body => {
+          build_excon_response({
             "kind" => "compute#machineTypeList",
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone_name}/machineTypes",
             "id" => "projects/high-cistern-340/zones/us-central1-a/machineTypes",
@@ -22,8 +22,7 @@ module Fog
             'zone' => zone_name,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_networks.rb
+++ b/lib/fog/google/requests/compute/list_networks.rb
@@ -14,8 +14,7 @@ module Fog
             'project' => @project
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_region_operations.rb
+++ b/lib/fog/google/requests/compute/list_region_operations.rb
@@ -17,8 +17,7 @@ module Fog
             'project' => @project,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_regions.rb
+++ b/lib/fog/google/requests/compute/list_regions.rb
@@ -3,7 +3,7 @@ module Fog
     class Google
       class Mock
         def list_regions
-          build_response(:body => {
+          build_excon_response({
             "kind" => "compute#regionList",
             "selfLink" => "https://www.googleapis.com/compute/v1/projects/#{@project}/regions",
             "id" => "projects/#{@project}/regions",
@@ -77,8 +77,7 @@ module Fog
             'project' => @project
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_routes.rb
+++ b/lib/fog/google/requests/compute/list_routes.rb
@@ -14,8 +14,7 @@ module Fog
             'project' => @project,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_servers.rb
+++ b/lib/fog/google/requests/compute/list_servers.rb
@@ -6,7 +6,7 @@ module Fog
           get_zone(zone_name)
           zone = self.data[:zones][zone_name]
           servers = self.data[:servers].values.select{|s| s["zone"] == zone["selfLink"]}
-          build_response(:body => {
+          build_excon_response({
             "kind" => "compute#instanceList",
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones/#{zone_name}/instances",
             "id" => "projects/#{@project}/zones/#{zone_name}/instances",
@@ -23,8 +23,7 @@ module Fog
             'zone' => zone_name,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_snapshots.rb
+++ b/lib/fog/google/requests/compute/list_snapshots.rb
@@ -15,8 +15,7 @@ module Fog
             'project' => project
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_target_pools.rb
+++ b/lib/fog/google/requests/compute/list_target_pools.rb
@@ -15,8 +15,7 @@ module Fog
             'region' => region_name
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_zone_operations.rb
+++ b/lib/fog/google/requests/compute/list_zone_operations.rb
@@ -17,8 +17,7 @@ module Fog
             'project' => @project,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/list_zones.rb
+++ b/lib/fog/google/requests/compute/list_zones.rb
@@ -4,7 +4,7 @@ module Fog
       class Mock
         def list_zones
           zones = self.data[:zones].values
-          build_response(:body => {
+          build_excon_response({
             "kind" => "compute#zoneList",
             "selfLink" => "https://www.googleapis.com/compute/#{api_version}/projects/#{@project}/zones",
             "id" => "projects/#{@project}/zones",
@@ -20,8 +20,7 @@ module Fog
             'project' => @project
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/remove_target_pool_health_checks.rb
+++ b/lib/fog/google/requests/compute/remove_target_pool_health_checks.rb
@@ -19,8 +19,7 @@ module Fog
             'healthChecks' => health_checks.map { |i| { 'healthCheck' => i } }
           }
 
-          result = self.build_result(api_method, parameters, body_object=body)
-          self.build_response(result)
+          request(api_method, parameters, body_object=body)
         end
       end
     end

--- a/lib/fog/google/requests/compute/remove_target_pool_instance.rb
+++ b/lib/fog/google/requests/compute/remove_target_pool_instance.rb
@@ -19,8 +19,7 @@ module Fog
             'instances' => instances.map { |i| { 'instance' => i } }
           }
 
-          result = self.build_result(api_method, parameters, body_object=body)
-          self.build_response(result)
+          request(api_method, parameters, body_object=body)
         end
       end
     end

--- a/lib/fog/google/requests/compute/remove_target_pool_instances.rb
+++ b/lib/fog/google/requests/compute/remove_target_pool_instances.rb
@@ -19,8 +19,7 @@ module Fog
             'instances' => instances.map { |i| { 'instance' => i } }
           }
 
-          result = self.build_result(api_method, parameters, body_object=body)
-          self.build_response(result)
+          request(api_method, parameters, body_object=body)
         end
       end
     end

--- a/lib/fog/google/requests/compute/reset_server.rb
+++ b/lib/fog/google/requests/compute/reset_server.rb
@@ -16,8 +16,7 @@ module Fog
             'zone'     => zone.split('/')[-1],
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/set_common_instance_metadata.rb
+++ b/lib/fog/google/requests/compute/set_common_instance_metadata.rb
@@ -18,8 +18,7 @@ module Fog
             :items => Array(metadata).map { |pair| { :key => pair[0], :value => pair[1] } },
           }
 
-          result = self.build_result(api_method, parameters, body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/set_forwarding_rule_target.rb
+++ b/lib/fog/google/requests/compute/set_forwarding_rule_target.rb
@@ -19,8 +19,7 @@ module Fog
             'target' => target
           }
 
-          result = self.build_result(api_method, parameters, body_object=body)
-          self.build_response(result)
+          request(api_method, parameters, body_object=body)
         end
       end
     end

--- a/lib/fog/google/requests/compute/set_metadata.rb
+++ b/lib/fog/google/requests/compute/set_metadata.rb
@@ -31,12 +31,7 @@ module Fog
             'fingerprint' => fingerprint,
             "items" => metadata.to_a.map {|pair| { :key => pair[0], :value => pair[1] } }
           }
-          result = self.build_result(
-            api_method,
-            parameters,
-            body_object=body_object
-          )
-          response = self.build_response(result)
+          request(api_method, parameters, body_object=body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/set_server_disk_auto_delete.rb
+++ b/lib/fog/google/requests/compute/set_server_disk_auto_delete.rb
@@ -18,8 +18,7 @@ module Fog
             'deviceName' => device_name,
           }
 
-          result = self.build_result(api_method, parameters)
-          response = self.build_response(result)
+          request(api_method, parameters)
         end
       end
     end

--- a/lib/fog/google/requests/compute/set_server_scheduling.rb
+++ b/lib/fog/google/requests/compute/set_server_scheduling.rb
@@ -21,8 +21,7 @@ module Fog
             'automaticRestart'  => automatic_restart,
           }
 
-          result = self.build_result(api_method, parameters, body_object)
-          response = self.build_response(result)
+          request(api_method, parameters, body_object)
         end
       end
     end

--- a/lib/fog/google/requests/compute/set_tags.rb
+++ b/lib/fog/google/requests/compute/set_tags.rb
@@ -16,12 +16,7 @@ module Fog
             'zone' => zone
           }
           body_object = { "fingerprint" => fingerprint, "items" => tags }
-          result = self.build_result(
-            api_method,
-            parameters,
-            body_object=body_object
-          )
-          response = self.build_response(result)
+          request(api_method, parameters, body_object=body_object)
         end
       end
     end


### PR DESCRIPTION
Commit d801b27 introduced a new Shared module with logic to initialize a google_client_api, and to make requests.

This commit refactors Compute to use the new Shared module.
