### PR TITLE
fix mock to reality

### DIFF
--- a/lib/fog/aws/requests/compute/attach_volume.rb
+++ b/lib/fog/aws/requests/compute/attach_volume.rb
@@ -55,6 +55,16 @@ module Fog
               }
               volume['attachmentSet'] = [data]
               volume['status'] = 'attaching'
+
+              # for hvm based arch device can not have a digit at the end like /dev/sdz1  otherwise we get this error:
+              # "InvalidParameterValue => Value (/dev/sdz1) for parameter device is invalid. /dev/sdz1 is not a valid EBS device name."
+              #
+              # TODO: how to determine hvm?() ie, r3, t2, etc
+              if device.match(/^[a-z\/]*1$/) && hvm?(instance_id)
+                message = "InvalidParameterValue => Value (#{device}) for parameter device is invalid. #{device} is not a valid EBS device name.")
+                raise Fog::Compute::AWS::Error.new(message)
+              end
+
               response.status = 200
               response.body = {
                 'requestId' => Fog::AWS::Mock.request_id


### PR DESCRIPTION
hvm based images can not have a digit at end of device name. AWS throws
an error. mock needs to reflect reality.

PR is WIP:

- [ ] need to figure out how to determine if a instance is hvm?
- [ ] need to integrate test (at least manually) to verify mock behavior etc.