### PR TITLE
[openstack] add remove header if setting directory back to private

### DIFF
--- a/lib/fog/openstack/requests/storage/put_container.rb
+++ b/lib/fog/openstack/requests/storage/put_container.rb
@@ -10,6 +10,7 @@ module Fog
         def put_container(name, options={})
           headers = options[:headers] || {}
           headers['X-Container-Read'] = '.r:*' if options[:public]
+          headers['X-Remove-Container-Read'] = 'x' if options[:public] == false
           request(
             :expects  => [201, 202],
             :method   => 'PUT',


### PR DESCRIPTION
This is needed if you want to put you container back to private. Since sending empty header wont do it. 
