### PR TITLE
Updating authentication functions to prevent sending expired token.

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -380,7 +380,7 @@ module Fog
             options = {
               :openstack_api_key    => @openstack_api_key,
               :openstack_username   => @openstack_username,
-              :openstack_auth_token => @auth_token,
+              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @auth_token,
               :openstack_auth_uri   => @openstack_auth_uri,
               :openstack_region     => @openstack_region,
               :openstack_tenant     => @openstack_tenant,

--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -255,7 +255,7 @@ module Fog
             options = {
               :openstack_api_key  => @openstack_api_key,
               :openstack_username => @openstack_username,
-              :openstack_auth_token => @openstack_auth_token,
+              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_tenant   => @openstack_tenant,
               :openstack_service_type => @openstack_service_type,

--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -179,7 +179,7 @@ module Fog
               :openstack_username => @openstack_username,
               :openstack_auth_uri => @openstack_auth_uri,
               :openstack_region   => @openstack_region,
-              :openstack_auth_token => @openstack_auth_token,
+              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
               :openstack_endpoint_type => @openstack_endpoint_type

--- a/lib/fog/openstack/metering.rb
+++ b/lib/fog/openstack/metering.rb
@@ -172,7 +172,7 @@ module Fog
               :openstack_api_key  => @openstack_api_key,
               :openstack_username => @openstack_username,
               :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_auth_token,
+              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
               :openstack_endpoint_type => @openstack_endpoint_type

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -314,7 +314,7 @@ module Fog
               :openstack_api_key  => @openstack_api_key,
               :openstack_username => @openstack_username,
               :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_auth_token,
+              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
               :openstack_endpoint_type => @openstack_endpoint_type,

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -176,7 +176,7 @@ module Fog
             options = {
               :openstack_api_key    => @openstack_api_key,
               :openstack_username   => @openstack_username,
-              :openstack_auth_token => @auth_token,
+              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @auth_token,
               :openstack_auth_uri   => @openstack_auth_uri,
               :openstack_region     => @openstack_region,
               :openstack_tenant     => @openstack_tenant,

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -193,7 +193,7 @@ module Fog
               :openstack_api_key  => @openstack_api_key,
               :openstack_username => @openstack_username,
               :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_auth_token,
+              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,
               :openstack_endpoint_type => @openstack_endpoint_type


### PR DESCRIPTION
When the Keystone token expires the existing OpenStack code sends in the expired token along with the re-authentication request.  Unfortunately, newer versions of Keystone error out with a "token not found" error when sending an expired token as a parameter, and logically it makes no sense to do so.

This code change will send nil instead of the expired token only in the case where we are re-authenticating and a new token will be retrieved and all calls will carry on as before.  The option to initially authenticate with a valid token still works with no changes.
