### PR TITLE
Enhance images details call by query

### DIFF
--- a/lib/fog/openstack/models/image/images.rb
+++ b/lib/fog/openstack/models/image/images.rb
@@ -11,8 +11,8 @@ module Fog
           load(service.list_public_images_detailed.body['images'])
         end
 
-        def details
-          load(service.list_public_images_detailed.body['images'])
+        def details(attribute=nil, query=nil)
+          load(service.list_public_images_detailed(attribute, query).body['images'])
         end
 
         def find_by_id(id)


### PR DESCRIPTION
The images.details method needs to support the query parameter.
There is no other way how to pass the query into the images
collection.
