### PR TITLE
[openstack] deprecate namespaced params

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -3,13 +3,21 @@ require 'fog/openstack/core'
 module Fog
   module Compute
     class OpenStack < Fog::Service
+      # the openstack_* params are all deprecated. remove the
+      # 'openstack_' part of the string from your config parameter names.
       requires :openstack_auth_url
+      recognizes :auth_url
+
       recognizes :openstack_auth_token, :openstack_management_url,
                  :persistent, :openstack_service_type, :openstack_service_name,
                  :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region,
                  :openstack_endpoint_type
+
+      recognizes :auth_token, :management_url, :persistent, :service_type,
+                 :service_name, :tenant, :api_key, :username, :identity_endpoint,
+                 :current_user, :current_tenant, :region, :endpoint_type
 
       ## MODELS
       #
@@ -246,38 +254,46 @@ module Fog
         end
 
         def initialize(options={})
-          @openstack_username = options[:openstack_username]
-          @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
 
-          @current_tenant = options[:openstack_tenant]
+          @username = options[:username]
+          @auth_uri = URI.parse(options[:auth_url])
+
+          @current_tenant = options[:tenant]
 
           @auth_token = Fog::Mock.random_base64(64)
           @auth_token_expiration = (Time.now.utc + 86400).iso8601
 
-          management_url = URI.parse(options[:openstack_auth_url])
+          management_url = URI.parse(options[:auth_url])
           management_url.port = 8774
           management_url.path = '/v1.1/1'
-          @openstack_management_url = management_url.to_s
+          @management_url = management_url.to_s
 
-          identity_public_endpoint = URI.parse(options[:openstack_auth_url])
+          identity_public_endpoint = URI.parse(options[:auth_url])
           identity_public_endpoint.port = 5000
-          @openstack_identity_public_endpoint = identity_public_endpoint.to_s
+          @identity_public_endpoint = identity_public_endpoint.to_s
         end
 
         def data
-          self.class.data["#{@openstack_username}-#{@current_tenant}"]
+          self.class.data["#{@username}-#{@current_tenant}"]
         end
 
         def reset_data
-          self.class.data.delete("#{@openstack_username}-#{@current_tenant}")
+          self.class.data.delete("#{@username}-#{@current_tenant}")
         end
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :openstack_identity_endpoint => @openstack_identity_public_endpoint }
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url,
+            :identity_endpoint => @identity_public_endpoint }
         end
       end
 
@@ -288,29 +304,36 @@ module Fog
         attr_reader :current_tenant
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
-          @auth_token        = options[:openstack_auth_token]
-          @openstack_identity_public_endpoint = options[:openstack_identity_endpoint]
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
+
+          @auth_token = options[:auth_token]
+          @identity_public_endpoint = options[:identity_endpoint]
 
           unless @auth_token
             missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+            @api_key  = options[:api_key]
+            @username = options[:username]
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
+            missing_credentials << :api_key  unless @api_key
+            missing_credentials << :username unless @username
             raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
           end
 
-          @openstack_tenant     = options[:openstack_tenant]
-          @openstack_auth_uri   = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type = options[:openstack_service_type] || ['nova', 'compute']
-          @openstack_service_name = options[:openstack_service_name]
-          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
-          @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
-          @openstack_region      = options[:openstack_region]
+          @tenant     = options[:tenant]
+          @auth_uri   = URI.parse(options[:auth_url])
+          @management_url       = options[:management_url]
+          @must_reauthenticate  = false
+          @service_type = options[:service_type] || ['nova', 'compute']
+          @service_name = options[:service_name]
+          @identity_service_type = options[:identity_service_type] || 'identity'
+          @endpoint_type = options[:endpoint_type] || 'publicURL'
+          @region      = options[:region]
 
           @connection_options = options[:connection_options] || {}
 
@@ -325,11 +348,11 @@ module Fog
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :openstack_identity_endpoint => @openstack_identity_public_endpoint,
-            :openstack_region         => @openstack_region,
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url,
+            :identity_endpoint => @identity_public_endpoint,
+            :region         => @region,
             :current_user             => @current_user,
             :current_tenant           => @current_tenant }
         end
@@ -351,7 +374,7 @@ module Fog
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration
-              @openstack_must_reauthenticate = true
+              @must_reauthenticate = true
               authenticate
               retry
             else # Bad Credentials
@@ -376,21 +399,21 @@ module Fog
         private
 
         def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
+          if !@management_url || @must_reauthenticate
             options = {
-              :openstack_api_key    => @openstack_api_key,
-              :openstack_username   => @openstack_username,
-              :openstack_auth_token => @auth_token,
-              :openstack_auth_uri   => @openstack_auth_uri,
-              :openstack_region     => @openstack_region,
-              :openstack_tenant     => @openstack_tenant,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_identity_service_type => @openstack_identity_service_type,
-              :openstack_endpoint_type => @openstack_endpoint_type
+              :api_key    => @api_key,
+              :username   => @username,
+              :auth_token => @auth_token,
+              :auth_uri   => @auth_uri,
+              :region     => @region,
+              :tenant     => @tenant,
+              :service_type => @service_type,
+              :service_name => @service_name,
+              :identity_service_type => @identity_service_type,
+              :endpoint_type => @endpoint_type
             }
 
-            if @openstack_auth_uri.path =~ /\/v2.0/
+            if @auth_uri.path =~ /\/v2.0/
 
               credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)
             else
@@ -400,14 +423,14 @@ module Fog
             @current_user = credentials[:user]
             @current_tenant = credentials[:tenant]
 
-            @openstack_must_reauthenticate = false
+            @must_reauthenticate = false
             @auth_token               = credentials[:token]
             @auth_token_expiration    = credentials[:expires]
