### PR TITLE
Local storage: Always try to create directories, handle already existing

### DIFF
--- a/lib/fog/local/models/storage/file.rb
+++ b/lib/fog/local/models/storage/file.rb
@@ -95,8 +95,10 @@ module Fog
               next
             end
             # create directory if it doesn't already exist
-            unless ::File.directory?(dir_path)
+            begin
               Dir.mkdir(dir_path)
+            rescue Errno::EEXIST
+              raise unless ::File.directory?(dir_path)
             end
           end
           file = ::File.new(path, 'wb')


### PR DESCRIPTION
This reduces the chances of races where two client try to upload the same file / two files with the same directory.

Not sure if this is the right way (or if the `.directory?` check should be left in); please advise.
