### PR TITLE
S3 invalid signature generation

### DIFF
--- a/lib/fog/aws/signaturev4.rb
+++ b/lib/fog/aws/signaturev4.rb
@@ -31,7 +31,7 @@ DATA
 
         string_to_sign.chop!
 
-        signature = URI.escape(derived_hmac(date).sign(string_to_sign), "+")
+        signature = CGI.escape(derived_hmac(date).sign(string_to_sign))
 
         "AWS4-HMAC-SHA256 Credential=#{@aws_access_key_id}/#{credential_scope}, SignedHeaders=#{signed_headers(params[:headers])}, Signature=#{signature.unpack('H*').first}"
       end


### PR DESCRIPTION
signatureV4.rb can generate signatures with + signs
ex) "x-amz-id-2"       => "5t1UgVprgnyMWwzu2C43kMLkKmdzmeFGDPzpFrLRM68TA1dMGNJp+7unLo6iKLko"
amazon however generates the hash with the + symbol escaped e.g) "5t1UgVprgnyMWwzu2C43kMLkKmdzmeFGDPzpFrLRM68TA1dMGNJp%2B7unLo6iKLko"
resulting in the request being rejected every time. Other symbols seem to have the same effect.

Other examples of people with this problem when interacting with S3:
http://stackoverflow.com/questions/17397924/amazon-s3-strange-error-sometimes-signaturedoesnotmatch-sometimes-it-does
https://coderwall.com/p/56a9ja

I believe the underlying cause is due to the fact S3 accepts the signature in both the header and as a query param and they are using the same code for both (i.e. + signs and / are invalid in the query param for obvious reasons) As a result any signature that gets generated with a special character in a url query param would be invalid in the header.

supporting documentation:
http://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html