-            @openstack_management_url = credentials[:server_management_url]
-            @openstack_identity_public_endpoint  = credentials[:identity_public_endpoint]
+            @management_url = credentials[:server_management_url]
+            @identity_public_endpoint  = credentials[:identity_public_endpoint]
           end
 
-          uri = URI.parse(@openstack_management_url)
+          uri = URI.parse(@management_url)
           @host   = uri.host
           @path, @tenant_id = uri.path.scan(/(\/.*)\/(.*)/).flatten
 
@@ -421,9 +444,9 @@ module Fog
           @scheme = uri.scheme
 
           # Not all implementations have identity service in the catalog
-          if @openstack_identity_public_endpoint || @openstack_management_url
+          if @identity_public_endpoint || @management_url
             @identity_connection = Fog::Core::Connection.new(
-              @openstack_identity_public_endpoint || @openstack_management_url,
+              @identity_public_endpoint || @management_url,
               false, @connection_options)
           end
 

--- a/lib/fog/openstack/docs/compute.md
+++ b/lib/fog/openstack/docs/compute.md
@@ -17,15 +17,15 @@ Once `irb` has launched you need to require the Fog library by executing:
 Next, create a connection to the Compute Service:
 
 	service = Fog::Compute.new({
-		:provider            => 'openstack',                                      # OpenStack Fog provider
-		:openstack_auth_url  => 'http://KEYSTONE_HOST:KEYSTONE_PORT/v2.0/tokens', # OpenStack Keystone endpoint
-		:openstack_username  => OPEN_STACK_USER,                                  # Your OpenStack Username
-		:openstack_tenant    => OPEN_STACK_TENANT,                                # Your tenant id
-		:openstack_api_key   => OPEN_STACK_PASSWORD,                              # Your OpenStack Password
+		:provider  => 'openstack',                                      # OpenStack Fog provider
+		:auth_url  => 'http://KEYSTONE_HOST:KEYSTONE_PORT/v2.0/tokens', # OpenStack Keystone endpoint
+		:username  => OPEN_STACK_USER,                                  # Your OpenStack Username
+		:tenant    => OPEN_STACK_TENANT,                                # Your tenant id
+		:api_key   => OPEN_STACK_PASSWORD,                              # Your OpenStack Password
 		:connection_options  => {}                                                # Optional
 	})
 
-**Note** `openstack_username` and `openstack_tenant` default to `admin` if omitted.
+**Note** `username` and `tenant` default to `admin` if omitted.
 
 ### Optional Connection Parameters
 

--- a/lib/fog/openstack/docs/storage.md
+++ b/lib/fog/openstack/docs/storage.md
@@ -30,14 +30,14 @@ Next, create a connection to Swift:
 
 ```ruby
 service = Fog::Storage.new({
-  :provider            => 'OpenStack',   # OpenStack Fog provider
-  :openstack_username  => USERNAME,      # Your OpenStack Username
-  :openstack_api_key   => PASSWORD,      # Your OpenStack Password
-  :openstack_auth_url  => 'http://YOUR_OPENSTACK_ENDPOINT:PORT/v2.0/tokens'
+  :provider  => 'OpenStack',   # OpenStack Fog provider
+  :username  => USERNAME,      # Your OpenStack Username
+  :api_key   => PASSWORD,      # Your OpenStack Password
+  :auth_url  => 'http://YOUR_ENDPOINT:PORT/v2.0/tokens'
 })
 ```
 
-Alternative regions are specified using the key `:openstack_region `. A list of regions available for Swift can be found by executing the following:
+Alternative regions are specified using the key `:region `. A list of regions available for Swift can be found by executing the following:
 
 ### Optional Service Parameters
 
@@ -53,23 +53,23 @@ The Storage service supports the following additional parameters:
 <td>If set to true, the service will use a persistent connection.</td>
 </tr>
 <tr>
-<td>:openstack_service_name</td>
+<td>:service_name</td>
 <td></td>
 </tr>
 <tr>
-<td>:openstack_service_type</td>
+<td>:service_type</td>
 <td></td>
 </tr>
 <tr>
-<td>:openstack_tenant</td>
+<td>:tenant</td>
 <td></td>
 </tr>
 <tr>
-<td>:openstack_region</td>
+<td>:region</td>
 <td></td>
 </tr>
 <tr>
-<td>:openstack_temp_url_key</td>
+<td>:temp_url_key</td>
 <td></td>
 </tr>
 </table>

--- a/lib/fog/openstack/examples/compute/basics.rb
+++ b/lib/fog/openstack/examples/compute/basics.rb
@@ -8,10 +8,10 @@ password = 'secret'
 tenant   = 'My Compute Tenant' # String
 
 compute_client ||= ::Fog::Compute.new(:provider           => :openstack,
-                                      :openstack_api_key  => password  ,
-                                      :openstack_username => username  ,
-                                      :openstack_auth_url => auth_url  ,
-                                      :openstack_tenant   => tenant)
+                                      :api_key  => password  ,
+                                      :username => username  ,
+                                      :auth_url => auth_url  ,
+                                      :tenant   => tenant)
 
 # Create VM
 # Options include metadata, availability zone, etc...

--- a/lib/fog/openstack/examples/identity/basics.rb
+++ b/lib/fog/openstack/examples/identity/basics.rb
@@ -8,9 +8,9 @@ username = 'admin@example.net'
 password = 'secret'
 
 keystone = Fog::Identity.new :provider           => 'OpenStack',
-                             :openstack_auth_url => auth_url,
-                             :openstack_username => username,
-                             :openstack_api_key  => password
+                             :auth_url => auth_url,
+                             :username => username,
+                             :api_key  => password
                              # Optional, self-signed certs
                              #:connection_options => { :ssl_verify_peer => false }
 

