### PR TITLE
cloudinit to customspec support

### DIFF
--- a/lib/fog/google/models/compute/images.rb
+++ b/lib/fog/google/models/compute/images.rb
@@ -17,7 +17,8 @@ module Fog
           'google-containers',
           'opensuse-cloud',
           'rhel-cloud',
-          'suse-cloud'
+          'suse-cloud',
+          'ubuntu-os-cloud'
         ]
 
         def all

--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -41,6 +41,7 @@ module Fog
 
       request_path 'fog/vsphere/requests/compute'
       request :current_time
+      request :cloudinit_to_customspec
       request :list_virtual_machines
       request :vm_power_off
       request :vm_power_on

--- a/lib/fog/vsphere/requests/compute/cloudinit_to_customspec.rb
+++ b/lib/fog/vsphere/requests/compute/cloudinit_to_customspec.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def cloudinit_to_customspec(user_data)
+          raise ArgumentError, "user_data cant be nil" if user_data.nil?
+          custom_spec = { 'customization_spec' => Hash.new }
+          user_data = YAML.load(user_data)
+          custom_spec['hostname']                    =  user_data['hostname'] if user_data.key?('hostname')
+          custom_spec['ipsettings']                  =  { 'ip' => user_data['ip'] } if user_data.key?('ip')
+          custom_spec['ipsettings']['subnetMask']    =  user_data['netmask'] if user_data.key?('netmask')
+          custom_spec['ipsettings']['dnsServerList'] =  user_data['dns'] if user_data.key?('dns')
+          custom_spec['domain']                      =  user_data['domain'] if user_data.key?('domain')
+          custom_spec['dnsSuffixList']               =  user_data['domain'] if user_data.key?('domain')
+          custom_spec['time_zone']                   =  user_data['timezone'] if user_data.key?('timezone')
+          custom_spec           
+        end
+      end
+
+      class Mock
+        def cloudinit_to_customspec(user_data)
+          raise ArgumentError, "user_data cant be nil" if user_data.nil?
+          true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
this PR adds a function to parse a user_data cloudinit like string ( as could be sent from foreman) and convert it to an hash usable as customisationspec