### PR TITLE
[Openstack|Compute|Volume] Ensure #attach succeeds and lists one attachment

### DIFF
--- a/lib/fog/openstack/models/compute/volume.rb
+++ b/lib/fog/openstack/models/compute/volume.rb
@@ -39,7 +39,6 @@ module Fog
         def attach(server_id, name)
           requires :id
           data = service.attach_volume(id, server_id, name)
-          merge_attributes(:attachments => attachments << data.body['volumeAttachment'])
           true
         end
 

--- a/tests/openstack/requests/compute/volume_tests.rb
+++ b/tests/openstack/requests/compute/volume_tests.rb
@@ -25,6 +25,16 @@ Shindo.tests('Fog::Compute[:openstack] | volume requests', ['openstack']) do
       Fog::Compute[:openstack].list_volumes.body
     end
 
+    tests('#attach').succeeds do
+      server_id = compute.create_server("test", get_image_ref, get_flavor_ref).body['server']['id']
+      volume    = compute.volumes.all.first
+      volume.attach(server_id, "vda")
+    end
+
+    tests('#attachments has one attachment').succeeds do
+      compute.volumes.all.first.attachments.length == 1
+    end
+
     tests('#get_volume_detail').data_matches_schema({'volume' => @volume_format}) do
       volume_id = Fog::Compute[:openstack].volumes.all.first.id
       Fog::Compute[:openstack].get_volume_details(volume_id).body


### PR DESCRIPTION
Previously, inspecting the test objects would show 2 attachments per
server for every time the #attach was called.