--- a/lib/fog/openstack/examples/image/upload-test-image.rb
+++ b/lib/fog/openstack/examples/image/upload-test-image.rb
@@ -45,10 +45,10 @@ end
 
 image_service = Fog::Image.new({
   :provider => 'OpenStack',
-  :openstack_api_key => ENV['OS_PASSWORD'],
-  :openstack_username => ENV["OS_USERNAME"],
-  :openstack_auth_url => ENV["OS_AUTH_URL"] + "/tokens",
-  :openstack_tenant => ENV["OS_TENANT_NAME"]
+  :api_key => ENV['OS_PASSWORD'],
+  :username => ENV["OS_USERNAME"],
+  :auth_url => ENV["OS_AUTH_URL"] + "/tokens",
+  :tenant => ENV["OS_TENANT_NAME"]
 })
 
 puts "Uploading AKI..."

--- a/lib/fog/openstack/examples/storage/set-account-quota.rb
+++ b/lib/fog/openstack/examples/storage/set-account-quota.rb
@@ -29,17 +29,17 @@ Excon.defaults[:ssl_verify_peer] = false
 # the tenant we want to set the quotas for.
 #
 id = Fog::Identity.new :provider => 'OpenStack',
-                       :openstack_auth_url => auth_url,
-                       :openstack_username => user,
-                       :openstack_api_key  => password
+                       :auth_url => auth_url,
+                       :username => user,
+                       :api_key  => password
 
 #
 # Storage service (Swift)
 #
 st = Fog::Storage.new :provider => 'OpenStack',
-                      :openstack_auth_url => auth_url,
-                      :openstack_username => user,
-                      :openstack_api_key  => password
+                      :auth_url => auth_url,
+                      :username => user,
+                      :api_key  => password
 
 id.tenants.each do |t|
   # We want to set the account quota for tenant demo@test.lan

--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -5,11 +5,20 @@ module Fog
     class OpenStack < Fog::Service
       SUPPORTED_VERSIONS = /v1(\.(0|1))*/
 
+      # the openstack_* params are all deprecated. remove the
+      # 'openstack_' part of the string from your config parameter names.
       requires :openstack_auth_url
+      recognizes :auth_url
+
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username,
                  :current_user, :current_tenant, :openstack_endpoint_type, :openstack_region
+
+      recognizes :auth_token, :management_url, :persistent,
+                 :service_type, :service_name, :tenant,
+                 :api_key, :username,
+                 :current_user, :current_tenant, :endpoint_type, :region
 
       model_path 'fog/openstack/models/image'
 
@@ -46,25 +55,33 @@ module Fog
         end
 
         def initialize(options={})
-          @openstack_username = options[:openstack_username]
-          @openstack_tenant   = options[:openstack_tenant]
-          @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
+
+          @username = options[:username]
+          @tenant   = options[:tenant]
+          @auth_uri = URI.parse(options[:auth_url])
 
           @auth_token = Fog::Mock.random_base64(64)
           @auth_token_expiration = (Time.now.utc + 86400).iso8601
 
-          management_url = URI.parse(options[:openstack_auth_url])
+          management_url = URI.parse(options[:auth_url])
           management_url.port = 9292
           management_url.path = '/v1'
-          @openstack_management_url = management_url.to_s
+          @management_url = management_url.to_s
 
           @data ||= { :users => {} }
-          unless @data[:users].find {|u| u['name'] == options[:openstack_username]}
+          unless @data[:users].find {|u| u['name'] == options[:username]}
             id = Fog::Mock.random_numbers(6).to_s
             @data[:users][id] = {
               'id'       => id,
-              'name'     => options[:openstack_username],
-              'email'    => "#{options[:openstack_username]}@mock.com",
+              'name'     => options[:username],
+              'email'    => "#{options[:username]}@mock.com",
               'tenantId' => Fog::Mock.random_numbers(6).to_s,
               'enabled'  => true
             }
@@ -72,19 +89,19 @@ module Fog
         end
 
         def data
-          self.class.data[@openstack_username]
+          self.class.data[@username]
         end
 
         def reset_data
-          self.class.data.delete(@openstack_username)
+          self.class.data.delete(@username)
         end
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_region         => @openstack_region,
-            :openstack_management_url => @openstack_management_url }
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :region         => @region,
+            :management_url => @management_url }
         end
       end
 
@@ -93,26 +110,34 @@ module Fog
         attr_reader :current_tenant
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
 
-          unless @openstack_auth_token
+          @auth_token = options[:auth_token]
+
+          unless @auth_token
             missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+            @api_key  = options[:api_key]
+            @username = options[:username]
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
+            missing_credentials << :api_key  unless @api_key
+            missing_credentials << :username unless @username
             raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
           end
 
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['image']
-          @openstack_service_name         = options[:openstack_service_name]
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
-          @openstack_region               = options[:openstack_region]
+          @tenant               = options[:tenant]
+          @auth_uri             = URI.parse(options[:auth_url])
+          @management_url       = options[:management_url]
+          @must_reauthenticate  = false
+          @service_type         = options[:service_type] || ['image']
+          @service_name         = options[:service_name]
+          @endpoint_type        = options[:endpoint_type] || 'adminURL'
+          @region               = options[:region]
 
           @connection_options = options[:connection_options] || {}
 
@@ -127,9 +152,9 @@ module Fog
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
+            :auth_url                 => @auth_uri.to_s,
+            :auth_token               => @auth_token,
+            :management_url           => @management_url,
             :current_user             => @current_user,
             :current_tenant           => @current_tenant }
         end
