### PR TITLE
Bump the API version for DynamoDB put

### DIFF
--- a/lib/fog/aws/requests/dynamodb/put_item.rb
+++ b/lib/fog/aws/requests/dynamodb/put_item.rb
@@ -30,7 +30,7 @@ module Fog
 
           request(
             :body       => Fog::JSON.encode(body),
-            :headers    => {'x-amz-target' => 'DynamoDB_20111205.PutItem'}
+            :headers    => {'x-amz-target' => 'DynamoDB_20120810.PutItem'}
           )
         end
       end


### PR DESCRIPTION
Increment the DynamoDB put item API version to allow for more data types to be used. (L, M, etc.). All the data types are listed here: http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_AttributeValue.html
