### PR TITLE
Fix parsing of SpotInstanceRequests responce when we also specify NetworkInterface

### DIFF
--- a/lib/fog/aws/parsers/compute/spot_instance_requests.rb
+++ b/lib/fog/aws/parsers/compute/spot_instance_requests.rb
@@ -36,7 +36,7 @@ module Fog
             when 'deviceName', 'status', 'volumeId'
               @block_device_mapping[name] = value
             when 'groupId'
-              if !@context.include?('networkInterfaceSet') then
+              if !@context.include?('networkInterfaceSet')
                 @spot_instance_request['launchSpecification']['groupSet'] << value
               end
             when 'arn', 'name'


### PR DESCRIPTION
When you specify LaunchSpecification.NetworkInterface.\* for [RequestSpotInstances](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-RequestSpotInstances.html)
response of [DescribeSpotInstanceRequests](http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-DescribeSpotInstanceRequests.html) have additional elements 

``` xml
<networkInterfaceSet>
   <item>
     <deviceIndex>0</deviceIndex>
     <subnetId>subnet-aa707382</subnetId>
     <description>test</description>
     <privateIpAddress>10.0.0.12</privateIpAddress>
     <groupSet>
       <item>
         <groupId>sg-f1612594</groupId>
       </item>
     </groupSet>
     <deleteOnTermination>true</deleteOnTermination>
   </item>
</networkInterfaceSet>
```

[Default xml response](http://pastebin.com/3FVeqmUB)
[With networking xml response](http://pastebin.com/c6BTeVtM)

With networking we does not parce instanceId well.
This pull request fix bug with parsing such cases.
