### PR TITLE
[Docker] Environment variables support

### DIFF
--- a/lib/fog/fogdocker/models/compute/server.rb
+++ b/lib/fog/fogdocker/models/compute/server.rb
@@ -36,6 +36,7 @@ module Fog
         attribute :image
         attribute :exposed_ports,               :aliases => 'config_exposed_ports'
         attribute :volumes
+        attribute :environment_variables,       :aliases => 'config_env'
 
         #raw = {"ID"=>"2ce79789656e4f7474624be6496dc6d988899af30d556574389a19aade2f9650",
         # "Created"=>"2014-01-16T12:42:38.081665295Z",
@@ -53,6 +54,9 @@ module Fog
         #     "AttachStderr"=>true,
         #     "PortSpecs"=>nil,
         #     "ExposedPorts"=>{},
+        #     "Env": [
+        #         "HOME=/mydir",
+        #     ],
         # "State"=>{
         #     "Running"=>true,
         #     "Pid"=>1505,

--- a/lib/fog/fogdocker/requests/compute/container_get.rb
+++ b/lib/fog/fogdocker/requests/compute/container_get.rb
@@ -40,6 +40,7 @@ module Fog
            'config_exposed_ports'       => { "29321/tcp" => {}, "39212/tcp" => {} },
            'sizerw'                     => 0,
            'sizerootfs'                 => 0,
+           'environment_variables'      => ["HOME=/mydir", "SAMPLEENV=samplevalue"],
            'name'                       => '123123123',
            'names'                      =>  ['/boring_engelbert']}
         end

--- a/tests/fogdocker/models/compute/server_tests.rb
+++ b/tests/fogdocker/models/compute/server_tests.rb
@@ -37,7 +37,8 @@ Shindo.tests('Fog::Compute[:fogdocker] | server model', ['fogdocker']) do
                      :privileged,
                      :tty,
                      :exposed_ports,
-                     :volumes
+                     :volumes,
+                     :environment_variables
       ]
       tests("The server model should respond to") do
         attributes.each do |attribute|


### PR DESCRIPTION
This allows the Docker provider to fetch env variables from docker and set them as an array, i.e:

```
container.environment_variables = ['foo=bar', 'baz=qux']
```