@@ -149,7 +174,7 @@ module Fog
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration
-              @openstack_must_reauthenticate = true
+              @must_reauthenticate = true
               authenticate
               retry
             else # bad credentials
@@ -172,17 +197,17 @@ module Fog
         private
 
         def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
+          if !@management_url || @must_reauthenticate
             options = {
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_region   => @openstack_region,
-              :openstack_auth_token => @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
+              :tenant   => @tenant,
+              :api_key  => @api_key,
+              :username => @username,
+              :auth_uri => @auth_uri,
+              :region   => @region,
+              :auth_token => @auth_token,
+              :service_type => @service_type,
+              :service_name => @service_name,
+              :endpoint_type => @endpoint_type
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)
@@ -190,13 +215,13 @@ module Fog
             @current_user = credentials[:user]
             @current_tenant = credentials[:tenant]
 
-            @openstack_must_reauthenticate = false
+            @must_reauthenticate = false
             @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
+            @management_url = credentials[:server_management_url]
+            uri = URI.parse(@management_url)
           else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
+            @auth_token = @auth_token
+            uri = URI.parse(@management_url)
           end
 
           @host   = uri.host

--- a/lib/fog/openstack/metering.rb
+++ b/lib/fog/openstack/metering.rb
@@ -3,12 +3,22 @@ require 'fog/openstack/core'
 module Fog
   module Metering
     class OpenStack < Fog::Service
+      # the openstack_* params are all deprecated. remove the
+      # 'openstack_' part of the string from your config parameter names.
       requires :openstack_auth_url
+      recognizes :auth_url
+
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username,
                  :current_user, :current_tenant,
                  :openstack_endpoint_type
+
+      recognizes :auth_token, :management_url, :persistent,
+                 :service_type, :service_name, :tenant,
+                 :api_key, :username,
+                 :current_user, :current_tenant,
+                 :endpoint_type
 
       model_path 'fog/openstack/models/metering'
 
@@ -39,25 +49,33 @@ module Fog
         end
 
         def initialize(options={})
-          @openstack_username = options[:openstack_username]
-          @openstack_tenant   = options[:openstack_tenant]
-          @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
+
+          @username = options[:username]
+          @tenant   = options[:tenant]
+          @auth_uri = URI.parse(options[:auth_url])
 
           @auth_token = Fog::Mock.random_base64(64)
           @auth_token_expiration = (Time.now.utc + 86400).iso8601
 
-          management_url = URI.parse(options[:openstack_auth_url])
+          management_url = URI.parse(options[:auth_url])
           management_url.port = 8776
           management_url.path = '/v1'
-          @openstack_management_url = management_url.to_s
+          @management_url = management_url.to_s
 
           @data ||= { :users => {} }
-          unless @data[:users].find {|u| u['name'] == options[:openstack_username]}
+          unless @data[:users].find {|u| u['name'] == options[:username]}
             id = Fog::Mock.random_numbers(6).to_s
             @data[:users][id] = {
               'id'       => id,
-              'name'     => options[:openstack_username],
-              'email'    => "#{options[:openstack_username]}@mock.com",
+              'name'     => options[:username],
+              'email'    => "#{options[:username]}@mock.com",
               'tenantId' => Fog::Mock.random_numbers(6).to_s,
               'enabled'  => true
             }
@@ -65,18 +83,18 @@ module Fog
         end
 
         def data
-          self.class.data[@openstack_username]
+          self.class.data[@username]
         end
 
         def reset_data
-          self.class.data.delete(@openstack_username)
+          self.class.data.delete(@username)
         end
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url }
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url }
         end
       end
 
@@ -85,26 +103,34 @@ module Fog
         attr_reader :current_tenant
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
 
-          unless @openstack_auth_token
+          @auth_token = options[:auth_token]
+
+          unless @auth_token
             missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+            @api_key  = options[:api_key]
+            @username = options[:username]
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
+            missing_credentials << :api_key  unless @api_key
+            missing_credentials << :username unless @username
             raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
           end
 
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['metering']
-          @openstack_service_name         = options[:openstack_service_name]
+          @tenant               = options[:tenant]
+          @auth_uri             = URI.parse(options[:auth_url])
+          @management_url       = options[:management_url]
+          @must_reauthenticate  = false
+          @service_type         = options[:service_type] || ['metering']
+          @service_name         = options[:service_name]
 
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
+          @endpoint_type        = options[:endpoint_type] || 'adminURL'
           @connection_options = options[:connection_options] || {}
 
           @current_user = options[:current_user]
@@ -118,9 +144,9 @@ module Fog
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url,
             :current_user             => @current_user,
             :current_tenant           => @current_tenant }
         end
@@ -143,7 +169,7 @@ module Fog
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration
-              @openstack_must_reauthenticate = true
+              @must_reauthenticate = true
               authenticate
               retry
             else # bad credentials
@@ -166,16 +192,16 @@ module Fog
         private
 
         def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
+          if !@management_url || @must_reauthenticate
             options = {
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
+              :tenant   => @tenant,
+              :api_key  => @api_key,
+              :username => @username,
+              :auth_uri => @auth_uri,
+              :auth_token => @auth_token,
+              :service_type => @service_type,
+              :service_name => @service_name,
+              :endpoint_type => @endpoint_type
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)
@@ -183,13 +209,13 @@ module Fog
             @current_user = credentials[:user]
             @current_tenant = credentials[:tenant]
 
-            @openstack_must_reauthenticate = false
+            @must_reauthenticate = false
             @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
+            @management_url = credentials[:server_management_url]
+            uri = URI.parse(@management_url)
           else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
+            @auth_token = @auth_token
+            uri = URI.parse(@management_url)
           end
 
           @host   = uri.host

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -5,11 +5,20 @@ module Fog
     class OpenStack < Fog::Service
       SUPPORTED_VERSIONS = /v2(\.0)*/
 
