### PR TITLE
Fix deprecation warning.

### DIFF
--- a/lib/fog/openstack/models/network/floating_ips.rb
+++ b/lib/fog/openstack/models/network/floating_ips.rb
@@ -20,7 +20,7 @@ module Fog
         end
 
         def get(floating_network_id)
-          if floating_ip = connection.get_floating_ip(floating_network_id).body['floatingip']
+          if floating_ip = service.get_floating_ip(floating_network_id).body['floatingip']
             new(floating_ip)
           end
         rescue Fog::Network::OpenStack::NotFound


### PR DESCRIPTION
```
[fog][DEPRECATION] #connection is deprecated, use #service instead (/home/rails/stronghold/vendor/bundle/ruby/2.1.0/gems/fog-1.22.1/lib/fog/openstack/models/network/floating_ips.rb:23:in `get')
```
