### PR TITLE
Error if FOG_CREDENTIAL doesn't match session

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -472,6 +472,7 @@ module Fog
             end
             @vcloud_token = response.headers[x_vcloud_authorization]
           end
+
           @org_name = response.body[:org]
           @user_name = response.body[:user]
         end


### PR DESCRIPTION
Currently, Fog will ignore the vCloud organisation specified by a
`FOG_CREDENTIAL` environment variable if a vCloud authorization token
is used to log in by specifying the `FOG_VCLOUD_TOKEN` environment
variable.

This happens because the organisation name is pulled from the response
body of the login request call. If a `FOG_VCLOUD_TOKEN` environment
variable is specified, the `get_current_session` API call is used and
the organisation returned in the response body will correspond to the
organisation specified when the vCloud token was first obtained using
the `post_login_session` API call.

It is therefore possible to specify a second `FOG_CREDENTIAL`, which
points to the same vCloud Director instance and specifies a different
organisation, but connect to the organisation used when creating the
vCloud session token. The end-user may believe that Fog is connecting to
the organisation specified by `FOG_CREDENTIAL`, but the effective
organisation is the one that was specified when first obtaining the
vCloud session token.

This could be potentially very serious if your production and test
organisations use the same vCloud Director instance (with the same
username for both organisations).

Raise an exception if the organisation implied by `FOG_CREDENTIAL`
differs to the one returned in the response body of the
`post_login_session` API call.

This behaves correctly if the session has expired; this code won't be
executed in that case.

---

I wasn't sure about the correct exception type to use, so went with `Fog::Errors::Error`; suggestions welcome if there's a better exception type to use.
