### PR TITLE
[Docker] Parse properly ports and links attributes

### DIFF
--- a/lib/fog/fogdocker/models/compute/server.rb
+++ b/lib/fog/fogdocker/models/compute/server.rb
@@ -14,15 +14,24 @@ module Fog
         attribute :path
         attribute :args
         attribute :hostname
+        attribute :links,                       :aliases => 'hostconfig_links'
+        attribute :privileged,                  :aliases => 'hostconfig_privileged'
+        attribute :port_bindings,               :aliases => 'hostconfig_port_bindings'
         attribute :ipaddress,                   :aliases => 'network_settings_ipaddress'
         attribute :bridge,                      :aliases => 'network_settings_bridge'
         attribute :state_running
         attribute :state_pid
-        attribute :cores,                       :aliases => 'config_cpu_shares'
+        attribute :state_exit_code
+        attribute :cores,                       :aliases => 'config_cpu_sets'
+        attribute :cpu_shares,                  :aliases => 'config_cpu_shares'
         attribute :memory,                      :aliases => 'config_memory'
         attribute :hostname,                    :aliases => 'config_hostname'
         attribute :cmd,                         :aliases => 'config_cmd'
         attribute :entrypoint,                  :aliases => 'config_entrypoint'
+        attribute :tty,                         :aliases => 'config_tty'
+        attribute :attach_stdin,                :aliases => 'config_attach_stdin'
+        attribute :attach_stdout,               :aliases => 'config_attach_stdout'
+        attribute :attach_stderr,               :aliases => 'config_attach_stderr'
         attribute :host
         attribute :image
         attribute :exposed_ports,               :aliases => 'config_exposed_ports'

--- a/lib/fog/fogdocker/requests/compute/container_get.rb
+++ b/lib/fog/fogdocker/requests/compute/container_get.rb
@@ -3,26 +3,45 @@ module Fog
     class Fogdocker
       class Real
         def container_get(id)
-          downcase_hash_keys Docker::Container.get(id).json
+          raw_container = Docker::Container.get(id).json
+          processed_container = downcase_hash_keys(raw_container)
+          processed_container['hostconfig_port_bindings'] = raw_container['HostConfig']['PortBindings']
+          processed_container['hostconfig_links']         = raw_container['HostConfig']['Links']
+          processed_container['config_exposed_ports']     = raw_container['Config']['ExposedPorts']
+          processed_container
         end
       end
       class Mock
         def container_get(id)
-          {'id'         => '2ce79789656e4f7474624be6496dc6d988899af30d556574389a19aade2f9650',
-           'image'      => 'mattdm/fedora:f19',
-           'command'    => '/bin/bash',
-           'created'    => '1389876158',
-           'status'     => 'Up 45 hours',
+          {'id'                         => '2ce79789656e4f7474624be6496dc6d988899af30d556574389a19aade2f9650',
+           'image'                      => 'mattdm/fedora:f19',
+           'command'                    => '/bin/bash',
+           'created'                    => '1389876158',
+           'status'                     => 'Up 45 hours',
            'state_running'              => true,
-           'config_cpu_shares'          => '1',
            'network_settings_ipaddress' => '172.17.0.2',
            'config_memory'              => '1024',
+           'config_cpu_sets'            => '0-3',
+           'config_cpu_shares'          => '20',
            'config_hostname'            => '21341234',
-           'ports'      =>  nil,
-           'sizerw'     =>  0,
-           'sizerootfs' =>  0,
-           'name'       => '123123123',
-           'names'      =>  ['/boring_engelbert']}
+           'config_attach_stdin'        => true,
+           'config_attach_stdout'       => true,
+           'config_attach_stderr'       => true,
+           'ports'                      => nil,
+           'config_tty'                 => true,
+           'hostconfig_privileged'      => true,
+           'hostconfig_links'           => nil,
+           'hostconfig_port_bindings'   => { "29321/tcp" => [{"HostIp"=>"", "HostPort"=>"3001"}],
+                                             "39212/tcp" => [{"HostIp"=>"", "HostPort"=>"2030"}]},
+           'state_exit_code'            => 0,
+           'state_pid'                  => 2932,
+           'cpu_shares'                 => 0,
+           'volumes'                    => nil,
+           'config_exposed_ports'       => { "29321/tcp" => {}, "39212/tcp" => {} },
+           'sizerw'                     => 0,
+           'sizerootfs'                 => 0,
+           'name'                       => '123123123',
+           'names'                      =>  ['/boring_engelbert']}
         end
       end
     end

--- a/tests/fogdocker/models/compute/server_tests.rb
+++ b/tests/fogdocker/models/compute/server_tests.rb
@@ -22,12 +22,22 @@ Shindo.tests('Fog::Compute[:fogdocker] | server model', ['fogdocker']) do
                      :created,
                      :ipaddress,
                      :state_running,
-                     :cores,
                      :memory,
+                     :cores,
+                     :cpu_shares,
                      :hostname,
                      :image,
-                     #:exposed_ports,
-                     #:volumes
+                     :attach_stdin,
+                     :attach_stdout,
+                     :attach_stderr,
+                     :state_exit_code,
+                     :state_pid,
+                     :port_bindings,
+                     :links,
+                     :privileged,
+                     :tty,
+                     :exposed_ports,
+                     :volumes
       ]
       tests("The server model should respond to") do
         attributes.each do |attribute|


### PR DESCRIPTION
Hash based attributes were not parsed properly by container_get. This
patch fixes that and adds support for tty, attach_stdin, attach_stdout,
attach_stderr, links, port bindings and exposed ports.
