### PR TITLE
Check region against static list, only if host is a subdomain of amazonaws

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -294,7 +294,22 @@ module Fog
           @aws_credentials_expire_at = Time::now + 20
           setup_credentials(options)
           @region = options[:region] || 'us-east-1'
-          validate_aws_region @region
+
+          if @endpoint = options[:endpoint]
+            endpoint = URI.parse(@endpoint)
+            @host = endpoint.host
+            @path = endpoint.path
+            @port = endpoint.port
+            @scheme = endpoint.scheme
+          else
+            @host = options[:host] || "ec2.#{options[:region]}.amazonaws.com"
+            @path       = options[:path]        || '/'
+            @persistent = options[:persistent]  || false
+            @port       = options[:port]        || 443
+            @scheme     = options[:scheme]      || 'https'
+          end
+
+          validate_aws_region(@host, @region)
         end
 
         def region_data
@@ -443,8 +458,6 @@ module Fog
           @instrumentor_name      = options[:instrumentor_name] || 'fog.aws.compute'
           @version                = options[:version]     ||  '2014-06-15'
 
-          validate_aws_region @region
-
           if @endpoint = options[:endpoint]
             endpoint = URI.parse(@endpoint)
             @host = endpoint.host
@@ -458,6 +471,8 @@ module Fog
             @port       = options[:port]        || 443
             @scheme     = options[:scheme]      || 'https'
           end
+
+          validate_aws_region(@host, @region)
           @connection = Fog::XML::Connection.new("#{@scheme}://#{@host}:#{@port}#{@path}", @persistent, @connection_options)
         end
 

--- a/lib/fog/aws/region_methods.rb
+++ b/lib/fog/aws/region_methods.rb
@@ -1,8 +1,8 @@
 module Fog
   module AWS
     module RegionMethods
-      def validate_aws_region region
-        unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(region)
+      def validate_aws_region host, region
+        if host.end_with?('.amazonaws.com') and not ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(region)
           raise ArgumentError, "Unknown region: #{region.inspect}"
         end
       end

--- a/tests/aws/requests/compute/region_tests.rb
+++ b/tests/aws/requests/compute/region_tests.rb
@@ -24,9 +24,17 @@ Shindo.tests('Fog::Compute[:aws] | region requests', ['aws']) do
         Fog::Compute::AWS.new({:aws_access_key_id => 'dummykey',
                 :aws_secret_access_key => 'dummysecret',
                 :aws_session_token => 'dummytoken',
-                :region => "world-antarctica-1"})
+                :region => 'world-antarctica-1'})
       end
 
+    end
+
+    tests("#unknown_endpoint").formats(@regions_format) do
+      Fog::Compute::AWS.new({:aws_access_key_id => 'dummykey',
+                             :aws_secret_access_key => 'dummysecret',
+                             :aws_session_token => 'dummytoken',
+                             :region => 'world-antarctica-1',
+                             :endpoint => 'aws-clone.example'}).describe_regions.body
     end
 
   end


### PR DESCRIPTION
Following the proposal in #3106, here is the simple approach of simply disabling the check for non-aws subdomains.
