### PR TITLE
Preserve @ symbols in vcloud_director usernames

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -487,7 +487,7 @@ module Fog
 
         def check_session_matches_credentials(session_org, session_user)
           fog_credential_org = @vcloud_director_username.split('@').last
-          fog_credential_user = @vcloud_director_username.split('@')[0...-1].join
+          fog_credential_user = @vcloud_director_username.split('@')[0...-1].join('@')
 
           if session_org != fog_credential_org
             raise Fog::Errors::Error.new "FOG_CREDENTIAL specified is for vCloud organisation '#{fog_credential_org}' but " +


### PR DESCRIPTION
It's valid to have an email address as a vCloud Director username which
would result in a `vcloud_director_username` string that looks like:

```
user@example.com@organisation
```

The previous code incorrectly stripped any @ symbols from the username which
would turn the previous example into:

```
fog_credential_user = 'userexample.com'
fog_credential_org = 'organisation'
```

This meant that check_session_matches_credentials() would always raise an
error for such usernames. Prevent this from happening by restoring the @
separators when we join the array back together (minus the org).

Fixes an error reported in gds-operations/vcloud-core#139
