### PR TITLE
Improved OpenNebula support

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -59,6 +59,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-sakuracloud", ">= 0.0.4")
   s.add_dependency("fog-radosgw", ">=0.0.2")
   s.add_dependency("fog-profitbricks")
+  s.add_dependency('opennebula', '>=4.4.0')
 
   ## List your development dependencies here. Development dependencies are
   ## those that are only needed during development

--- a/lib/fog/opennebula/models/compute/flavors.rb
+++ b/lib/fog/opennebula/models/compute/flavors.rb
@@ -23,7 +23,14 @@ module Fog
 
         def get_by_name(flavor_name)
           data = service.template_pool({:name => flavor_name})
-          load(data)
+          load(data).first
+        rescue Fog::Compute::OpenNebula::NotFound
+          nil
+        end
+
+        def get_by_filter(flavor_filter)
+          data = service.template_pool(flavor_filter)
+          load(data).first
         rescue Fog::Compute::OpenNebula::NotFound
           nil
         end

--- a/lib/fog/opennebula/models/compute/network.rb
+++ b/lib/fog/opennebula/models/compute/network.rb
@@ -7,6 +7,7 @@ module Fog
 
         identity :id
         attribute :name
+        attribute :uname
         attribute :uid
         attribute :gid
         attribute :description

--- a/lib/fog/opennebula/models/compute/networks.rb
+++ b/lib/fog/opennebula/models/compute/networks.rb
@@ -15,6 +15,10 @@ module Fog
           self.all({:id => id}).first
         end
 
+        def get_by_filter(filter)
+          self.all(filter).first
+        end
+
       end
     end
   end

--- a/lib/fog/opennebula/requests/compute/list_networks.rb
+++ b/lib/fog/opennebula/requests/compute/list_networks.rb
@@ -6,36 +6,43 @@ module Fog
     class OpenNebula
       class Real
         def list_networks(filter = { })
-
           networks=[]
-            netpool = ::OpenNebula::VirtualNetworkPool.new(client)
-            if filter[:id].nil?
-              netpool.info!(-2,-1,-1)
-            elsif filter[:id]
-              filter[:id] = filter[:id].to_i if filter[:id].is_a?(String)
-              netpool.info!(-2, filter[:id], filter[:id])
-            end # if filter[:id].nil?
- 
+          netpool = ::OpenNebula::VirtualNetworkPool.new(client)
+          if filter[:id].nil?
+            netpool.info!(-2,-1,-1)
+          elsif filter[:id]
+            filter[:id] = filter[:id].to_i if filter[:id].is_a?(String)
+            netpool.info!(-2, filter[:id], filter[:id])
+          end # if filter[:id].nil?
+
           netpool.each do |network| 
-	    networks << network_to_attributes(network.to_hash)
-	  end
+            if filter[:network] && filter[:network].is_a?(String) && !filter[:network].empty?
+              next if network.to_hash["VNET"]["NAME"] != filter[:network]
+            end
+            if filter[:network_uname] && filter[:network_uname].is_a?(String) && !filter[:network_uname].empty?
+              next if network.to_hash["VNET"]["UNAME"] != filter[:network_uname]
+            end
+            if filter[:network_uid] && filter[:network_uid].is_a?(String) && !filter[:network_uid].empty?
+              next if network.to_hash["VNET"]["UID"] != filter[:network_uid]
+            end
+            networks << network_to_attributes(network.to_hash)
+          end
           networks
         end
 
         def network_to_attributes(net)
           return if net.nil?
