### PR TITLE
[rackspace] add :type to LoadBalancers nodes

### DIFF
--- a/lib/fog/rackspace/models/load_balancers/node.rb
+++ b/lib/fog/rackspace/models/load_balancers/node.rb
@@ -10,6 +10,7 @@ module Fog
         attribute :status
         attribute :weight
         attribute :port
+        attribute :type
         attribute :condition
 
         def destroy
@@ -38,6 +39,9 @@ module Fog
           unless weight.nil?
             options[:weight] = weight
           end
+          unless type.nil?
+            options[:type] = type
+          end
           data = service.create_node(load_balancer.id, address, port, condition, options)
           merge_attributes(data.body['nodes'][0])
         end
@@ -49,6 +53,9 @@ module Fog
           }
           unless weight.nil?
             options[:weight] = weight
+          end
+          unless type.nil?
+            options[:type] = type
           end
           service.update_node(load_balancer.id, identity, options)
         end

--- a/lib/fog/rackspace/requests/load_balancers/create_node.rb
+++ b/lib/fog/rackspace/requests/load_balancers/create_node.rb
@@ -14,6 +14,9 @@ module Fog
           if options.key?(:weight)
             data['nodes'][0]['weight'] = options[:weight]
           end
+          if options.key? :type
+            data['node']['type'] = options[:type]
+          end
           request(
             :body     => Fog::JSON.encode(data),
             :expects  => [200, 202],

--- a/lib/fog/rackspace/requests/load_balancers/update_node.rb
+++ b/lib/fog/rackspace/requests/load_balancers/update_node.rb
@@ -12,6 +12,9 @@ module Fog
           if options.key? :condition
             data['node']['condition'] = options[:condition]
           end
+          if options.key? :type
+            data['node']['type'] = options[:type]
+          end
           #TODO - Do anything if no valid options are passed in?
           request(
             :body     => Fog::JSON.encode(data),


### PR DESCRIPTION
http://docs.rackspace.com/loadbalancers/api/v1.0/clb-devguide/content/Nodes-d1e2173.html
Type of node:

PRIMARY – Nodes defined as PRIMARY are in the normal rotation to receive traffic from the load balancer.

SECONDARY – Nodes defined as SECONDARY are only in the rotation to receive traffic from the load balancer when all the primary nodes fail. This provides a failover feature that automatically routes traffic to the secondary node in the event that the primary node is disabled or in a failing state. Note that active health monitoring must be enabled on the load balancer to enable the failover feature to the secondary node.

This is cleaned up and 'works for me'

I used  Charles Proxy to debug traffic generate the gists

https://gist.github.com/hh/d9cbd23097d42db7e531

``` ruby
c=Fog::Rackspace::LoadBalancers.new(rackspace_region: :dfw,
  connection_options: {ssl_verify_peer: false, proxy: 'http://localhost:8888'})
[1] pry(main)> lb=s.load_balancers.find {|lb| lb.name == 'testhttp'} 
[2] pry(main)> lb.nodes
=> [  <Fog::Rackspace::LoadBalancers::Node
    id=592343,
    address="72.32.12.183",
    status="OFFLINE",
    weight=1,
    port=80,
    type="PRIMARY",
    condition="ENABLED"
  >,
   <Fog::Rackspace::LoadBalancers::Node
    id=592345,
    address="98.129.97.72",
    status="ONLINE",
    weight=1,
    port=80,
    type="SECONDARY",
    condition="ENABLED"
  >,
   <Fog::Rackspace::LoadBalancers::Node
    id=712997,
    address="10.179.69.183",
    status="OFFLINE",
    weight=1,
    port=80,
    type="PRIMARY",
    condition="ENABLED"
  >]
[3] pry(main)> lb.nodes.last.type="SECONDARY"
=> "SECONDARY"
[4] pry(main)> lb.nodes.last.save
=> true
[5] pry(main)> s.load_balancers.find {|lb| lb.name == 'testhttp'}.nodes
=> [  <Fog::Rackspace::LoadBalancers::Node
    id=592343,
    address="72.32.12.183",
    status="OFFLINE",
    weight=1,
    port=80,
    type="PRIMARY",
    condition="ENABLED"
  >,
   <Fog::Rackspace::LoadBalancers::Node
    id=592345,
    address="98.129.97.72",
    status="ONLINE",
    weight=1,
    port=80,
    type="SECONDARY",
    condition="ENABLED"
  >,
   <Fog::Rackspace::LoadBalancers::Node
    id=712997,
    address="10.179.69.183",
    status="OFFLINE",
    weight=1,
    port=80,
    type="SECONDARY",
    condition="ENABLED"
  >]

```
