### PR TITLE
[AWS] Setup a fog keypair only if not supplied.

### DIFF
--- a/lib/fog/aws/models/compute/servers.rb
+++ b/lib/fog/aws/models/compute/servers.rb
@@ -175,8 +175,8 @@ module Fog
 
         private
 
-        def _setup_bootstrap(server, new_attributes = {})
-          unless new_attributes[:key_name]
+        def _setup_bootstrap(server)
+          unless server.key_name
             # first or create fog_#{credential} keypair
             name = Fog.respond_to?(:credential) && Fog.credential || :default
             unless server.key_pair = service.key_pairs.get("fog_#{name}")


### PR DESCRIPTION
When calling bootstrap, the :key_name argument is currently ignored
and not passed to the internal _setup_bootstrap() method. This results
in fog creating a keypair and using it for the instance.

The additional parameter -- new_attributes -- is also never actually
used when calling _setup_bootstrap().

The patch removes the new_attributes parameter and uses the key_name
attribute of the passed server object to ascertain whether a default
fog keypair should be created.