+      # the openstack_* params are all deprecated. remove the
+      # 'openstack_' part of the string from your config parameter names.
       requires :openstack_auth_url
+      recognizes :auth_url
+
       recognizes :openstack_auth_token, :openstack_management_url, :persistent,
                  :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_endpoint_type,
                  :current_user, :current_tenant, :openstack_region
+
+      recognizes :auth_token, :management_url, :persistent,
+                 :service_type, :service_name, :tenant,
+                 :api_key, :username, :endpoint_type,
+                 :current_user, :current_tenant, :region
 
       ## MODELS
       #
@@ -202,23 +211,31 @@ module Fog
         end
 
         def initialize(options={})
-          @openstack_username = options[:openstack_username]
-          @openstack_tenant   = options[:openstack_tenant]
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
+
+          @username = options[:username]
+          @tenant   = options[:tenant]
         end
 
         def data
-          self.class.data["#{@openstack_username}-#{@openstack_tenant}"]
+          self.class.data["#{@username}-#{@tenant}"]
         end
 
         def reset_data
-          self.class.data.delete("#{@openstack_username}-#{@openstack_tenant}")
+          self.class.data.delete("#{@username}-#{@tenant}")
         end
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url }
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url }
         end
       end
 
@@ -227,26 +244,34 @@ module Fog
         attr_reader :current_tenant
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
 
-          unless @openstack_auth_token
+          @auth_token = options[:auth_token]
+
+          unless @auth_token
             missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+            @api_key  = options[:api_key]
+            @username = options[:username]
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
+            missing_credentials << :api_key  unless @api_key
+            missing_credentials << :username unless @username
             raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
           end
 
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['network']
-          @openstack_service_name         = options[:openstack_service_name]
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'publicURL'
-          @openstack_region               = options[:openstack_region]
+          @tenant               = options[:tenant]
+          @auth_uri             = URI.parse(options[:auth_url])
+          @management_url       = options[:management_url]
+          @must_reauthenticate  = false
+          @service_type         = options[:service_type] || ['network']
+          @service_name         = options[:service_name]
+          @endpoint_type        = options[:endpoint_type] || 'publicURL'
+          @region               = options[:region]
 
           @connection_options = options[:connection_options] || {}
 
@@ -261,12 +286,12 @@ module Fog
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url,
             :current_user             => @current_user,
             :current_tenant           => @current_tenant,
-            :openstack_region         => @openstack_region }
+            :region         => @region }
         end
 
         def reload
@@ -285,7 +310,7 @@ module Fog
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration
-              @openstack_must_reauthenticate = true
+              @must_reauthenticate = true
               authenticate
               retry
             else # bad credentials
@@ -308,17 +333,17 @@ module Fog
         private
 
         def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
+          if !@management_url || @must_reauthenticate
             options = {
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type,
-              :openstack_region => @openstack_region
+              :tenant   => @tenant,
+              :api_key  => @api_key,
+              :username => @username,
+              :auth_uri => @auth_uri,
+              :auth_token => @auth_token,
+              :service_type => @service_type,
+              :service_name => @service_name,
+              :endpoint_type => @endpoint_type,
+              :region => @region
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)
@@ -326,13 +351,13 @@ module Fog
             @current_user = credentials[:user]
             @current_tenant = credentials[:tenant]
 
-            @openstack_must_reauthenticate = false
+            @must_reauthenticate = false
             @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
+            @management_url = credentials[:server_management_url]
+            uri = URI.parse(@management_url)
           else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
+            @auth_token = @auth_token
+            uri = URI.parse(@management_url)
           end
 
           @host   = uri.host

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -3,13 +3,24 @@ require 'fog/openstack/core'
 module Fog
   module Orchestration
     class OpenStack < Fog::Service
+      # the openstack_* params are all deprecated. remove the
+      # 'openstack_' part of the string from your config parameter names.
       requires :openstack_auth_url
+      recognizes :auth_url
+
       recognizes :openstack_auth_token, :openstack_management_url,
                  :persistent, :openstack_service_type, :openstack_service_name,
                  :openstack_tenant,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region,
                  :openstack_endpoint_type
+
+      recognizes :auth_token, :management_url,
+                 :persistent, :service_type, :service_name,
+                 :tenant,
+                 :api_key, :username, :identity_endpoint,
+                 :current_user, :current_tenant, :region,
+                 :endpoint_type
 
       model_path 'fog/openstack/models/orchestration'
       model       :stack
@@ -40,38 +51,46 @@ module Fog
         end
 
         def initialize(options={})
-          @openstack_username = options[:openstack_username]
-          @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
 
-          @current_tenant = options[:openstack_tenant]
+          @username = options[:username]
+          @auth_uri = URI.parse(options[:auth_url])
+
+          @current_tenant = options[:tenant]
 
           @auth_token = Fog::Mock.random_base64(64)
           @auth_token_expiration = (Time.now.utc + 86400).iso8601
 
-          management_url = URI.parse(options[:openstack_auth_url])
+          management_url = URI.parse(options[:auth_url])
           management_url.port = 8774
           management_url.path = '/v1'
-          @openstack_management_url = management_url.to_s
+          @management_url = management_url.to_s
 
-          identity_public_endpoint = URI.parse(options[:openstack_auth_url])
+          identity_public_endpoint = URI.parse(options[:auth_url])
           identity_public_endpoint.port = 5000
-          @openstack_identity_public_endpoint = identity_public_endpoint.to_s
+          @identity_public_endpoint = identity_public_endpoint.to_s
         end
 
         def data
