### PR TITLE
Do not throw a warning about falling back to path_style

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -220,13 +220,15 @@ module Fog
             bucket_name = params[:bucket_name]
 
             path_style = params.fetch(:path_style, @path_style)
-            if !path_style && COMPLIANT_BUCKET_NAMES !~ bucket_name
-              Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
-              path_style = true
-            elsif scheme == 'https' && bucket_name =~ /\./
-              Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
-              path_style = true
-            end  
+            if !path_style
+              if COMPLIANT_BUCKET_NAMES !~ bucket_name
+                Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
+                path_style = true
+              elsif scheme == 'https' && bucket_name =~ /\./
+                Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
+                path_style = true
+              end  
+            end
 
             if path_style
               path = bucket_to_path bucket_name, path


### PR DESCRIPTION
... if the user has already explicitly specified path_style.  Dots are, after all, a perfectly valid thing to have in a bucket name).
