### PR TITLE
Allow get_object_https_url to accept a method

### DIFF
--- a/lib/fog/rackspace/requests/storage/get_object_https_url.rb
+++ b/lib/fog/rackspace/requests/storage/get_object_https_url.rb
@@ -8,6 +8,7 @@ module Fog
         # * container<~String> - Name of container containing object
         # * object<~String> - Name of object to get expiring url for
         # * expires<~Time> - An expiry time for this url
+        # * options<~Hash> - Options to override the method or scheme
         #
         # ==== Returns
         # * response<~Excon::Response>:


### PR DESCRIPTION
get_object_https_url is used to generate GET URLs to cloud files. However, we can support PUT requests (uploads) by allowing people to specify PUT as the method rather than having it hard coded to GET.