-          self.class.data["#{@openstack_username}-#{@current_tenant}"]
+          self.class.data["#{@username}-#{@current_tenant}"]
         end
 
         def reset_data
-          self.class.data.delete("#{@openstack_username}-#{@current_tenant}")
+          self.class.data.delete("#{@username}-#{@current_tenant}")
         end
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :openstack_identity_endpoint => @openstack_identity_public_endpoint }
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url,
+            :identity_endpoint => @identity_public_endpoint }
         end
       end
 
@@ -82,29 +101,36 @@ module Fog
         attr_reader :current_tenant
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
-          @auth_token        = options[:openstack_auth_token]
-          @openstack_identity_public_endpoint = options[:openstack_identity_endpoint]
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
+
+          @auth_token = options[:auth_token]
+          @identity_public_endpoint = options[:identity_endpoint]
 
           unless @auth_token
             missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+            @api_key  = options[:api_key]
+            @username = options[:username]
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
+            missing_credentials << :api_key  unless @api_key
+            missing_credentials << :username unless @username
             raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
           end
 
-          @openstack_tenant     = options[:openstack_tenant]
-          @openstack_auth_uri   = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type = options[:openstack_service_type] || ['orchestration']
-          @openstack_service_name = options[:openstack_service_name]
-          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
-          @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
-          @openstack_region      = options[:openstack_region]
+          @tenant     = options[:tenant]
+          @auth_uri   = URI.parse(options[:auth_url])
+          @management_url       = options[:management_url]
+          @must_reauthenticate  = false
+          @service_type = options[:service_type] || ['orchestration']
+          @service_name = options[:service_name]
+          @identity_service_type = options[:identity_service_type] || 'identity'
+          @endpoint_type = options[:endpoint_type] || 'publicURL'
+          @region      = options[:region]
 
           @connection_options = options[:connection_options] || {}
 
@@ -119,11 +145,11 @@ module Fog
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :openstack_identity_endpoint => @openstack_identity_public_endpoint,
-            :openstack_region         => @openstack_region,
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url,
+            :identity_endpoint => @identity_public_endpoint,
+            :region         => @region,
             :current_user             => @current_user,
             :current_tenant           => @current_tenant }
         end
@@ -139,15 +165,15 @@ module Fog
                 'Content-Type' => 'application/json',
                 'Accept' => 'application/json',
                 'X-Auth-Token' => @auth_token,
-                'X-Auth-User'  => @openstack_username,
-                'X-Auth-Key'   => @openstack_api_key
+                'X-Auth-User'  => @username,
+                'X-Auth-Key'   => @api_key
               }.merge!(params[:headers] || {}),
               :path     => "#{@path}/#{@tenant_id}/#{params[:path]}",
               :query    => params[:query]
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration
-              @openstack_must_reauthenticate = true
+              @must_reauthenticate = true
               authenticate
               retry
             else # Bad Credentials
@@ -172,21 +198,21 @@ module Fog
         private
 
         def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
+          if !@management_url || @must_reauthenticate
             options = {
-              :openstack_api_key    => @openstack_api_key,
-              :openstack_username   => @openstack_username,
-              :openstack_auth_token => @auth_token,
-              :openstack_auth_uri   => @openstack_auth_uri,
-              :openstack_region     => @openstack_region,
-              :openstack_tenant     => @openstack_tenant,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_identity_service_type => @openstack_identity_service_type,
-              :openstack_endpoint_type => @openstack_endpoint_type
+              :api_key    => @api_key,
+              :username   => @username,
+              :auth_token => @auth_token,
+              :auth_uri   => @auth_uri,
+              :region     => @region,
+              :tenant     => @tenant,
+              :service_type => @service_type,
+              :service_name => @service_name,
+              :identity_service_type => @identity_service_type,
+              :endpoint_type => @endpoint_type
             }
 
-            if @openstack_auth_uri.path =~ /\/v2.0\//
+            if @auth_uri.path =~ /\/v2.0\//
 
               credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)
             else
@@ -196,14 +222,14 @@ module Fog
             @current_user = credentials[:user]
             @current_tenant = credentials[:tenant]
 
-            @openstack_must_reauthenticate = false
+            @must_reauthenticate = false
             @auth_token               = credentials[:token]
             @auth_token_expiration    = credentials[:expires]
-            @openstack_management_url = credentials[:server_management_url]
-            @openstack_identity_public_endpoint  = credentials[:identity_public_endpoint]
+            @management_url = credentials[:server_management_url]
+            @identity_public_endpoint  = credentials[:identity_public_endpoint]
           end
 
-          uri = URI.parse(@openstack_management_url)
+          uri = URI.parse(@management_url)
           @host   = uri.host
           @path, @tenant_id = uri.path.scan(/(\/.*)\/(.*)/).flatten
 
@@ -213,9 +239,9 @@ module Fog
           @scheme = uri.scheme
 
           # Not all implementations have identity service in the catalog
-          if @openstack_identity_public_endpoint || @openstack_management_url
+          if @identity_public_endpoint || @management_url
             @identity_connection = Fog::Core::Connection.new(
-              @openstack_identity_public_endpoint || @openstack_management_url,
+              @identity_public_endpoint || @management_url,
               false, @connection_options)
           end
 

--- a/lib/fog/openstack/requests/compute/create_security_group.rb
+++ b/lib/fog/openstack/requests/compute/create_security_group.rb
@@ -21,7 +21,7 @@ module Fog
 
       class Mock
         def create_security_group(name, description)
