### PR TITLE
cloud_init support in ovirt

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -67,7 +67,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rbvmomi')
   s.add_development_dependency('yard')
   s.add_development_dependency('thor')
-  s.add_development_dependency('rbovirt', '0.0.24')
+  s.add_development_dependency('rbovirt', '0.0.31')
   s.add_development_dependency('shindo', '~> 0.3.4')
   s.add_development_dependency('fission')
   s.add_development_dependency('pry')

--- a/lib/fog/ovirt/compute.rb
+++ b/lib/fog/ovirt/compute.rb
@@ -24,6 +24,7 @@ module Fog
       request_path 'fog/ovirt/requests/compute'
 
       request :vm_action
+      request :vm_start_with_cloudinit
       request :destroy_vm
       request :create_vm
       request :update_vm

--- a/lib/fog/ovirt/models/compute/server.rb
+++ b/lib/fog/ovirt/models/compute/server.rb
@@ -79,19 +79,26 @@ module Fog
           service.add_volume(id, attrs)
         end
 
-        def update_volume attrs
-          wait_for { stopped? } if attrs[:blocking]
-          service.update_volume(id, attrs)
-        end
-
         def destroy_volume attrs
           wait_for { stopped? } if attrs[:blocking]
           service.destroy_volume(id, attrs)
         end
 
+        def update_volume attrs
+          wait_for { stopped? } if attrs[:blocking]
+          service.update_volume(id, attrs)
+        end
+
         def start(options = {})
           wait_for { !locked? } if options[:blocking]
           service.vm_action(:id =>id, :action => :start)
+          reload
+        end
+
+        def start_with_cloudinit(options = {})
+          wait_for { !locked? } if options[:blocking]
+          user_data = Hash[YAML.load(options[:user_data]).map{|a| [a.first.to_sym, a.last]}]
+          service.vm_start_with_cloudinit(:id =>id, :user_data =>user_data)
           reload
         end
 

--- a/lib/fog/ovirt/requests/compute/vm_start_with_cloudinit.rb
+++ b/lib/fog/ovirt/requests/compute/vm_start_with_cloudinit.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Ovirt
+      class Real
+        def vm_start_with_cloudinit(options = {})
+          raise ArgumentError, "instance id is a required parameter" unless options.key? :id
+          client.vm_start_with_cloudinit(options[:id], options[:user_data])
+        end
+      end
+
+      class Mock
+        def vm_start_with_cloudinit(options = {})
+          raise ArgumentError, "instance id is a required parameter" unless options.key? :id
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/cloudinit_to_customspec.rb
+++ b/lib/fog/vsphere/requests/compute/cloudinit_to_customspec.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def cloudinit_to_customspec(user_data)
+          raise ArgumentError, "user_data cant be nil" if user_data.nil?
+          custom_spec = Hash.new 
+          user_data = YAML.load(user_data)
+          custom_spec['hostname']                 =  user_data['hostname'] if user_data.key?('hostname')
+          custom_spec['ipsettings']               =  { 'ip' => user_data['ip'] } if user_data.key?('ip')
+          custom_spec['ipsettings']['subnetMask'] =  user_data['netmask'] if user_data.key?('netmask')
+          custom_spec['domain']                   =  user_data['domain'] if user_data.key?('domain')
+          custom_spec['dnsServerList']            =  user_data['dns'] if user_data.key?('dns')
+          custom_spec['dnsSuffixList']            =  user_data['domain'] if user_data.key?('domain')
+          custom_spec['time_zone']                =  user_data['timezone'] if user_data.key?('timezone')
+          custom_spec           
+        end
+      end
+
+      class Mock
+        def cloudinit_to_customspec(user_data)
+          raise ArgumentError, "user_data cant be nil" if user_data.nil?
+          true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
this pr brings cloud_init support for ovirt provider by means of providing a user_data hash upon starting of the vm.
the rbovirt related part is under review at https://github.com/abenari/rbovirt/pull/48
