### PR TITLE
fix CGI escaping

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -527,7 +527,7 @@ DATA
           port   = params.delete(:port) || DEFAULT_SCHEME_PORT[scheme]
 
           params[:headers]['Date'] = expires
-          params[:headers]['Authorization'] = "AWS #{@aws_access_key_id}:#{CGI.escape(signature)}"
+          params[:headers]['Authorization'] = "AWS #{@aws_access_key_id}:#{signature}"
           # FIXME: ToHashParser should make this not needed
           original_params = params.dup
 


### PR DESCRIPTION
The prior PR (https://github.com/fog/fog/pull/3144) ended up causing some travis failures that we were unaware of. We're still testing the effect of this PR's change on our system, but it at least moves the escaping to a more appropriate place and allows the failing signaturev4 tests to pass.
