### PR TITLE
make zones.get(domain_or_id) work, same as dnsimple

### DIFF
--- a/lib/fog/rackspace/models/dns/zones.rb
+++ b/lib/fog/rackspace/models/dns/zones.rb
@@ -47,7 +47,8 @@ module Fog
           data = service.list_domain_details(zone_id).body
           new(data)
         rescue Fog::DNS::Rackspace::NotFound
-          nil
+          # if we can't find it by id, go back and find it via domain
+          find{|z| z.domain == zone_id}
         #Accessing a valid (but other customer's) id returns a 503 error
         rescue Fog::Rackspace::Errors::ServiceUnavailable
           nil


### PR DESCRIPTION
zones.find() returns nil if not found
While it does result in two calls, it now functions similarly to dnsimple.
Do we have a definition for how the top levels should work across providers?

dns.zones.get('domainname.com') makes the most sense to me
