### PR TITLE
#3258 - allow modification of ConnectionSettings.IdleTimeout parameter in AWS ELBs

### DIFF
--- a/lib/fog/aws/models/elb/load_balancer.rb
+++ b/lib/fog/aws/models/elb/load_balancer.rb
@@ -61,6 +61,17 @@ module Fog
           service.modify_load_balancer_attributes(id, 'CrossZoneLoadBalancing' => {'Enabled' => value})
         end
 
+        def connection_settings_idle_timeout
+          requires :id
+          service.describe_load_balancer_attributes(id).body['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['ConnectionSettings']['IdleTimeout']
+        end
+
+        def set_connection_settings_idle_timeout(timeout=60)
+          requires :id
+          attrs = {'IdleTimeout' => timeout}
+          service.modify_load_balancer_attributes(id,'ConnectionSettings' => attrs)
+        end
+
         def register_instances(instances)
           requires :id
           data = service.register_instances_with_load_balancer(instances, id).body['RegisterInstancesWithLoadBalancerResult']

--- a/lib/fog/aws/parsers/elb/describe_load_balancer_attributes.rb
+++ b/lib/fog/aws/parsers/elb/describe_load_balancer_attributes.rb
@@ -15,6 +15,8 @@ module Fog
               @connection_draining = {}
             when 'CrossZoneLoadBalancing'
               @cross_zone_load_balancing = {}
+            when 'ConnectionSettings'
+              @connection_settings = {}
             end
           end
 
@@ -26,6 +28,8 @@ module Fog
               elsif @connection_draining
                 @connection_draining['Enabled'] = value == 'true' ? true : false
               end
+            when 'IdleTimeout'
+              @connection_settings['IdleTimeout'] = value.to_i
             when 'Timeout'
               if @connection_draining
                 @connection_draining['Timeout'] = value.to_i
@@ -36,6 +40,9 @@ module Fog
             when 'CrossZoneLoadBalancing'
               @response['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['CrossZoneLoadBalancing'] = @cross_zone_load_balancing
               @cross_zone_load_balancing = nil
+            when 'ConnectionSettings'
+              @response['DescribeLoadBalancerAttributesResult']['LoadBalancerAttributes']['ConnectionSettings'] = @connection_settings
+              @connection_settings = nil
             when 'RequestId'
               @response['ResponseMetadata'][name] = value
             end

--- a/lib/fog/aws/requests/elb/create_load_balancer.rb
+++ b/lib/fog/aws/requests/elb/create_load_balancer.rb
@@ -174,7 +174,8 @@ module Fog
             'ListenerDescriptions' => listeners,
             'LoadBalancerAttributes' => {
               'ConnectionDraining' => {'Enabled' => false, 'Timeout' => 300},
-              'CrossZoneLoadBalancing' => {'Enabled' => false}
+              'CrossZoneLoadBalancing' => {'Enabled' => false},
+              'ConnectionSettings' => {'IdleTimeout' => 60}
             },
             'LoadBalancerName' => lb_name,
             'Policies' => {

--- a/lib/fog/aws/requests/elb/describe_load_balancer_attributes.rb
+++ b/lib/fog/aws/requests/elb/describe_load_balancer_attributes.rb
@@ -21,6 +21,9 @@ module Fog
         #           * 'Timeout'<~Integer> - max time (in seconds) to keep existing conns open before deregistering instances.
         #         * 'CrossZoneLoadBalancing'<~Hash>
         #           * 'Enabled'<~Boolean> - whether crosszone load balancing is enabled
+        #         * 'ConnectionSettings'<~Hash>
+        #           * 'IdleTimeout'<~Integer> - time (in seconds) the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.
+
         def describe_load_balancer_attributes(lb_name)
           request({
             'Action'  => 'DescribeLoadBalancerAttributes',

--- a/lib/fog/aws/requests/elb/modify_load_balancer_attributes.rb
+++ b/lib/fog/aws/requests/elb/modify_load_balancer_attributes.rb
@@ -6,8 +6,12 @@ module Fog
 
         # Sets attributes of the load balancer
         #
-        # Currently the only attributes that can be set are whether CrossZoneLoadBalancing
-        # or ConnectionDraining are enabled. You can also set the Timeout for ConnectionDraining.
+        # The following attributes can be set:
+        # * CrossZoneLoadBalancing (enable/disable)
+        # * ConnectionDraining (enable/disable and timeout)
+        # * Idle Connection Timeouts
+        #
+        # Still requires: AccessLog configuration
         #
         # http://docs.aws.amazon.com/ElasticLoadBalancing/latest/APIReference/API_ModifyLoadBalancerAttributes.html
         # ==== Parameters
@@ -18,6 +22,8 @@ module Fog
         #     * 'Timeout'<~Integer> max time to keep existing conns open before deregistering instances
         #   * 'CrossZoneLoadBalancing'<~Hash>:
         #     * 'Enabled'<~Boolean> whether to enable cross zone load balancing
+        #   * 'ConnectionSettings'<~Hash>:
+        #     * 'IdleTimeout'<~Integer> time (in seconds) the connection is allowed to be idle (no data has been sent over the connection) before it is closed by the load balancer.
         #
         # ==== Returns
         # * response<~Excon::Response>:
@@ -38,7 +44,7 @@ module Fog
         def modify_load_balancer_attributes(lb_name, attributes)
           raise Fog::AWS::ELB::NotFound unless load_balancer = self.data[:load_balancers][lb_name]
 
-          if attributes['CrossZoneLoadBalancing'] || attributes['ConnectionDraining']
+          if attributes['CrossZoneLoadBalancing'] || attributes['ConnectionDraining'] || attributes['ConnectionSettings']
             load_balancer['LoadBalancerAttributes'].merge! attributes
           end
 

--- a/tests/aws/models/elb/model_tests.rb
+++ b/tests/aws/models/elb/model_tests.rb
@@ -221,6 +221,12 @@ Shindo.tests('AWS::ELB | models', ['aws', 'elb']) do
       returns(true) {elb.cross_zone_load_balancing?}
     end
 
+    tests('idle_connection_settings') do
+      returns(60) { elb.connection_settings_idle_timeout }
+      elb.set_connection_settings_idle_timeout(180)
+      returns(180) { elb.connection_settings_idle_timeout }
+    end
+
     tests('default health check') do
       default_health_check = {
         "HealthyThreshold"=>10,

--- a/tests/aws/requests/elb/load_balancer_tests.rb
+++ b/tests/aws/requests/elb/load_balancer_tests.rb
@@ -39,7 +39,8 @@ Shindo.tests('AWS::ELB | load_balancer_tests', ['aws', 'elb']) do
     tests("modify_load_balancer_attributes") do
       attributes = {
         'ConnectionDraining' => {'Enabled' => true, 'Timeout' => 600},
-        'CrossZoneLoadBalancing' => {'Enabled' => true}
+        'CrossZoneLoadBalancing' => {'Enabled' => true},
+        'ConnectionSettings' => {'IdleTimeout' => 180}
       }
       Fog::AWS[:elb].modify_load_balancer_attributes(@load_balancer_id, attributes).body
       response = Fog::AWS[:elb].describe_load_balancer_attributes(@load_balancer_id).
@@ -50,6 +51,9 @@ Shindo.tests('AWS::ELB | load_balancer_tests', ['aws', 'elb']) do
       end
       tests("ConnectionDraining has a 600 second Timeout").returns(600) do
         response['ConnectionDraining']['Timeout']
+      end
+      tests("ConnectionSettings has a 180 second IdleTimeout").returns(180) do
+        response['ConnectionSettings']['IdleTimeout']
       end
       tests("CrossZoneLoadBalancing is enabled") do
         response['CrossZoneLoadBalancing']['Enabled'] == true


### PR DESCRIPTION
This PR adds functionality to AWS::ELB module for adjusting ConnectionSettings.IdleTimeout via AWS::ELB.ModifyLoadBalanceAttributes
