### PR TITLE
[google|dns] Add initial support for Google Cloud DNS.

### DIFF
--- a/lib/fog/bin/google.rb
+++ b/lib/fog/bin/google.rb
@@ -4,6 +4,8 @@ module Google # deviates from other bin stuff to accomodate gem
       case key
       when :compute
         Fog::Compute::Google
+      when :dns
+        Fog::DNS::Google
       when :monitoring
         Fog::Google::Monitoring
       when :storage
@@ -18,16 +20,19 @@ module Google # deviates from other bin stuff to accomodate gem
     def [](service)
       @@connections ||= Hash.new do |hash, key|
         hash[key] = case key
-        when :storage
-          Fog::Logger.warning("Google[:storage] is not recommended, use Storage[:google] for portability")
-          Fog::Storage.new(:provider => 'Google')
         when :compute
           Fog::Logger.warning("Google[:compute] is not recommended, use Compute[:google] for portability")
           Fog::Compute.new(:provider => 'Google')
+        when :dns
+          Fog::Logger.warning("Google[:dns] is not recommended, use DNS[:google] for portability")
+          Fog::DNS.new(:provider => 'Google')
         when :monitoring
           Fog::Google::Monitoring.new
         when :sql
           Fog::Google::SQL.new
+        when :storage
+          Fog::Logger.warning("Google[:storage] is not recommended, use Storage[:google] for portability")
+          Fog::Storage.new(:provider => 'Google')
         else
           raise ArgumentError, "Unrecognized service: #{key.inspect}"
         end

--- a/lib/fog/google.rb
+++ b/lib/fog/google.rb
@@ -1,4 +1,5 @@
 require 'fog/google/compute'
+require 'fog/google/dns'
 require 'fog/google/monitoring'
 require 'fog/google/storage'
 require 'fog/google/sql'

--- a/lib/fog/google/core.rb
+++ b/lib/fog/google/core.rb
@@ -6,6 +6,7 @@ module Fog
     extend Fog::Provider
 
     service(:compute,    'Compute')
+    service(:dns,        'DNS')
     service(:monitoring, 'Monitoring')
     service(:storage,    'Storage')
     service(:sql,        'SQL')

