### PR TITLE
[vsphere] find network by name and dvswitch

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_network.rb
+++ b/lib/fog/vsphere/requests/compute/get_network.rb
@@ -10,15 +10,44 @@ module Fog
 
         protected
 
-        def get_raw_network(name, datacenter_name, distributedswitch_name=nil)
-          dc = find_raw_datacenter(datacenter_name)
-
-          @connection.serviceContent.viewManager.CreateContainerView({
-            :container  => dc.networkFolder,
-            :type       =>  ["Network"],
-            :recursive  => true
-          }).view.select { |n| n.name == name and (not distributedswitch_name or n.config.distributedVirtualSwitch.name == distributedswitch_name)}.first
+        def get_raw_network(name, datacenter_name, distributedswitch=nil)
+          finder = choose_finder(name, distributedswitch)
+          networks = get_all_raw_networks(datacenter_name)
+          networks.find { |n| finder.call(n) }
         end
+      end
+
+      module Shared
+
+        protected
+
+        def get_all_raw_networks(datacenter_name)
+          dc = find_raw_datacenter(datacenter_name)
+          @connection.serviceContent.viewManager.
+            CreateContainerView({
+                                 :container => dc.networkFolder,
+                                 :type =>      ["Network"],
+                                 :recursive => true
+                                }).view
+        end
+
+        def choose_finder(name, distributedswitch)
+          case distributedswitch
+          when String
+            # only the one will do
+            Proc.new { |n| (n.name == name) &&
+                (n.class.to_s == "DistributedVirtualPortgroup") &&
+                (n.config.distributedVirtualSwitch.name == distributedswitch)
+            }
+          when :dvs
+            # the first distributed virtual switch will do - selected by network - gives control to vsphere
+            Proc.new { |n| (n.name == name) && (n.class.to_s == "DistributedVirtualPortgroup") }
+          else
+            # the first matching network will do, seems like the non-distributed networks come first
+            Proc.new { |n| (n.name == name) }
+          end
+        end
+
       end
 
       class Mock

--- a/tests/vsphere/requests/compute/get_network_tests.rb
+++ b/tests/vsphere/requests/compute/get_network_tests.rb
@@ -1,0 +1,48 @@
+Shindo.tests('Fog::Compute[:vsphere] | get_network request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+
+  class DistributedVirtualPortgroup
+    attr_accessor :name, :dvs_name
+
+    def initialize attrs
+      @name = attrs.fetch(:name)
+      @dvs_name = attrs.fetch(:dvs_name)
+    end
+
+    def config
+      OpenStruct.new( :distributedVirtualSwitch => OpenStruct.new(:name => dvs_name))
+    end
+  end
+
+  fake_networks = [OpenStruct.new(:name => 'non-dvs'),
+                   DistributedVirtualPortgroup.new( :name => 'web1', :dvs_name => 'dvs5'),
+                   DistributedVirtualPortgroup.new( :name => 'web1', :dvs_name => 'dvs11'),
+                   DistributedVirtualPortgroup.new( :name => 'other', :dvs_name => 'other'),
+                  ]
+
+
+  tests('#choose_finder should') do
+    test('choose the network based on network name and dvs name'){
+      finder = compute.send(:choose_finder, 'web1', 'dvs11')
+      found_network = fake_networks.find{ |n| finder.call(n) }
+      found_network.name == 'web1' && found_network.dvs_name == 'dvs11'
+    }
+    test('choose the network based on network name and any dvs'){
+      finder = compute.send(:choose_finder, 'web1', :dvs)
+      found_network = fake_networks.find{ |n| finder.call(n) }
+      found_network.name == 'web1' && found_network.dvs_name == 'dvs5'
+    }
+    test('choose the network based on network name only'){
+      finder = compute.send(:choose_finder, 'other', nil)
+      found_network = fake_networks.find{ |n| finder.call(n) }
+      found_network.name == 'other' && found_network.dvs_name == 'other'
+    }
+    test('choose the network based on network name only for non-dvs'){
+      finder = compute.send(:choose_finder, 'non-dvs', nil)
+      found_network = fake_networks.find{ |n| finder.call(n) }
+      found_network.name == 'non-dvs' && found_network.class.name.to_s == 'OpenStruct'
+    }
+  end
+end


### PR DESCRIPTION
given a name and a switch name
or just a name and whether a dvs is desired
or just a name

When you just want the first (or only) distributed virtual switch on a given cluster, you for example call `get_raw_network(name, datacenter_name, true)` This enables a network admin to choose where a new machine will be placed on the network by moving a network to a distributed virtual switch or non distributed virtual switch.