### PR TITLE
Raise docker-api errors up

### DIFF
--- a/lib/fog/fogdocker/core.rb
+++ b/lib/fog/fogdocker/core.rb
@@ -1,15 +1,9 @@
 require 'fog/core'
+require 'fog/fogdocker/errors'
 
 module Fog
   module Fogdocker
     extend Fog::Provider
-
-    module Errors
-      class ServiceError < Fog::Errors::Error; end
-      class SecurityError < ServiceError; end
-      class NotFound < ServiceError; end
-    end
-
     service(:compute, 'Compute')
   end
 end

--- a/lib/fog/fogdocker/errors.rb
+++ b/lib/fog/fogdocker/errors.rb
@@ -1,0 +1,9 @@
+module Fog
+  module Errors
+    module Fogdocker
+      class ServiceError < Fog::Errors::Error; end
+      class AuthenticationError < ServiceError; end
+    end
+  end
+end
+

--- a/lib/fog/fogdocker/requests/compute/container_action.rb
+++ b/lib/fog/fogdocker/requests/compute/container_action.rb
@@ -7,6 +7,14 @@ module Fog
           raise ArgumentError, "action is a required parameter" unless options.key? :action
           container = Docker::Container.get(options[:id])
           downcase_hash_keys container.send(options[:action]).json
+        rescue Docker::Error::NotFoundError => e
+          raise Fog::Errors::Error::NotFound.new(e.message)
+        rescue Docker::Error::TimeoutError => e
+          raise Fog::Errors::Error::TimeoutError.new(e.message)
+        rescue Docker::Error::UnauthorizedError => e
+          raise Fog::Errors::Fogdocker::ServiceError::AuthenticationError.new(e.message)
+        rescue Docker::Error::DockerError => e
+          raise Fog::Errors::Fogdocker::ServiceError.new(e.message)
         end
       end
 


### PR DESCRIPTION
This allows Docker API errors to be caught by Fog's clients and also raises specific errors depending on the problem.
