### PR TITLE
Fix typo: Fog::Connection is deprecated, not Fog::XML::Connection.

### DIFF
--- a/lib/fog/core/deprecated/connection.rb
+++ b/lib/fog/core/deprecated/connection.rb
@@ -14,9 +14,9 @@ module Fog
   class Connection < Fog::XML::Connection
     def request(params, &block)
       if params.key?(:parser)
-        Fog::Logger.deprecation("Fog::XML::Connection is deprecated use Fog::XML::Connection instead [light_black](#{caller.first})[/]")
+        Fog::Logger.deprecation("Fog::Connection is deprecated use Fog::XML::Connection instead [light_black](#{caller.first})[/]")
       else
-        Fog::Logger.deprecation("Fog::XML::Connection is deprecated use Fog::Core::Connection instead [light_black](#{caller.first})[/]")
+        Fog::Logger.deprecation("Fog::Connection is deprecated use Fog::Core::Connection instead [light_black](#{caller.first})[/]")
       end
       super(params)
     end


### PR DESCRIPTION
Commit 0e1daf3d did a mass rename and accidentally renamed the intended deprecated method.

@tokengeek I'm new to the fog codebase but judging the commit and the CHANGELOG, I believe this PR is correct.  Can you review this please?
Thanks!
