### PR TITLE
Requiring fog/version

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -1,3 +1,8 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'fog/version'
+
 Gem::Specification.new do |s|
   s.specification_version = 2 if s.respond_to? :specification_version=
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=


### PR DESCRIPTION
fix #3203 

@geemus The problem was that fog was not requiring its own `version` file.
Before the [changes](https://github.com/fog/fog-core/pull/86) in `fog-core` it was using the file from `fog-core`.
After we made the change in `fog-core` the edge build in `fog` begin to break because of that miss.
