### PR TITLE
[Openstack|Compute] fix randomly failing spec

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -203,7 +203,7 @@ module Fog
               :servers => {},
               :key_pairs => {},
               :security_groups => {
-                0 => {
+                '0' => {
                   "id"          => 0,
                   "tenant_id"   => Fog::Mock.random_hex(8),
                   "name"        => "default",

--- a/lib/fog/openstack/requests/compute/create_security_group.rb
+++ b/lib/fog/openstack/requests/compute/create_security_group.rb
@@ -23,7 +23,7 @@ module Fog
         def create_security_group(name, description)
           Fog::Identity::OpenStack.new(:openstack_auth_url => credentials[:openstack_auth_url])
           tenant_id = Fog::Identity::OpenStack::Mock.data[current_tenant][:tenants].keys.first
-          security_group_id = Fog::Mock.random_numbers(2).to_i
+          security_group_id = Fog::Mock.random_numbers(2).to_i + 1
           self.data[:security_groups][security_group_id.to_s] = {
             'tenant_id' => tenant_id,
             'rules'     => [],


### PR DESCRIPTION
The security group failure tests have been failing randomly. This happens
because the random id assigned by the create security group mock can collide
with the id (0) of the default security group. The mock data stores the keys
as strings (except) for the default one, meaning that you end up with 2
security groups with id 0, one stored under the key 0 and the other
under the key '0'

I've addressed this by storing the default group as '0' (so that it can 
be retrieved properly) and also by changing the create security group mock
so that it will never assign the id 0

I'm not an openstack user, so review appreciated - just want to stop random
build failures. It also occurs to me that perhaps the mock should take
steps to make duplicate ids impossible - could lead to some hard to reproduce problems if you were using the mocks.