-          Fog::Identity::OpenStack.new(:openstack_auth_url => credentials[:openstack_auth_url])
+          Fog::Identity::OpenStack.new(:auth_url => credentials[:auth_url])
           tenant_id = Fog::Identity::OpenStack::Mock.data[current_tenant][:tenants].keys.first
           security_group_id = Fog::Mock.random_numbers(2).to_i
           self.data[:security_groups][security_group_id.to_s] = {

--- a/lib/fog/openstack/requests/compute/create_server.rb
+++ b/lib/fog/openstack/requests/compute/create_server.rb
@@ -90,17 +90,17 @@ module Fog
           response.status = 202
 
           server_id = Fog::Mock.random_numbers(6).to_s
-          identity = Fog::Identity::OpenStack.new :openstack_auth_url => credentials[:openstack_auth_url]
+          identity = Fog::Identity::OpenStack.new :auth_url => credentials[:auth_url]
           user = identity.users.find { |u|
-            u.name == @openstack_username
+            u.name == @username
           }
 
           user_id = if user then
                       user.id
                     else
-                       response = identity.create_user(@openstack_username,
+                       response = identity.create_user(@username,
                          'password',
-                         "#{@openstack_username}@example.com")
+                         "#{@username}@example.com")
                        response.body["user"]["id"]
                     end
 
@@ -119,7 +119,7 @@ module Fog
             'status'       => 'BUILD',
             'created'      => '2012-09-27T00:04:18Z',
             'updated'      => '2012-09-27T00:04:27Z',
-            'user_id'      => @openstack_username,
+            'user_id'      => @username,
             'config_drive' => options['config_drive'] || '',
           }
 

--- a/lib/fog/openstack/requests/compute/set_tenant.rb
+++ b/lib/fog/openstack/requests/compute/set_tenant.rb
@@ -3,8 +3,8 @@ module Fog
     class OpenStack
       class Real
         def set_tenant(tenant)
-          @openstack_must_reauthenticate = true
-          @openstack_tenant = tenant.to_s
+          @must_reauthenticate = true
+          @tenant = tenant.to_s
           authenticate
         end
       end

--- a/lib/fog/openstack/requests/identity/set_tenant.rb
+++ b/lib/fog/openstack/requests/identity/set_tenant.rb
@@ -3,8 +3,8 @@ module Fog
     class OpenStack
       class Real
         def set_tenant(tenant)
-          @openstack_must_reauthenticate = true
-          @openstack_tenant = tenant.to_s
+          @must_reauthenticate = true
+          @tenant = tenant.to_s
           authenticate
         end
       end

--- a/lib/fog/openstack/requests/image/set_tenant.rb
+++ b/lib/fog/openstack/requests/image/set_tenant.rb
@@ -3,8 +3,8 @@ module Fog
     class OpenStack
       class Real
         def set_tenant(tenant)
-          @openstack_must_reauthenticate = true
-          @openstack_tenant = tenant.to_s
+          @must_reauthenticate = true
+          @tenant = tenant.to_s
           authenticate
         end
       end

--- a/lib/fog/openstack/requests/network/set_tenant.rb
+++ b/lib/fog/openstack/requests/network/set_tenant.rb
@@ -3,8 +3,8 @@ module Fog
     class OpenStack
       class Real
         def set_tenant(tenant)
-          @openstack_must_reauthenticate = true
-          @openstack_tenant = tenant.to_s
+          @must_reauthenticate = true
+          @tenant = tenant.to_s
           authenticate
         end
       end

--- a/lib/fog/openstack/requests/storage/get_object_https_url.rb
+++ b/lib/fog/openstack/requests/storage/get_object_https_url.rb
@@ -34,7 +34,7 @@ module Fog
         # http://docs.rackspace.com/files/api/v1/cf-devguide/content/Create_TempURL-d1a444.html
         def create_temp_url(container, object, expires, method, options = {})
           raise ArgumentError, "Insufficient parameters specified." unless (container && object && expires && method)
-          raise ArgumentError, "Storage must be instantiated with the :openstack_temp_url_key option" if @openstack_temp_url_key.nil?
+          raise ArgumentError, "Storage must be instantiated with the :temp_url_key option" if @temp_url_key.nil?
 
           scheme = options[:scheme] || @scheme
 
@@ -49,7 +49,7 @@ module Fog
           object_path_unescaped = "#{@path}/#{Fog::OpenStack.escape(container)}/#{object}"
           string_to_sign = "#{method}\n#{expires}\n#{object_path_unescaped}"
 