--- a/lib/fog/google/dns.rb
+++ b/lib/fog/google/dns.rb
@@ -1,0 +1,62 @@
+require 'fog/google/core'
+
+module Fog
+  module DNS
+    class Google < Fog::Service
+      requires :google_project
+      recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string, :google_client
+
+      GOOGLE_DNS_API_VERSION     = 'v1beta1'
+      GOOGLE_DNS_BASE_URL        = 'https://www.googleapis.com/dns/'
+      GOOGLE_DNS_API_SCOPE_URLS  = %w(https://www.googleapis.com/auth/ndev.clouddns.readwrite)
+
+      request_path 'fog/google/requests/dns'
+      request :list_managed_zones
+      request :create_managed_zone
+      request :delete_managed_zone
+
+      class Mock
+	include Fog::Google::Shared
+
+        def initialize(options)
+          shared_initialize(options[:google_project], GOOGLE_DNS_API_VERSION, GOOGLE_DNS_BASE_URL)
+        end
+
+	def self.data(api_version)
+	  @data ||= {}
+	end
+
+	def self.reset
+	  @data = nil
+	end
+
+        def data(project=@project)
+          self.class.data(api_version)[project] ||= {
+              :managed_zones => {
+                  :by_id => {},
+                  :by_name => {},
+              },
+	  }
+        end
+
+        def reset_data
+          self.class.data(api_version).delete(@project)
+        end
+      end
+
+      class Real
+        include Fog::Google::Shared
+
+        attr_accessor :client
+        attr_reader :dns
+
+        def initialize(options)
+          shared_initialize(options[:google_project], GOOGLE_DNS_API_VERSION, GOOGLE_DNS_BASE_URL)
+          options.merge!(:google_api_scope_url => GOOGLE_DNS_API_SCOPE_URLS.join(' '))
+          @client = initialize_google_client(options)
+          @dns = @client.discovered_api('dns', api_version)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/dns/create_managed_zone.rb
+++ b/lib/fog/google/requests/dns/create_managed_zone.rb
@@ -1,0 +1,49 @@
+require 'date'
+module Fog
+  module DNS
+    class Google
+
+      class Mock
+        def create_managed_zone(zone_name, dns_name, descr='')
+          id = Fog::Mock.random_numbers(19).to_s
+          object = {
+            "kind" => "dns#managedZone",
+            "id" => id,
+            "creationTime" => DateTime.now.strftime('%FT%T.%LZ'),
+            "name" => zone_name,
+            "dnsName" => dns_name,
+            "description" => descr,
+	    "nameServers" => [
+	      "ns-cloud-e1.googledomains.com.",
+	      "ns-cloud-e2.googledomains.com.",
+	      "ns-cloud-e3.googledomains.com.",
+	      "ns-cloud-e4.googledomains.com.",
+	    ],
+	  }
+          self.data[:managed_zones][:by_name][zone_name] = object
+          self.data[:managed_zones][:by_id][id] = object
+
+          build_excon_response(object)
+        end
+
+      end
+
+      class Real
+        def create_managed_zone(zone_name, dns_name, descr='')
+          api_method = @dns.managed_zones.create
+          parameters = {
+            'project' => @project,
+          }
+
+          body_object = {
+	    'name' => zone_name,
+	    'dnsName' => dns_name,
+	  }
+	  body_object['description'] = descr unless descr.nil?
+
+          request(api_method, parameters, body_object)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/dns/delete_managed_zone.rb
+++ b/lib/fog/google/requests/dns/delete_managed_zone.rb
@@ -1,0 +1,39 @@
+module Fog
+  module DNS
+    class Google
+
+      class Mock
+        def delete_managed_zone(zone_name_or_id)
+	  if self.data[:managed_zones][:by_name].has_key?(zone_name_or_id)
+            zone_name = zone_name_or_id
+            zone = self.data[:managed_zones][:by_name][zone_name]
+	    zone_id = zone['id']
+	  elsif self.data[:managed_zones][:by_id].has_key?(zone_name_or_id)
+            zone_id = zone_name_or_id
+            zone = self.data[:managed_zones][:by_name][zone_id]
+	    zone_name = zone['name']
+	  else
+	    raise Fog::Errors::NotFound, "The 'parameters.managedZone' resource named '#{zone_name_or_id}' does not exist."
+	  end
+	  self.data[:managed_zones][:by_name].delete(zone_name)
+	  self.data[:managed_zones][:by_id].delete(zone_id)
+
+          build_excon_response(nil)
+        end
+
+      end
+
+      class Real
+        def delete_managed_zone(zone_name_or_id)
+          api_method = @dns.managed_zones.delete
+          parameters = {
+            'project' => @project,
+	    'managedZone' => zone_name_or_id,
+          }
+
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/dns/list_managed_zones.rb
+++ b/lib/fog/google/requests/dns/list_managed_zones.rb
@@ -1,0 +1,26 @@
+module Fog
+  module DNS
+    class Google
+      class Mock
+        def list_managed_zones()
+          zones = self.data[:managed_zones][:by_id].values
+          build_excon_response({
+	    "kind" => "dns#managedZonesListResponse",
+	    "managedZones" => zones,
+          })
+        end
+      end
+
+      class Real
+        def list_managed_zones()
+          api_method = @dns.managed_zones.list
+          parameters = {
+            'project' => @project,
+          }
+
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/tests/google/requests/dns/managed_zone_tests.rb
+++ b/tests/google/requests/dns/managed_zone_tests.rb
@@ -1,0 +1,52 @@
+Shindo.tests('Fog::DNS[:google] | managed_zone requests', ['google']) do
+
+  @google = Fog::DNS[:google]
+
+  @create_managed_zone_schema = {
+      'kind' => String,
+      'id' => String,
+      'creationTime' => String,
+      'name' => String,
+      'dnsName' => String,
+      'description' => String,
+      'nameServers' => [String],
+  }
+
+  @list_managed_zones_schema = {
+      'kind' => String,
+      'managedZones' => [@create_managed_zone_schema],
+  }
+
+  tests('success') do
+
+    zone_name = 'new-zone-test'
+    # TODO: this will fail in non-mocked mode, since Google requires
+    # confirmation of ownership for created domains in some cases.
+    zone_dns_name = 'fog-test.your-own-domain.com.'
+    # You can comment out this line if you set the above to a verified domain
+    # of yours.
+    tests('Needs a verified domain').pending unless Fog.mocking?
+
+    tests("#create_managed_zone").data_matches_schema(
+        @create_managed_zone_schema, {:allow_extra_keys => false}) do
+      @google.create_managed_zone(zone_name, zone_dns_name).body
+    end
+
+    tests("#list_managed_zones") do
+      response = @google.list_managed_zones().body
+      tests('schema').data_matches_schema(@list_managed_zones_schema, {:allow_extra_keys => false}) { response }
+      tests('test zone present').returns(true) { response['managedZones'].one? { |zone| zone['name'] == zone_name } }
+    end
+
+    tests("#delete_managed_zone").returns(nil) do
+     @google.delete_managed_zone(zone_name).body
+    end
+  end
+
+  tests('failure') do
+    tests("#delete_managed_zone").raises(Fog::Errors::NotFound) do
+     @google.delete_managed_zone('zone-which-does-not-exist').body
+    end
+  end
+
+end


### PR DESCRIPTION
- some common plumbing
- requests for creating, deleting and listing managed zones, with tests

One thing we should discuss is the test domain in tests/google/requests/dns/managed_zone_tests.rb
For the test to pass in non-mocked mode, the developer who runs the tests needs to confirm its ownership with Google. This implies that it needs to be configured for every developer individually.
Alternatively (and this is what probably should be the default) is to disable most (if not all) the Google DNS tests in non-mocked mode.
