### PR TITLE
[oVirt] expose ips attribute

### DIFF
--- a/lib/fog/ovirt/models/compute/server.rb
+++ b/lib/fog/ovirt/models/compute/server.rb
@@ -26,6 +26,7 @@ module Fog
         attribute :volumes
         attribute :raw
         attribute :quota
+        attribute :ips
 
         def ready?
           !(status =~ /down/i)


### PR DESCRIPTION
This attribute contains a list of IP addresses as used by the guest virtual machine
