### PR TITLE
AWS: Add EBSOptimized flag to Autoscaling Launch Configuration

### DIFF
--- a/lib/fog/aws/models/auto_scaling/configuration.rb
+++ b/lib/fog/aws/models/auto_scaling/configuration.rb
@@ -10,6 +10,7 @@ module Fog
         attribute :associate_public_ip,   :aliases => 'AssociatePublicIpAddress'
         attribute :block_device_mappings, :aliases => 'BlockDeviceMappings'
         attribute :created_at,            :aliases => 'CreatedTime'
+        attribute :ebs_optimized,         :aliases => 'EbsOptimized'
         attribute :iam_instance_profile,  :aliases => 'IamInstanceProfile'
         attribute :image_id,              :aliases => 'ImageId'
         #attribute :instance_monitoring,   :aliases => 'InstanceMonitoring'

--- a/lib/fog/aws/requests/auto_scaling/create_launch_configuration.rb
+++ b/lib/fog/aws/requests/auto_scaling/create_launch_configuration.rb
@@ -41,6 +41,8 @@ module Fog
         #     market price.
         #   * 'UserData'<~String> - The user data available to the launched
         #     Amazon EC2 instances.
+        #   * 'EbsOptimized'<~Boolean> - Whether the instance is optimized for
+        #     EBS I/O. Not required, default false.
         #
         # ==== Returns
         # * response<~Excon::Response>:
@@ -86,6 +88,7 @@ module Fog
             'AssociatePublicIpAddress' => nil,
             'BlockDeviceMappings'     => [],
             'CreatedTime'             => Time.now.utc,
+            'EbsOptimized'            => false,
             'IamInstanceProfile'      => nil,
             'ImageId'                 => image_id,
             'InstanceMonitoring'      => {'Enabled' => true},


### PR DESCRIPTION
Adds the EbsOptimized flag to launch configurations. See here for reference.
http://docs.aws.amazon.com/AutoScaling/latest/APIReference/API_CreateLaunchConfiguration.html 
