### PR TITLE
Fix floating_ip detection for OpenStack Folsom Release

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -131,6 +131,7 @@ module Fog
               1
             else 0 end
           }
+          all_floating.empty? ? manual : all_floating
         end
 
         alias_method :public_ip_addresses, :floating_ip_addresses


### PR DESCRIPTION
OS-EXT-IPS:type was introduced only in Grizzly, thus Folsom
cannot rely on this api extension.
See https://bugs.launchpad.net/openstack-api-site/+bug/1128562
Meanwhile we can designate floating ip from fixed_ip by provided
fallback
