### PR TITLE
Accessors to get credentials from AWS::Storage

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -388,6 +388,9 @@ module Fog
       class Real
         include Utils
         include Fog::AWS::CredentialFetcher::ConnectionMethods
+
+        attr_accessor :aws_access_key_id, :aws_secret_access_key, :aws_session_token, :aws_credentials_expire_at, :host
+
         # Initialize connection to S3
         #
         # ==== Notes


### PR DESCRIPTION
I'm not sure this is the best way, but in my code I have an instance of `Fog::AWS::Storage::Real` and I need to somehow extract AWS credentials from this object.
