### PR TITLE
Docker: Support for logs/top operations

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -66,7 +66,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('pry')
   s.add_development_dependency('opennebula', '>=4.4.0')
   s.add_development_dependency('google-api-client', '~> 0.6', '>= 0.6.2')
-  s.add_development_dependency('docker-api', '>= 1.8.0')
+  s.add_development_dependency('docker-api', '>= 1.13.6')
   s.add_development_dependency('rubocop') if RUBY_VERSION > "1.9"
 
   if ENV["FOG_USE_LIBVIRT"]

--- a/lib/fog/fogdocker/compute.rb
+++ b/lib/fog/fogdocker/compute.rb
@@ -41,7 +41,7 @@ module Fog
           url      = options[:docker_url]
 
           Docker.url = url
-          Docker.authenticate!('username' => username, 'password' => password, 'email' => email) unless username. nil? || username.empty?
+          Docker.authenticate!('username' => username, 'password' => password, 'email' => email) unless username.nil? || username.empty?
         end
 
         def downcase_hash_keys(hash, k = [])

--- a/lib/fog/fogdocker/models/compute/server.rb
+++ b/lib/fog/fogdocker/models/compute/server.rb
@@ -115,6 +115,14 @@ module Fog
           service.container_delete(:id => id)
         end
 
+        def logs(options = { :stdout => 1, :stderr => 1 })
+          service.container_action(:id =>id, :action => :logs, :options => options)
+        end
+
+        def top(options = {})
+          service.container_action(:id =>id, :action => :top)
+        end
+
         def save
           if persisted?
             service.container_update(attributes)

--- a/lib/fog/fogdocker/requests/compute/container_action.rb
+++ b/lib/fog/fogdocker/requests/compute/container_action.rb
@@ -5,8 +5,13 @@ module Fog
         def container_action(options = {})
           raise ArgumentError, "instance id is a required parameter" unless options.key? :id
           raise ArgumentError, "action is a required parameter" unless options.key? :action
-          container = Docker::Container.get(options[:id])
-          downcase_hash_keys container.send(options[:action]).json
+          result = Docker::Container.get(options[:id]).send(options[:action], options[:options])
+
+          if result.is_a?(Hash)
+            downcase_hash_keys(result)
+          else
+            result
+          end
         rescue Docker::Error::NotFoundError => e
           raise Fog::Errors::Error::NotFound.new(e.message)
         rescue Docker::Error::TimeoutError => e
@@ -22,7 +27,44 @@ module Fog
         def container_action(options = {})
           raise ArgumentError, "id is a required parameter" unless options.key? :id
           raise ArgumentError, "action is a required parameter" unless options.key? :action
-          {'id' => 'a6b02c7ca29a22619f7d0e59062323247739bc0cd375d619f305f0b519af4ef3','state_running' => false}
+          response_matcher(options[:action])
+        end
+
+        private
+
+        def response_matcher(action)
+          send("#{action}_response".to_sym)
+        rescue NoMethodError
+          default_response
+        end
+
+        def default_response
+          { 'id'           => 'a6b02c7ca29a22619f7d0e59062323247739bc0cd375d619f305f0b519af4ef3',
+           'state_running' => false }
+        end
+
+        def start_response
+          default_response.merge({ 'state_running' => true })
+        end
+
+        def top_response
+          [
+            {
+              'UID'   => 'root',
+              'PID'   => '15306',
+              'PPID'  => '13567',
+              'C'     => '0',
+              'STIME' => 'Oct15',
+              'TTY'   => '?',
+              'TIME'  => '00:00:11',
+              'CMD'   => 'ping theforeman.org'
+            }
+          ]
+        end
+
+        # Sample response from a ping
+        def logs_response
+          "\u0001\u0000\u0000\u0000\u0000\u0000\u0000]64 bytes from fra07s30-in-f6.1e100.net (173.194.112.102): icmp_req=35272 ttl=52 time=36.9 ms\n\u0001\u0000\u0000\u0000\u0000\u0000\u0000]64 bytes from fra07s30-in-f6.1e100.net (173.194.112.102): icmp_req=35273 ttl=52 time=35.3 ms\n"
         end
       end
     end

--- a/tests/fogdocker/requests/compute/container_action_tests.rb
+++ b/tests/fogdocker/requests/compute/container_action_tests.rb
@@ -2,23 +2,34 @@ Shindo.tests("Fog::Compute[:fogdocker] | container_action request", 'fogdocker')
 
   compute = Fog::Compute[:fogdocker]
   name = "fog-#{Time.now.to_i}"
-  response = compute.container_create(:name => name, 'image' => 'mattdm/fedora:f19','Cmd' => ['date'] )
+  response = compute.container_create(:name => name, 'image' => 'mattdm/fedora:f19','Cmd' => ['date'])
   id = response['id']
 
   tests("Start Container") do
-    response = compute.container_action(:id => id, :action => 'start' )
-    test("should be a kind of Hash") { response.kind_of?  Hash}
+    response = compute.container_action(:id => id, :action => :start)
+    test("should be a kind of Hash") { response.kind_of? Hash }
+    test("should be running") { response['state_running'] == true }
   end
 
   tests("Stop Container") do
-    response = compute.container_action(:id => id, :action => 'stop' )
-    test("should be a kind of Hash") { response.kind_of? Hash}
+    response = compute.container_action(:id => id, :action => :stop)
+    test("should be a kind of Hash") { response.kind_of? Hash }
   end
 
   tests("Kill Container") do
-    response = compute.container_action(:id => id, :action => 'kill' )
-    test("should be a kind of Hash") { response.kind_of?  Hash}
-    test("should be stopped") { response['state_running'] == false}
+    response = compute.container_action(:id => id, :action => :kill)
+    test("should be a kind of Hash") { response.kind_of? Hash }
+    test("should be stopped") { response['state_running'] == false }
   end
 
+  tests("Top Container") do
+    response = compute.container_action(:id => id, :action => :top)
+    test("should be an Array") { response.kind_of? Array }
+    test("should be an array of processes") { !!(response.first['PID'] =~ /^\d+$/) }
+  end
+
+  tests("Logs Container") do
+    response = compute.container_action(:id => id, :action => :logs)
+    test("should be a String") { response.kind_of? String }
+  end
 end


### PR DESCRIPTION
In order to test this properly, responses from the mock return values
closer to what the API actually returns. Examples are from Remote API
1.18.

downcasing hash keys cannot be performed on all Docker API operations so
now it will only be done where the top element is a hash. Logs, top, and
many others will not return a hash.
