### PR TITLE
[aws] catch invalid uri

### DIFF
--- a/lib/fog/aws/compute.rb
+++ b/lib/fog/aws/compute.rb
@@ -153,6 +153,8 @@ module Fog
       request :monitor_instances
       request :unmonitor_instances
 
+      class InvalidURIError < Exception; end
+
       # deprecation
       class Real
         def modify_image_attributes(*params)
@@ -297,7 +299,7 @@ module Fog
 
           if @endpoint = options[:endpoint]
             endpoint = URI.parse(@endpoint)
-            @host = endpoint.host
+            @host = endpoint.host or raise InvalidURIError.new("could not parse endpoint: #{@endpoint}")
             @path = endpoint.path
             @port = endpoint.port
             @scheme = endpoint.scheme
@@ -308,7 +310,6 @@ module Fog
             @port       = options[:port]        || 443
             @scheme     = options[:scheme]      || 'https'
           end
-
           validate_aws_region(@host, @region)
         end
 
@@ -460,7 +461,7 @@ module Fog
 
           if @endpoint = options[:endpoint]
             endpoint = URI.parse(@endpoint)
-            @host = endpoint.host
+            @host = endpoint.host or raise InvalidURIError.new("could not parse endpoint: #{@endpoint}")
             @path = endpoint.path
             @port = endpoint.port
             @scheme = endpoint.scheme

--- a/tests/aws/requests/compute/region_tests.rb
+++ b/tests/aws/requests/compute/region_tests.rb
@@ -34,7 +34,17 @@ Shindo.tests('Fog::Compute[:aws] | region requests', ['aws']) do
                              :aws_secret_access_key => 'dummysecret',
                              :aws_session_token => 'dummytoken',
                              :region => 'world-antarctica-1',
-                             :endpoint => 'aws-clone.example'}).describe_regions.body
+                             :endpoint => 'http://aws-clone.example'}).describe_regions.body
+    end
+
+    tests("#invalid_endpoint") do
+      raises(Fog::Compute::AWS::InvalidURIError) do
+        Fog::Compute::AWS.new({:aws_access_key_id => 'dummykey',
+                             :aws_secret_access_key => 'dummysecret',
+                             :aws_session_token => 'dummytoken',
+                             :region => 'world-antarctica-1',
+                             :endpoint => 'aws-clone.example'})
+      end
     end
 
   end


### PR DESCRIPTION
if URI.parse does not result in a host we don't continue and raise
an error.
this fixes the failing build
