### PR TITLE
Don't attempt to rewind IO if it's not offset

### DIFF
--- a/lib/fog/aws/models/glacier/archive.rb
+++ b/lib/fog/aws/models/glacier/archive.rb
@@ -44,7 +44,9 @@ module Fog
 
           hash = Fog::AWS::Glacier::TreeHash.new
 
-          body.rewind if body.respond_to?(:rewind)
+          if body.respond_to?(:rewind)
+            body.rewind  rescue nil
+          end
           offset = 0
           while (chunk = body.read(multipart_chunk_size)) do
             part_hash = hash.add_part(chunk)


### PR DESCRIPTION
This will permit the passing in of pipes, sockets, or other IO objects that
don't support the #rewind method.
