### PR TITLE
[linode|compute] Get number of CPU cores from the API

### DIFF
--- a/lib/fog/linode/models/compute/flavor.rb
+++ b/lib/fog/linode/models/compute/flavor.rb
@@ -9,31 +9,7 @@ module Fog
         attribute :name
         attribute :ram
         attribute :price
-
-        def cores
-          case id
-          when 1
-            1
-          when 2
-          	2
-          when 4
-          	4
-          when 6
-          	6
-          when 7
-          	8
-          when 8
-          	12
-          when 9
-          	16
-          when 10
-          	20
-          when 12
-          	20
-          else
-          	0
-          end
-        end
+        attribute :cores
 
         def bits
           0 # these are determined by images you select not the hardware

--- a/lib/fog/linode/requests/compute/avail_linodeplans.rb
+++ b/lib/fog/linode/requests/compute/avail_linodeplans.rb
@@ -56,6 +56,7 @@ module Fog
           { "PRICE" => 19.95, "RAM" => 512, "XFER" => 200,
             "PLANID" => linodeplan_id, "LABEL" => "Linode #{linodeplan_id}",
             "DISK" => 20,
+            "CORES" => 1,
             "AVAIL" => {
               "3"=>48, "2"=>207, "7"=>161, "6"=>143, "4"=>108, "8"=>60
             }

--- a/tests/linode/requests/compute/linodeplans_tests.rb
+++ b/tests/linode/requests/compute/linodeplans_tests.rb
@@ -15,7 +15,8 @@ Shindo.tests('Fog::Compute[:linode] | linodeplans requests', ['linode']) do
       'PRICE'   => Float,
       'RAM'     => Integer,
       'LABEL'   => String,
-      'XFER'    => Integer
+      'XFER'    => Integer,
+      'CORES'   => Integer
     }]
   })
 


### PR DESCRIPTION
Linode's `avail.linodeplans` API call (https://www.linode.com/api/utility/avail.linodeplans) now returns the number of CPU cores for a given plan; these changes take advantage of that.
