### PR TITLE
Fix spelling mistake in docs for AWS File#public_url

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -149,7 +149,7 @@ module Fog
           new_public
         end
 
-        # Get pubically acessible url via http GET.
+        # Get publicly accessible url via http GET.
         # Checks permissions before creating.
         # Defaults to s3 subdomain or compliant bucket name
         #


### PR DESCRIPTION
I ran across this spelling mistake trying to figure out why `public_url` was making api calls, and figured it wouldn't hurt to submit a PR to fix the issue, as amusing as the misspelling is.
