### PR TITLE
[AWS|Core] aws needs fog/core/parser to be loaded

### DIFF
--- a/lib/fog/aws/core.rb
+++ b/lib/fog/aws/core.rb
@@ -1,4 +1,5 @@
 require 'fog/core'
+require 'fog/core/parser'
 require 'fog/xml'
 require 'fog/json'
 require 'fog/aws/credential_fetcher'


### PR DESCRIPTION
I've not really been following the efforts to split fog up but as of current master requiring just 'fog/aws' doesn't work because Fog::Parsers::Base hasn't been loaded. This fixes it, although I don't know whether this is the best place for this (eg should this be pulled in by fog/xml ?)