-	  #{"VNET"=>{"ID"=>"155", "UID"=>"0", "GID"=>"1", "UNAME"=>"oneadmin", "GNAME"=>"users", "NAME"=>"vlan99-2", "PERMISSIONS"=>{"OWNER_U"=>"1", "OWNER_M"=>"1", "OWNER_A"=>"0", "GROUP_U"=>"1", "GROUP_M"=>"0", "GROUP_A"=>"0", "OTHER_U"=>"0", "OTHER_M"=>"0", "OTHER_A"=>"0"}, "CLUSTER_ID"=>"-1", "CLUSTER"=>{}, "TYPE"=>"0", "BRIDGE"=>"ovsbr", "VLAN"=>"1", "PHYDEV"=>{}, "VLAN_ID"=>"99", "GLOBAL_PREFIX"=>{}, "SITE_PREFIX"=>{}, "RANGE"=>{"IP_START"=>"10.10.99.127", "IP_END"=>"10.10.99.249"}, "TOTAL_LEASES"=>"0", "TEMPLATE"=>{"DESCRIPTION"=>"test", "NETWORK_ADDRESS"=>"10.10.99.0", "NETWORK_MASK"=>"255.255.255.0"}}}
           h = {
-            :id    	 => net["VNET"]["ID"],
-            :name  	 => net["VNET"]["NAME"],
-	    :uid   	 => net["VNET"]["UID"],
-	    :gid   	 => net["VNET"]["GID"],
+            :id   => net["VNET"]["ID"],
+            :name => net["VNET"]["NAME"],
+            :uid  => net["VNET"]["UID"],
+            :gid  => net["VNET"]["GID"],
           }
 
-	  h[:description] = net["VNET"]["TEMPLATE"]["DESCRIPTION"] unless net["VNET"]["TEMPLATE"]["DESCRIPTION"].nil?
-	  h[:vlan] 	  = net["VNET"]["VLAN_ID"] unless (net["VNET"]["VLAN_ID"].nil? || net["VNET"]["VLAN_ID"].empty?)
+          h[:description] = net["VNET"]["TEMPLATE"]["DESCRIPTION"] unless net["VNET"]["TEMPLATE"]["DESCRIPTION"].nil?
+          h[:vlan] 	      = net["VNET"]["VLAN_ID"] unless (net["VNET"]["VLAN_ID"].nil? || net["VNET"]["VLAN_ID"].empty?)
 
-	  return h
+          return h
         end
 
       end
@@ -49,12 +56,12 @@ module Fog
 
         def mock_network name
           {
-            :id    	 => "5",
-            :name  	 => name,
-	    :uid   	 => "5",
-	    :gid   	 => "5",
-	    :description => "netDescription",
-	    :vlan	 => "5"
+            :id    	     => "5",
+            :name  	     => name,
+            :uid   	     => "5",
+            :gid   	     => "5",
+            :description => "netDescription",
+            :vlan	       => "5"
           }
         end
       end

--- a/lib/fog/opennebula/requests/compute/template_pool.rb
+++ b/lib/fog/opennebula/requests/compute/template_pool.rb
@@ -41,7 +41,13 @@ module Fog
             # filtering by name
             # done here, because OpenNebula:TemplatePool does not support something like .delete_if
             if filter[:name] && filter[:name].is_a?(String) && !filter[:name].empty?
-                next if t.to_hash["VMTEMPLATE"]["NAME"] != filter[:name]
+              next if t.to_hash["VMTEMPLATE"]["NAME"] != filter[:name]
+            end
+            if filter[:uname] && filter[:uname].is_a?(String) && !filter[:uname].empty?
+              next if t.to_hash["VMTEMPLATE"]["UNAME"] != filter[:uname]
+            end
+            if filter[:uid] && filter[:uid].is_a?(String) && !filter[:uid].empty?
+              next if t.to_hash["VMTEMPLATE"]["UID"] != filter[:uid]
             end
 
             h = Hash[
@@ -62,8 +68,14 @@ module Fog
               end
             elsif nics.is_a? Hash
               nics["model"] = "virtio" if nics["model"].nil?
-              nics["uuid"] = "0" if nics["uuid"].nil? # is it better is to remove this NIC?
-              h["NIC"] << interfaces.new({ :vnet => networks.get(nics["uuid"]), :model => nics["model"]})
+              #nics["uuid"] = "0" if nics["uuid"].nil? # is it better is to remove this NIC?
+              n = networks.get_by_filter({
+                :id => nics["NETWORK_ID"],
+                :network => nics["NETWORK"],
+                :network_uname => nics["NETWORK_UNAME"],
+                :network_uid => nics["NETWORK_UID"]
+              })
+              h["NIC"] << interfaces.new({ :vnet => n })
             else
               # should i break?
             end


### PR DESCRIPTION
This patch improves Fog's OpenNebula support in a number of ways:
Better NIC support in VM templates
Better ability to tune number of CPUs and memory
Ability to add/remove entries from a VM template's context section
Ability to add/remove entries from a VM template's user variables
Improved filtering for templates and NICs
