### PR TITLE
[GH-3156] Fix fog binary dependencies

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   # Modular providers
   s.add_dependency("fog-brightbox")
   s.add_dependency("fog-softlayer")
-  s.add_dependency("fog-sakuracloud")
+  s.add_dependency("fog-sakuracloud", ">= 0.0.4")
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development


### PR DESCRIPTION
The Sakuracloud `bin` file was removed to `v0.0.4` but the dependency
was not declared.

Using `$ fog` without manually updating the dependency would trigger a
require error due to this missing file.

This adds the minimal dependency required.
