### PR TITLE
[Brightbox] Update Brightbox gem to add storage

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |s|
   s.add_dependency('ipaddress', '~>0.5')
 
   # Modular providers
-  s.add_dependency("fog-brightbox")
+  s.add_dependency("fog-brightbox", "~> 0.4")
   s.add_dependency("fog-softlayer")
   s.add_dependency("fog-sakuracloud", ">= 0.0.4")
   s.add_dependency("fog-radosgw", ">=0.0.2")

--- a/lib/fog/bin/brightbox.rb
+++ b/lib/fog/bin/brightbox.rb
@@ -4,8 +4,10 @@ class Brightbox < Fog::Bin
       case key
       when :compute
         Fog::Compute::Brightbox
+      when :storage
+        Fog::Storage::Brightbox
       else
-        raise ArgumentError, "Unrecognized service: #{key}"
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
       end
     end
 


### PR DESCRIPTION
This adds support for our Orbit storage service to the `Fog` binary.

Due to the whitelisting of supported services, without these changes
versions of `fog-brightbox >= 0.4.0` would error when the `shindo` tests
were starting so all Brightbox tests would be skipped.
