### PR TITLE
[RACKSPACE] allow userdata to be passed to Rackspace AutoScale

### DIFF
--- a/lib/fog/rackspace/models/auto_scale/group_builder.rb
+++ b/lib/fog/rackspace/models/auto_scale/group_builder.rb
@@ -60,6 +60,8 @@ module Fog
             }
 
             server_template["personality"] = attributes[:personality] if attributes[:personality]
+            server_template["user_data"] = [attributes[:user_data]].pack('m') if attributes[:user_data]
+            server_template["config_drive"] = 'true' if attributes[:config_drive]
             server_template["networks"] = networks_to_hash(attributes[:networks]) if attributes[:networks]
             server_template
           end


### PR DESCRIPTION
Hi,
this passes through the options to create a config-drive and upload user-data to it. It makes me rather sad that we might end up copying all of the attributes of the v2 node creation into the auto scale launch config, but I can't see a more appropriate approach right now.