-          hmac = Fog::HMAC.new('sha1', @openstack_temp_url_key)
+          hmac = Fog::HMAC.new('sha1', @temp_url_key)
           sig  = sig_to_hex(hmac.sign(string_to_sign))
 
           temp_url_options = {

--- a/lib/fog/openstack/requests/storage/post_set_meta_temp_url_key.rb
+++ b/lib/fog/openstack/requests/storage/post_set_meta_temp_url_key.rb
@@ -6,7 +6,7 @@ module Fog
         # used to generate signed expiring URLs.
         #
         # Once the key has been set with this request you should create new
-        # Storage objects with the :openstack_temp_url_key option then use
+        # Storage objects with the :temp_url_key option then use
         # the get_object_https_url method to generate expiring URLs.
         #
         # *** CAUTION *** changing this secret key will invalidate any expiring

--- a/lib/fog/openstack/requests/volume/set_tenant.rb
+++ b/lib/fog/openstack/requests/volume/set_tenant.rb
@@ -3,8 +3,8 @@ module Fog
     class OpenStack
       class Real
         def set_tenant(tenant)
-          @openstack_must_reauthenticate = true
-          @openstack_tenant = tenant.to_s
+          @must_reauthenticate = true
+          @tenant = tenant.to_s
           authenticate
         end
       end

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -3,12 +3,21 @@ require 'fog/openstack/core'
 module Fog
   module Volume
     class OpenStack < Fog::Service
+      # the openstack_* params are all deprecated. remove the
+      # 'openstack_' part of the string from your config parameter names.
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
+      recognizes :auth_url
+
+      recognizes :openstack_auth_token, :openstack_management_url,
                  :openstack_service_type, :openstack_service_name, :openstack_tenant,
                  :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant,
                  :openstack_endpoint_type, :openstack_region
+
+      recognizes :auth_token, :management_url, :persistent,
+                 :service_type, :service_name, :tenant,
+                 :api_key, :username,
+                 :current_user, :current_tenant,
+                 :endpoint_type, :region
 
       model_path 'fog/openstack/models/volume'
 
@@ -60,25 +69,33 @@ module Fog
         end
 
         def initialize(options={})
-          @openstack_username = options[:openstack_username]
-          @openstack_tenant   = options[:openstack_tenant]
-          @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
+
+          @username = options[:username]
+          @tenant   = options[:tenant]
+          @auth_uri = URI.parse(options[:auth_url])
 
           @auth_token = Fog::Mock.random_base64(64)
           @auth_token_expiration = (Time.now.utc + 86400).iso8601
 
-          management_url = URI.parse(options[:openstack_auth_url])
+          management_url = URI.parse(options[:auth_url])
           management_url.port = 8776
           management_url.path = '/v1'
-          @openstack_management_url = management_url.to_s
+          @management_url = management_url.to_s
 
           @data ||= { :users => {} }
-          unless @data[:users].find {|u| u['name'] == options[:openstack_username]}
+          unless @data[:users].find {|u| u['name'] == options[:username]}
             id = Fog::Mock.random_numbers(6).to_s
             @data[:users][id] = {
               'id'       => id,
-              'name'     => options[:openstack_username],
-              'email'    => "#{options[:openstack_username]}@mock.com",
+              'name'     => options[:username],
+              'email'    => "#{options[:username]}@mock.com",
               'tenantId' => Fog::Mock.random_numbers(6).to_s,
               'enabled'  => true
             }
@@ -86,18 +103,18 @@ module Fog
         end
 
         def data
-          self.class.data[@openstack_username]
+          self.class.data[@username]
         end
 
         def reset_data
-          self.class.data.delete(@openstack_username)
+          self.class.data.delete(@username)
         end
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url }
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url }
         end
       end
 
@@ -106,27 +123,35 @@ module Fog
         attr_reader :current_tenant
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          # deprecate namespaced params
+          options.each { |k,v|
+            if k =~ /^openstack_/
+              Fog::Logger.deprecation(":#{k} is deprecated, please use :#{k.to_s.gsub('openstack_','')} instead.")
+            end
+          }
+          options = Hash[options.map { |k, v| [k.to_s.gsub('openstack_','').to_sym, v] }]
 
-          unless @openstack_auth_token
+          @auth_token = options[:auth_token]
+
+          unless @auth_token
             missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+            @api_key  = options[:api_key]
+            @username = options[:username]
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
+            missing_credentials << :api_key  unless @api_key
+            missing_credentials << :username unless @username
             raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
           end
 
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['volume']
-          @openstack_service_name         = options[:openstack_service_name]
-          @openstack_region               = options[:openstack_region]
+          @tenant               = options[:tenant]
+          @auth_uri             = URI.parse(options[:auth_url])
+          @management_url       = options[:management_url]
+          @must_reauthenticate  = false
+          @service_type         = options[:service_type] || ['volume']
+          @service_name         = options[:service_name]
+          @region               = options[:region]
 
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
+          @endpoint_type        = options[:endpoint_type] || 'adminURL'
           @connection_options = options[:connection_options] || {}
 
           @current_user = options[:current_user]
@@ -140,9 +165,9 @@ module Fog
 
         def credentials
           { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
+            :auth_url       => @auth_uri.to_s,
+            :auth_token     => @auth_token,
+            :management_url => @management_url,
             :current_user             => @current_user,
             :current_tenant           => @current_tenant }
         end
@@ -163,7 +188,7 @@ module Fog
             }))
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration
-              @openstack_must_reauthenticate = true
+              @must_reauthenticate = true
               authenticate
               retry
             else # bad credentials
@@ -186,17 +211,17 @@ module Fog
         private
 
         def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
+          if !@management_url || @must_reauthenticate
             options = {
-              :openstack_region   => @openstack_region,
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
+              :region   => @region,
+              :tenant   => @tenant,
+              :api_key  => @api_key,
+              :username => @username,
+              :auth_uri => @auth_uri,
+              :auth_token => @auth_token,
+              :service_type => @service_type,
+              :service_name => @service_name,
+              :endpoint_type => @endpoint_type
             }
 
             credentials = Fog::OpenStack.authenticate_v2(options, @connection_options)
@@ -204,13 +229,13 @@ module Fog
             @current_user = credentials[:user]
             @current_tenant = credentials[:tenant]
 
-            @openstack_must_reauthenticate = false
+            @must_reauthenticate = false
             @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
+            @management_url = credentials[:server_management_url]
+            uri = URI.parse(@management_url)
           else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
+            @auth_token = @auth_token
+            uri = URI.parse(@management_url)
           end
 
           @host   = uri.host


### PR DESCRIPTION
This normalizes all of the class options for the openstack provider by removing the prepended "openstack_" string to all config parameters.

When developing tooling for a multi-cloud environment (e.g. openstack and aws), the goal should be to abstract away differences between cloud providers. This is not possible when each fog provider has chosen to add provider-specific nomenclature to their configuration parameters.

When I specify "region", it should be implied that it means "region" in whatever provider I've instantiated. I shouldn't have to add complexity to my code to say "In the AWS case, the param is called "region", but in the OpenStack case, it's called "openstack_region".

This pull request is aimed at fixing this issue.