### PR TITLE
Rescue "Illegal Seek" exception in case body is a pipe or socket

### DIFF
--- a/lib/fog/aws/models/storage/file.rb
+++ b/lib/fog/aws/models/storage/file.rb
@@ -257,7 +257,9 @@ module Fog
           # TODO: optionally upload chunks in parallel using threads
           # (may cause network performance problems with many small chunks)
           # TODO: Support large chunk sizes without reading the chunk into memory
-          body.rewind if body.respond_to?(:rewind)
+          if body.respond_to?(:rewind)
+            body.rewind  rescue nil
+          end
           while (chunk = body.read(multipart_chunk_size)) do
             md5 = Base64.encode64(Digest::MD5.digest(chunk)).strip
             part_upload = service.upload_part(directory.key, key, upload_id, part_tags.size + 1, chunk, 'Content-MD5' => md5 )


### PR DESCRIPTION
As for Glacier, this is needed for when an unseekable IO is passed in for the body (e.g. end of a Pipe or socket).
