### PR TITLE
Openstack storage public urls

### DIFF
--- a/lib/fog/openstack/models/storage/directory.rb
+++ b/lib/fog/openstack/models/storage/directory.rb
@@ -9,7 +9,7 @@ module Fog
 
         attribute :bytes, :aliases => 'X-Container-Bytes-Used'
         attribute :count, :aliases => 'X-Container-Object-Count'
-        
+
         attr_writer :public
 
         def destroy
@@ -30,7 +30,15 @@ module Fog
         end
 
         def public_url
-          raise NotImplementedError
+          requires :key
+          @public_url ||= begin
+            begin response = service.head_container(key)
+              # escape the key to cover for special char. in container names
+              url = service.public_url(key)
+            rescue Fog::Storage::OpenStack::NotFound => err
+              nil
+            end
+          end
         end
 
         def save

--- a/lib/fog/openstack/requests/storage/public_url.rb
+++ b/lib/fog/openstack/requests/storage/public_url.rb
@@ -1,0 +1,32 @@
+module Fog
+  module Storage
+    class OpenStack
+      class Real
+
+        def url
+          "#{@scheme}://#{@host}:#{@port}#{@path}"
+        end
+
+        # Get public_url for an object
+        #
+        # ==== Parameters
+        # * container<~String> - Name of container to look in
+        # * object<~String> - Name of object to look for
+        #
+        def public_url(container=nil, object=nil)
+          public_url = nil
+          unless container.nil?
+            if object.nil?
+              # return container public url
+              public_url = "#{url}/#{Fog::OpenStack.escape(container)}"
+            else
+              # return object public url
+              public_url = "#{url}/#{Fog::OpenStack.escape(container)}/#{Fog::OpenStack.escape(object)}"
+            end
+          end
+          public_url
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -36,6 +36,7 @@ module Fog
       request :put_dynamic_obj_manifest
       request :put_static_obj_manifest
       request :post_set_meta_temp_url_key
+      request :public_url
 
       class Mock
         def self.data


### PR DESCRIPTION
This PR introduces public_url generation for the OpenStack provider's storage module.

I did not know how to test the feature in the correct way, so please feel free to give me an introduction to do so, or help me implementing the test suite.

I already tested it manually using our Swift installation and it worked as expected.

Cheers,
Julian Weber
