### PR TITLE
Handle Docker authentication errors

### DIFF
--- a/lib/fog/fogdocker/compute.rb
+++ b/lib/fog/fogdocker/compute.rb
@@ -42,6 +42,8 @@ module Fog
 
           Docker.url = url
           Docker.authenticate!('username' => username, 'password' => password, 'email' => email) unless username.nil? || username.empty?
+        rescue Docker::Error::AuthenticationError => e
+          raise Fog::Errors::Fogdocker::AuthenticationError.new(e.message)
         end
 
         def downcase_hash_keys(hash, k = [])

--- a/lib/fog/fogdocker/errors.rb
+++ b/lib/fog/fogdocker/errors.rb
@@ -2,7 +2,7 @@ module Fog
   module Errors
     module Fogdocker
       class ServiceError < Fog::Errors::Error; end
-      class AuthenticationError < ServiceError; end
+      class AuthenticationError < Fog::Errors::Fogdocker::ServiceError; end
     end
   end
 end

--- a/lib/fog/fogdocker/requests/compute/container_action.rb
+++ b/lib/fog/fogdocker/requests/compute/container_action.rb
@@ -17,7 +17,7 @@ module Fog
         rescue Docker::Error::TimeoutError => e
           raise Fog::Errors::Error::TimeoutError.new(e.message)
         rescue Docker::Error::UnauthorizedError => e
-          raise Fog::Errors::Fogdocker::ServiceError::AuthenticationError.new(e.message)
+          raise Fog::Errors::Fogdocker::AuthenticationError.new(e.message)
         rescue Docker::Error::DockerError => e
           raise Fog::Errors::Fogdocker::ServiceError.new(e.message)
         end


### PR DESCRIPTION
Fog was not handling at all the error returned by docker-api. This
commit fixes that and raises an AuthenticationError that can be caught
by Fog clients.

There was a bug in the errors code for container_action that this PR
fixes too.
