### PR TITLE
[rackspace] Queues: makes block optional when dequeuing

### DIFF
--- a/lib/fog/rackspace/models/queues/queue.rb
+++ b/lib/fog/rackspace/models/queues/queue.rb
@@ -91,7 +91,7 @@ module Fog
 
           if claim
             message = claim.messages.first
-            yield message
+            yield message if block_given?
             message.destroy
             true
           else

--- a/tests/rackspace/models/queues/queue_tests.rb
+++ b/tests/rackspace/models/queues/queue_tests.rb
@@ -24,5 +24,14 @@ Shindo.tests('Fog::Rackspace::Queues | queue', ['rackspace']) do
       @instance.dequeue(60, 60) do |message|
       end
     end
+
+    tests('#dequeue(60, 60) => not passing block').returns(true) do
+      @instance.enqueue("msg", 60)
+      @instance.dequeue(60, 60)
+    end
+
+    tests('#dequeue(60, 60) => with not messages and not passing block').returns(false) do
+      @instance.dequeue(60, 60)
+    end
   end
 end


### PR DESCRIPTION
Currently when you want to dequeue a message you always have to pass a block, even if you have no reasons for one. I've found my self passing empty blocks all the time, when I just want to dequeue a message.

This PR makes a simple modification to make the block optional. This way you don't need  to pass an empty block when you don't need one. No side effects and backward compatible.
