### PR TITLE
[AWS|S3] Vhost buckets don't work if bucket name has a . in it

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -218,6 +218,7 @@ module Fog
               Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
               path_style = true
             elsif scheme == 'https' && bucket_name =~ /\./
+              Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
               path_style = true
             end  
 


### PR DESCRIPTION
We shouldn't convert to dns addresseing in this case since the S3 wildcard cert is only valid for *.s3.amazonaws.com, not foo.*.amazonaws.com. 
