### PR TITLE
AWS Frankfurt region announced

### DIFF
--- a/lib/fog/aws/cloud_watch.rb
+++ b/lib/fog/aws/cloud_watch.rb
@@ -54,7 +54,7 @@ module Fog
 
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-1', 'us-west-2'].include?(@region)
+          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-1', 'us-west-2'].include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end

--- a/lib/fog/aws/elb.rb
+++ b/lib/fog/aws/elb.rb
@@ -85,7 +85,7 @@ module Fog
 
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'].include?(@region)
+          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2'].include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end

--- a/lib/fog/aws/rds.rb
+++ b/lib/fog/aws/rds.rb
@@ -115,7 +115,7 @@ module Fog
           @use_iam_profile = options[:use_iam_profile]
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(@region)
+          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end

--- a/lib/fog/aws/region_methods.rb
+++ b/lib/fog/aws/region_methods.rb
@@ -2,7 +2,7 @@ module Fog
   module AWS
     module RegionMethods
       def validate_aws_region host, region
-        if host.end_with?('.amazonaws.com') and not ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1', 'us-gov-west-1'].include?(region)
+        if host.end_with?('.amazonaws.com') and not ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1', 'us-gov-west-1'].include?(region)
           raise ArgumentError, "Unknown region: #{region.inspect}"
         end
       end

--- a/lib/fog/aws/requests/compute/describe_availability_zones.rb
+++ b/lib/fog/aws/requests/compute/describe_availability_zones.rb
@@ -63,6 +63,9 @@ module Fog
             {"messageSet" => [], "regionName" => "eu-west-1", "zoneName" => "eu-west-1b", "zoneState" => "available"},
             {"messageSet" => [], "regionName" => "eu-west-1", "zoneName" => "eu-west-1c", "zoneState" => "available"},
 
+            {"messageSet" => [], "regionName" => "eu-central-1", "zoneName" => "eu-central-1a", "zoneState" => "available"},
+            {"messageSet" => [], "regionName" => "eu-central-1", "zoneName" => "eu-central-1b", "zoneState" => "available"},
+
             {"messageSet" => [], "regionName" => "ap-northeast-1", "zoneName" => "ap-northeast-1a", "zoneState" => "available"},
             {"messageSet" => [], "regionName" => "ap-northeast-1", "zoneName" => "ap-northeast-1b", "zoneState" => "available"},
 

--- a/lib/fog/aws/requests/compute/describe_regions.rb
+++ b/lib/fog/aws/requests/compute/describe_regions.rb
@@ -41,8 +41,11 @@ module Fog
 
           response = Excon::Response.new
           region_info = [
+            {"regionName"=>"eu-central-1", "regionEndpoint"=>"eu-central-1.ec2.amazonaws.com"},
             {"regionName"=>"eu-west-1", "regionEndpoint"=>"eu-west-1.ec2.amazonaws.com"},
-            {"regionName"=>"us-east-1", "regionEndpoint"=>"us-east-1.ec2.amazonaws.com"}
+            {"regionName"=>"us-east-1", "regionEndpoint"=>"us-east-1.ec2.amazonaws.com"},
+            {"regionName"=>"us-west-1", "regionEndpoint"=>"eu-west-1.ec2.amazonaws.com"},
+            {"regionName"=>"us-west-2", "regionEndpoint"=>"eu-west-2.ec2.amazonaws.com"}
           ]
 
           aliases = {'region-name' => 'regionName', 'endpoint' => 'regionEndpoint'}

--- a/lib/fog/aws/sqs.rb
+++ b/lib/fog/aws/sqs.rb
@@ -40,7 +40,7 @@ module Fog
           setup_credentials(options)
           @region = options[:region] || 'us-east-1'
 
-          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(@region)
+          unless ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-west-1', 'us-east-1', 'us-west-1', 'us-west-2', 'sa-east-1'].include?(@region)
             raise ArgumentError, "Unknown region: #{@region.inspect}"
           end
         end


### PR DESCRIPTION
http://aws.amazon.com/blogs/aws/aws-region-germany/

"The new Frankfurt Region supports Amazon Elastic Compute Cloud (EC2) and related services including Amazon Elastic Block Store (EBS), Amazon Virtual Private Cloud, Auto Scaling, and Elastic Load Balancing."

"It also supports AWS Elastic Beanstalk, AWS CloudFormation, Amazon CloudFront, Amazon CloudSearch, AWS CloudTrail, Amazon CloudWatch, AWS Direct Connect, Amazon DynamoDB, Amazon Elastic MapReduce, AWS Storage Gateway, Amazon Glacier, AWS CloudHSM, AWS Identity and Access Management (IAM), Amazon Kinesis, AWS OpsWorks, Amazon Route 53, Amazon Relational Database Service (RDS), Amazon Redshift, Amazon Simple Storage Service (S3), Amazon Simple Notification Service (SNS), Amazon Simple Queue Service (SQS), and Amazon Simple Workflow Service (SWF)."

Would be more helpful to know what it didn't support.
