### PR TITLE
[vsphere] get resource pool without name

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_resource_pool.rb
+++ b/lib/fog/vsphere/requests/compute/get_resource_pool.rb
@@ -13,7 +13,7 @@ module Fog
         def get_raw_resource_pool(name, cluster_name, datacenter_name)
           dc      = find_raw_datacenter(datacenter_name)
           cluster = dc.find_compute_resource(cluster_name)
-          cluster.resourcePool.find name
+          name.nil? ? cluster.resourcePool : cluster.resourcePool.find( name)
         end
       end
 


### PR DESCRIPTION
This appears to be the best way to allow cloning into a chosen cluster which is not using any resource pools. Luckily the cluster is able to return a default resource pool. I have this working with vsphere 5.1 and rbvmomi 1.6.0.
The option to the vm_clone method would look like this `'resource_pool' => ['cluster5', nil]`