### PR TITLE
Require docker-api in Gemfile

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -65,6 +65,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry')
   s.add_development_dependency('opennebula', '>=4.4.0')
   s.add_development_dependency('google-api-client', '~> 0.6', '>= 0.6.2')
+  s.add_development_dependency('docker-api', '>= 1.8.0')
   s.add_development_dependency('rubocop') if RUBY_VERSION > "1.9"
 
   if ENV["FOG_USE_LIBVIRT"]


### PR DESCRIPTION
In lib/fog/fogdocker/compute.rb, require 'docker' is used.
The gem is used throughout this part of the code but is not required in the Gemfile,
I've added it, it's https://github.com/swipely/docker-api , 'docker-api.
