### PR TITLE
Added GovCloud region to acceptable AWS list

### DIFF
--- a/lib/fog/aws/region_methods.rb
+++ b/lib/fog/aws/region_methods.rb
@@ -2,7 +2,7 @@ module Fog
   module AWS
     module RegionMethods
       def validate_aws_region host, region
-        if host.end_with?('.amazonaws.com') and not ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(region)
+        if host.end_with?('.amazonaws.com') and not ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1', 'us-gov-west-1'].include?(region)
           raise ArgumentError, "Unknown region: #{region.inspect}"
         end
       end


### PR DESCRIPTION
I'm working with fog in the Amazon's GovCloud region, us-gov-west-1. Please include it as a valid region.
