### PR TITLE
Revert "Moved to Fog::Core"

### DIFF
--- a/bin/fog
+++ b/bin/fog
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'fog'))
+require 'optparse'
+require 'irb'
+require 'yaml'
+
+options = OptionParser.new do |opts|
+  opts.banner = 'usage: fog [options] CREDENTIAL'
+
+  opts.on('-C', '--credentials-path FILE', 'Path to the credentials file') do |file|
+    Fog.credentials_path = file
+  end
+
+  opts.on_tail('-v', '--version', 'Prints the version') do
+    puts Fog::VERSION
+    exit
+  end
+
+  opts.on_tail('-h', '--help', 'Prints this message') do
+    puts opts
+    exit
+  end
+end
+options.parse!
+
+Fog.credential = ARGV.first ? ARGV.first.to_sym : nil
+Fog.mock! if ENV['FOG_MOCK']
+if Fog.credentials.empty?
+  begin
+    Fog::Errors.missing_credentials
+  rescue Fog::Errors::LoadError => error
+    abort error.message
+  end
+end
+
+require 'fog/bin'
+
+providers = Fog.available_providers
+providers = if providers.length > 1
+  providers[0...-1].join(', ') << ' and ' << providers[-1]
+else
+  providers.first
+end
+
+if ARGV.length > 1
+
+  result = instance_eval(ARGV[1..-1].join(' '))
+  puts(Fog::JSON.encode(result))
+
+else
+
+  ARGV.clear # Avoid passing args to IRB
+  IRB.setup(nil)
+  @irb = IRB::Irb.new(nil)
+  IRB.conf[:MAIN_CONTEXT] = @irb.context
+  IRB.conf[:PROMPT][:FOG] = IRB.conf[:PROMPT][:SIMPLE].dup
+  IRB.conf[:PROMPT][:FOG][:RETURN] = "%s\n"
+  @irb.context.prompt_mode = :FOG
+  @irb.context.workspace = IRB::WorkSpace.new(binding)
+
+  trap 'INT' do
+    @irb.signal_handle
+  end
+
+  Formatador.display_line('Welcome to fog interactive!')
+  Formatador.display_line(":#{Fog.credential} provides #{providers}")
+  providers = Fog.providers
+
+  # FIXME: hacks until we can `include Fog` in bin
+  CDN     = Fog::CDN
+  Compute = Fog::Compute
+  DNS     = Fog::DNS
+  Storage = Fog::Storage
+
+  catch(:IRB_EXIT) { @irb.eval_input }
+
+end

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.require_paths = %w[lib]
 
   ## If your gem includes any executables, list them here.
-  # s.executables = ["fog"]
+  s.executables = ["fog"]
 
   ## Specify any RDoc options here. You'll want to add your README and
   ## LICENSE files to the extra_rdoc_files list.

--- a/lib/fog/bin.rb
+++ b/lib/fog/bin.rb
@@ -1,0 +1,98 @@
+require 'fog/core/credentials'
+
+module Fog
+  class << self
+    def available_providers
+      @available_providers ||= Fog.providers.values.select {|provider| Kernel.const_get(provider).available?}.sort
+    end
+
+    def registered_providers
+      @registered_providers ||= Fog.providers.values.sort
+    end
+  end
+
+  class Bin
+    class << self
+      def available?
+        availability = true
+        for service in services
+          begin
+            service = self.class_for(service)
+            availability &&= service.requirements.all? { |requirement| Fog.credentials.include?(requirement) }
+          rescue ArgumentError => e
+            Fog::Logger.warning(e.message)
+            availability = false
+          rescue => e
+            availability = false
+          end
+        end
+
+        if availability
+          for service in services
+            for collection in self.class_for(service).collections
+              unless self.respond_to?(collection)
+                self.class_eval <<-EOS, __FILE__, __LINE__
+                  def self.#{collection}
+                    self[:#{service}].#{collection}
+                  end
+                EOS
+              end
+            end
+          end
+        end
+
+        availability
+      end
+
+      def collections
+        services.map {|service| self[service].collections}.flatten.sort_by {|service| service.to_s}
+      end
+    end
+  end
+end
+
+require 'fog/bin/atmos'
+require 'fog/bin/aws'
+require 'fog/bin/bluebox'
+require 'fog/bin/brightbox'
+require 'fog/bin/cloudstack'
+require 'fog/bin/clodo'
+require 'fog/bin/digitalocean'
+require 'fog/bin/dnsimple'
+require 'fog/bin/dnsmadeeasy'
+require 'fog/bin/fogdocker'
+require 'fog/bin/dreamhost'
+require 'fog/bin/dynect'
+require 'fog/bin/ecloud'
+require 'fog/bin/glesys'
+require 'fog/bin/go_grid'
+require 'fog/bin/google'
+require 'fog/bin/hp'
+require 'fog/bin/ibm'
+require 'fog/bin/internet_archive'
+require 'fog/bin/joyent'
+require 'fog/bin/libvirt'
+require 'fog/bin/linode'
+require 'fog/bin/local'
+require 'fog/bin/bare_metal_cloud'
+require 'fog/bin/ninefold'
+require 'fog/bin/rage4'
+require 'fog/bin/riakcs'
+require 'fog/bin/openstack'
+require 'fog/bin/ovirt'
+require 'fog/bin/profitbricks'
+require 'fog/bin/sakuracloud'
+require 'fog/bin/serverlove'
+require 'fog/bin/softlayer'
+require 'fog/bin/storm_on_demand'
+require 'fog/bin/terremark'
+require 'fog/bin/vcloud'
+require 'fog/bin/vcloud_director'
+require 'fog/bin/vmfusion'
+require 'fog/bin/vsphere'
+require 'fog/bin/voxel'
+require 'fog/bin/xenserver'
+require 'fog/bin/zerigo'
+require 'fog/bin/cloudsigma'
+require 'fog/bin/openvz'
+require 'fog/bin/opennebula'

--- a/lib/fog/bin/atmos.rb
+++ b/lib/fog/bin/atmos.rb
@@ -1,0 +1,29 @@
+class Atmos < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :storage
+        Fog::Storage::Atmos
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :storage
+          Fog::Logger.warning("Atmos[:storage] is not recommended, use Storage[:atmos] for portability")
+          Fog::Storage.new(:provider => 'Atmos')
+        else
+          raise ArgumentError, "Unrecognized service: #{service}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Atmos.services
+    end
+  end
+end

--- a/lib/fog/bin/aws.rb
+++ b/lib/fog/bin/aws.rb
@@ -1,0 +1,121 @@
+class AWS < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :auto_scaling
+        Fog::AWS::AutoScaling
+      when :beanstalk
+        Fog::AWS::ElasticBeanstalk
+      when :cdn
+        Fog::CDN::AWS
+      when :cloud_formation
+        Fog::AWS::CloudFormation
+      when :cloud_watch
+        Fog::AWS::CloudWatch
+      when :compute
+        Fog::Compute::AWS
+      when :data_pipeline
+        Fog::AWS::DataPipeline
+      when :ddb, :dynamodb
+        Fog::AWS::DynamoDB
+      when :dns
+        Fog::DNS::AWS
+      when :elasticache
+        Fog::AWS::Elasticache
+      when :elb
+        Fog::AWS::ELB
+      when :emr
+        Fog::AWS::EMR
+      when :glacier
+        Fog::AWS::Glacier
+      when :iam
+        Fog::AWS::IAM
+      when :redshift
+        Fog::AWS::Redshift
+      when :sdb, :simpledb
+        Fog::AWS::SimpleDB
+      when :ses
+        Fog::AWS::SES
+      when :sqs
+        Fog::AWS::SQS
+      when :eu_storage, :storage
+        Fog::Storage::AWS
+      when :rds
+        Fog::AWS::RDS
+      when :sns
+        Fog::AWS::SNS
+      when :sts
+        Fog::AWS::STS
+      else
+        # @todo Replace most instances of ArgumentError with NotImplementedError
+        # @todo For a list of widely supported Exceptions, see:
+        # => http://www.zenspider.com/Languages/Ruby/QuickRef.html#35
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :auto_scaling
+          Fog::AWS::AutoScaling.new
+        when :beanstalk
+          Fog::AWS::ElasticBeanstalk.new
+        when :cdn
+          Fog::Logger.warning("AWS[:cdn] is not recommended, use CDN[:aws] for portability")
+          Fog::CDN.new(:provider => 'AWS')
+        when :cloud_formation
+          Fog::AWS::CloudFormation.new
+        when :cloud_watch
+          Fog::AWS::CloudWatch.new
+        when :compute
+          Fog::Logger.warning("AWS[:compute] is not recommended, use Compute[:aws] for portability")
+          Fog::Compute.new(:provider => 'AWS')
+        when :data_pipeline
+          Fog::AWS::DataPipeline
+        when :ddb, :dynamodb
+          Fog::AWS::DynamoDB.new
+        when :dns
+          Fog::Logger.warning("AWS[:dns] is not recommended, use DNS[:aws] for portability")
+          Fog::DNS.new(:provider => 'AWS')
+        when :elasticache
+          Fog::AWS::Elasticache.new
+        when :elb
+          Fog::AWS::ELB.new
+        when :emr
+          Fog::AWS::EMR.new
+        when :glacier
+          Fog::AWS::Glacier.new
+        when :iam
+          Fog::AWS::IAM.new
+        when :redshift
+          Fog::AWS::Redshift.new
+        when :rds
+          Fog::AWS::RDS.new
+        when :eu_storage
+          Fog::Storage.new(:provider => 'AWS', :region => 'eu-west-1')
+        when :sdb, :simpledb
+          Fog::AWS::SimpleDB.new
+        when :ses
+          Fog::AWS::SES.new
+        when :sqs
+          Fog::AWS::SQS.new
+        when :storage
+          Fog::Logger.warning("AWS[:storage] is not recommended, use Storage[:aws] for portability")
+          Fog::Storage.new(:provider => 'AWS')
+        when :sns
+          Fog::AWS::SNS.new
+        when :sts
+          Fog::AWS::STS.new
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::AWS.services
+    end
+  end
+end

--- a/lib/fog/bin/bare_metal_cloud.rb
+++ b/lib/fog/bin/bare_metal_cloud.rb
@@ -1,0 +1,29 @@
+class BareMetalCloud < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::BareMetalCloud
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("BareMetalCloud[:compute] is not recommended, use Compute[:baremetalcloud] for portability")
+          Fog::Compute.new(:provider => 'BareMetalCloud')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::BareMetalCloud.services
+    end
+  end
+end

--- a/lib/fog/bin/bluebox.rb
+++ b/lib/fog/bin/bluebox.rb
@@ -1,0 +1,36 @@
+class Bluebox < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Bluebox
+      when :dns
+        Fog::DNS::Bluebox
+      when :blb
+        Fog::Bluebox::BLB
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Bluebox[:compute] is not recommended, use Compute[:bluebox] for portability")
+          Fog::Compute.new(:provider => 'Bluebox')
+        when :dns
+          Fog::Logger.warning("Bluebox[:dns] is not recommended, use DNS[:bluebox] for portability")
+          Fog::DNS.new(:provider => 'Bluebox')
+        else
+          raise ArgumentError, "Unrecognized service: #{service}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Bluebox.services
+    end
+  end
+end

--- a/lib/fog/bin/brightbox.rb
+++ b/lib/fog/bin/brightbox.rb
@@ -1,0 +1,35 @@
+class Brightbox < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Brightbox
+      when :storage
+        Fog::Storage::Brightbox
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Brightbox[:compute] is not recommended, use Compute[:brightbox] for portability")
+          Fog::Compute.new(:provider => 'Brightbox')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def account
+      @@connections[:compute].account
+    end
+
+    def services
+      Fog::Brightbox.services
+    end
+  end
+end

--- a/lib/fog/bin/clodo.rb
+++ b/lib/fog/bin/clodo.rb
@@ -1,0 +1,29 @@
+class Clodo < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Clodo
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Formatador.display_line("[yellow][WARN] Clodo[:compute] is deprecated, use Compute[:clodo] instead[/]")
+          Fog::Compute.new(:provider => 'Clodo')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Clodo.services
+    end
+  end
+end

--- a/lib/fog/bin/cloudsigma.rb
+++ b/lib/fog/bin/cloudsigma.rb
@@ -1,0 +1,28 @@
+class CloudSigma < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+        when :compute
+          Fog::Compute::CloudSigma
+        else
+          raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+                      when :compute
+                        Fog::Compute.new(:provider => 'CloudSigma')
+                      else
+                        raise ArgumentError, "Unrecognized service: #{key.inspect}"
+                    end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::CloudSigma.services
+    end
+  end
+end

--- a/lib/fog/bin/cloudstack.rb
+++ b/lib/fog/bin/cloudstack.rb
@@ -1,0 +1,28 @@
+class Cloudstack < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Cloudstack
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Compute.new(:provider => 'Cloudstack')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Cloudstack.services
+    end
+  end
+end

--- a/lib/fog/bin/digitalocean.rb
+++ b/lib/fog/bin/digitalocean.rb
@@ -1,0 +1,29 @@
+class DigitalOcean < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::DigitalOcean
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("DigitalOcean[:compute] is not recommended, use Compute[:digitalocean] for portability")
+          Fog::Compute.new(:provider => 'DigitalOcean')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::DigitalOcean.services
+    end
+  end
+end

--- a/lib/fog/bin/dnsimple.rb
+++ b/lib/fog/bin/dnsimple.rb
@@ -1,0 +1,29 @@
+class DNSimple < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :dns
+        Fog::DNS::DNSimple
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :dns
+          Fog::Logger.warning("DNSimple[:dns] is not recommended, use DNS[:dnsimple] for portability")
+          Fog::DNS.new(:provider => 'DNSimple')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::DNSimple.services
+    end
+  end
+end

--- a/lib/fog/bin/dnsmadeeasy.rb
+++ b/lib/fog/bin/dnsmadeeasy.rb
@@ -1,0 +1,29 @@
+class DNSMadeEasy < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :dns
+        Fog::DNS::DNSMadeEasy
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :dns
+          Fog::Logger.warning("DNSMadeEasy[:dns] is not recommended, use DNS[:dnsmadeeasy] for portability")
+          Fog::DNS.new(:provider => 'DNSMadeEasy')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::DNSMadeEasy.services
+    end
+  end
+end

--- a/lib/fog/bin/dreamhost.rb
+++ b/lib/fog/bin/dreamhost.rb
@@ -1,0 +1,29 @@
+class Dreamhost < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :dns
+        Fog::DNS::Dreamhost
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :dns
+          Fog::Logger.warning("Dreamhost[:dns] is not recommended, use DNS[:dreamhost] for portability")
+          Fog::DNS.new(:provider => 'Dreamhost')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Dreamhost.services
+    end
+  end
+end

--- a/lib/fog/bin/dynect.rb
+++ b/lib/fog/bin/dynect.rb
@@ -1,0 +1,28 @@
+class Dynect < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :dns
+        Fog::DNS::Dynect
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :dns
+          Fog::DNS.new(:provider => 'Dynect')
+        else
+          raise ArgumentError, "Unrecognized service: #{service}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      [:dns]
+    end
+  end
+end

--- a/lib/fog/bin/fogdocker.rb
+++ b/lib/fog/bin/fogdocker.rb
@@ -1,0 +1,28 @@
+class Fogdocker < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Fogdocker
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+                    when :compute
+                      Fog::Compute.new(:provider => 'Fogdocker')
+                    else
+                      raise ArgumentError, "Unrecognized service: #{key.inspect}"
+                    end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Fogdocker.services
+    end
+  end
+end

--- a/lib/fog/bin/glesys.rb
+++ b/lib/fog/bin/glesys.rb
@@ -1,0 +1,29 @@
+class Glesys < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Glesys
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Glesys[:compute] is not recommended, use Compute[:glesys] for portability")
+          Fog::Compute.new(:provider => 'Glesys')
+        else
+          raise ArgumentError, "Unrecognized service: #{service}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Glesys.services
+    end
+  end
+end

--- a/lib/fog/bin/go_grid.rb
+++ b/lib/fog/bin/go_grid.rb
@@ -1,0 +1,29 @@
+class GoGrid < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::GoGrid
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("GoGrid[:compute] is not recommended, use Compute[:gogrid] for portability")
+          Fog::Compute.new(:provider => 'GoGrid')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::GoGrid.services
+    end
+  end
+end

--- a/lib/fog/bin/google.rb
+++ b/lib/fog/bin/google.rb
@@ -1,0 +1,88 @@
+module Google # deviates from other bin stuff to accomodate gem
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Google
+      when :dns
+        Fog::DNS::Google
+      when :monitoring
+        Fog::Google::Monitoring
+      when :storage
+        Fog::Storage::Google
+      when :sql
+        Fog::Google::SQL
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Google[:compute] is not recommended, use Compute[:google] for portability")
+          Fog::Compute.new(:provider => 'Google')
+        when :dns
+          Fog::Logger.warning("Google[:dns] is not recommended, use DNS[:google] for portability")
+          Fog::DNS.new(:provider => 'Google')
+        when :monitoring
+          Fog::Google::Monitoring.new
+        when :sql
+          Fog::Google::SQL.new
+        when :storage
+          Fog::Logger.warning("Google[:storage] is not recommended, use Storage[:google] for portability")
+          Fog::Storage.new(:provider => 'Google')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def account
+      @@connections[:compute].account
+    end
+
+    def services
+      Fog::Google.services
+    end
+
+    # based off of virtual_box.rb
+    def available?
+      # Make sure the gem we use is enabled.
+      availability = if Gem::Specification.respond_to?(:find_all_by_name)
+        !Gem::Specification.find_all_by_name('google-api-client').empty? # newest rubygems
+      else
+        !Gem.source_index.find_name('google-api-client').empty? # legacy
+      end
+      # Then make sure we have all of the requirements
+      for service in services
+        begin
+          service = self.class_for(service)
+          availability &&= service.requirements.all? { |requirement| Fog.credentials.include?(requirement) }
+        rescue ArgumentError => e
+          Fog::Logger.warning(e.message)
+          availability = false
+        rescue => e
+          availability = false
+        end
+      end
+
+      if availability
+        for service in services
+          for collection in self.class_for(service).collections
+            unless self.respond_to?(collection)
+              self.class_eval <<-EOS, __FILE__, __LINE__
+                def self.#{collection}
+                  self[:#{service}].#{collection}
+                end
+              EOS
+            end
+          end
+        end
+      end
+      availability
+    end
+  end
+end

--- a/lib/fog/bin/hp.rb
+++ b/lib/fog/bin/hp.rb
@@ -1,0 +1,60 @@
+class HP < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :block_storage
+        Fog::HP::BlockStorage
+      when :block_storage_v2
+        Fog::HP::BlockStorageV2
+      when :cdn
+        Fog::CDN::HP
+      when :compute
+        Fog::Compute::HP
+      when :dns
+        Fog::HP::DNS
+      when :lb
+        Fog::HP::LB
+      when :network
+        Fog::HP::Network
+      when :storage
+        Fog::Storage::HP
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :block_storage
+          Fog::Logger.deprecation "HP Cloud Block Storage V1 service will be soon deprecated. Please use `Fog::HP::BlockStorageV2` provider to use latest HP Cloud Block Storage service."
+          Fog::HP::BlockStorage.new
+        when :block_storage_v2
+          Fog::HP::BlockStorageV2.new
+        when :cdn
+          Fog::Logger.warning("HP[:cdn] is deprecated, use CDN[:hp] instead")
+          Fog::CDN.new(:provider => 'HP')
+        when :compute
+          Fog::Logger.warning("HP[:compute] is deprecated, use Compute[:hp] instead")
+          Fog::Compute.new(:provider => 'HP')
+        when :dns
+          Fog::HP::DNS.new
+        when :lb
+          Fog::HP::LB.new
+        when :network
+          Fog::HP::Network.new
+        when :storage
+          Fog::Logger.warning("HP[:storage] is deprecated, use Storage[:hp] instead")
+          Fog::Storage.new(:provider => 'HP')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::HP.services
+    end
+  end
+end

--- a/lib/fog/bin/ibm.rb
+++ b/lib/fog/bin/ibm.rb
@@ -1,0 +1,32 @@
+class IBM < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::IBM
+      when :storage
+        Fog::Storage::IBM
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Compute.new(:provider => 'IBM')
+        when :storage
+          Fog::Storage.new(:provider => 'Storage')
+        else
+          raise ArgumentError, "Unrecognized service: #{service}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::IBM.services
+    end
+  end
+end

--- a/lib/fog/bin/internet_archive.rb
+++ b/lib/fog/bin/internet_archive.rb
@@ -1,0 +1,32 @@
+class InternetArchive < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :storage
+        Fog::Storage::InternetArchive
+      else
+        # @todo Replace most instances of ArgumentError with NotImplementedError
+        # @todo For a list of widely supported Exceptions, see:
+        # => http://www.zenspider.com/Languages/Ruby/QuickRef.html#35
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :storage
+          Fog::Logger.warning("InternetArchive[:storage] is not recommended, use Storage[:aws] for portability")
+          Fog::Storage.new(:provider => 'InternetArchive')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::InternetArchive.services
+    end
+  end
+end

--- a/lib/fog/bin/joyent.rb
+++ b/lib/fog/bin/joyent.rb
@@ -1,0 +1,33 @@
+class Joyent < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Joyent
+      when :analytics
+        Fog::Joyent::Analytics
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Joyent[:compute] is not recommended, use Compute[:joyent] for portability")
+          Fog::Compute.new(:provider => 'Joyent')
+        when :analytics
+          Fog::Joyent::Analytics.new
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Joyent.services
+    end
+  end
+end

--- a/lib/fog/bin/libvirt.rb
+++ b/lib/fog/bin/libvirt.rb
@@ -1,0 +1,58 @@
+module Libvirt # deviates from other bin stuff to accomodate gem
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Libvirt
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Libvirt[:compute] is not recommended, use Compute[:libvirt] for portability")
+          Fog::Compute.new(:provider => 'Libvirt')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def available?
+      begin
+        availability=true unless Gem::Specification::find_by_name("ruby-libvirt").nil?
+      rescue Gem::LoadError
+        availability=false
+      rescue
+        availability_gem=Gem.available?("ruby-libvirt")
+      end
+
+      if availability
+        for service in services
+          for collection in self.class_for(service).collections
+            unless self.respond_to?(collection)
+              self.class_eval <<-EOS, __FILE__, __LINE__
+                def self.#{collection}
+                  self[:#{service}].#{collection}
+                end
+              EOS
+            end
+          end
+        end
+      end
+      availability
+    end
+
+    def collections
+      services.map {|service| self[service].collections}.flatten.sort_by {|service| service.to_s}
+    end
+
+    def services
+      Fog::Libvirt.services
+    end
+  end
+end

--- a/lib/fog/bin/linode.rb
+++ b/lib/fog/bin/linode.rb
@@ -1,0 +1,34 @@
+class Linode < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Linode
+      when :dns
+        Fog::DNS::Linode
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Linode[:compute] is not recommended, use Compute[:linode] for portability")
+          Fog::Compute.new(:provider => 'Linode')
+        when :dns
+          Fog::Logger.warning("Linode[:dns] is not recommended, use DNS[:linode] for portability")
+          Fog::DNS.new(:provider => 'Linode')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Linode.services
+    end
+  end
+end

--- a/lib/fog/bin/local.rb
+++ b/lib/fog/bin/local.rb
@@ -1,0 +1,29 @@
+class Local < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :storage
+        Fog::Storage::Local
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :storage
+          Fog::Logger.warning("Local[:storage] is not recommended, use Storage[:local] for portability")
+          Fog::Storage.new(:provider => 'Local')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Local.services
+    end
+  end
+end

--- a/lib/fog/bin/ninefold.rb
+++ b/lib/fog/bin/ninefold.rb
@@ -1,0 +1,34 @@
+class Ninefold < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Ninefold
+      when :storage
+        Fog::Storage::Ninefold
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Ninefold[:compute] is not recommended, use Compute[:ninefold] for portability")
+          Fog::Compute.new(:provider => 'Ninefold')
+        when :storage
+          Fog::Logger.warning("Ninefold[:storage] is not recommended, use Storage[:ninefold] for portability")
+          Fog::Storage.new(:provider => 'Ninefold')
+        else
+          raise ArgumentError, "Unrecognized service: #{service}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Ninefold.services
+    end
+  end
+end

--- a/lib/fog/bin/opennebula.rb
+++ b/lib/fog/bin/opennebula.rb
@@ -1,0 +1,60 @@
+module OpenNebula # deviates from other bin stuff to accomodate gem
+  class << self
+
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::OpenNebula
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("OpenNebula[:compute] is not recommended, use Compute[:opennebula] for portability")
+          Fog::Compute.new(:provider => 'OpenNebula')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def available?
+      begin
+        availability=true unless Gem::Specification::find_by_name("opennebula").nil?
+      rescue Gem::LoadError
+        availability=false
+      rescue
+        availability_gem=Gem.available?("opennebula")
+      end
+
+      if availability
+        for service in services
+          for collection in self.class_for(service).collections
+            unless self.respond_to?(collection)
+              self.class_eval <<-EOS, __FILE__, __LINE__
+                def self.#{collection}
+                  self[:#{service}].#{collection}
+                end
+              EOS
+            end
+          end
+        end
+      end
+      availability
+    end
+
+    def collections
+      services.map {|service| self[service].collections}.flatten.sort_by {|service| service.to_s}
+    end
+
+    def services
+      Fog::OpenNebula.services
+    end
+
+  end
+end

--- a/lib/fog/bin/openstack.rb
+++ b/lib/fog/bin/openstack.rb
@@ -1,0 +1,64 @@
+class OpenStack < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::OpenStack
+      when :identity
+        Fog::Identity::OpenStack
+      when :image
+        Fog::Image::OpenStack
+      when :network
+        Fog::Network::OpenStack
+      when :storage
+        Fog::Storage::OpenStack
+      when :volume
+        Fog::Volume::OpenStack
+      when :metering
+        Fog::Metering::OpenStack
+      when :orchestration
+        Fog::Orchestration::OpenStack
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("OpenStack[:compute] is not recommended, use Compute[:openstack] for portability")
+          Fog::Compute.new(:provider => 'OpenStack')
+        when :identity
+          Fog::Logger.warning("OpenStack[:identity] is not recommended, use Identity[:openstack] for portability")
+          Fog::Identity.new(:provider => 'OpenStack')
+        when :image
+          Fog::Logger.warning("OpenStack[:image] is not recommended, use Image[:openstack] for portability")
+          Fog::Image.new(:provider => 'OpenStack')
+        when :network
+          Fog::Logger.warning("OpenStack[:network] is not recommended, use Network[:openstack] for portability")
+          Fog::Network.new(:provider => 'OpenStack')
+        when :storage
+          Fog::Logger.warning("OpenStack[:storage] is not recommended, use Storage[:openstack] for portability")
+          Fog::Storage.new(:provider => 'OpenStack')
+        when :volume
+          Fog::Logger.warning("OpenStack[:volume] is not recommended, use Volume[:openstack] for portability")
+          Fog::Volume.new(:provider => 'OpenStack')
+        when :metering
+          Fog::Logger.warning("OpenStack[:metering] is not recommended, use Metering[:openstack] for portability")
+          Fog::Metering.new(:provider => 'OpenStack')
+        when :orchestration
+          Fog::Logger.warning("OpenStack[:orchestration] is not recommended, use Orchestration[:openstack] for portability")
+          Fog::Orchestration.new(:provider => 'OpenStack')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::OpenStack.services
+    end
+  end
+end

--- a/lib/fog/bin/openvz.rb
+++ b/lib/fog/bin/openvz.rb
@@ -1,0 +1,29 @@
+class Openvz < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Openvz
+      else
+        raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Openvz[:compute] is not recommended, use Compute[:openvz] for portability")
+          Fog::Compute.new(:provider => 'Openvz')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Openvz.services
+    end
+  end
+end

--- a/lib/fog/bin/ovirt.rb
+++ b/lib/fog/bin/ovirt.rb
@@ -1,0 +1,28 @@
+class Ovirt < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Ovirt
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+                    when :compute
+                      Fog::Compute.new(:provider => 'Ovirt')
+                    else
+                      raise ArgumentError, "Unrecognized service: #{key.inspect}"
+                    end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Ovirt.services
+    end
+  end
+end

--- a/lib/fog/bin/rage4.rb
+++ b/lib/fog/bin/rage4.rb
@@ -1,0 +1,29 @@
+class Rage4 < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :dns
+        Fog::DNS::Rage4
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :dns
+          Fog::Logger.warning("Rage4[:dns] is not recommended, use DNS[:rage4] for portability")
+          Fog::DNS.new(:provider => 'Rage4')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Rage4.services
+    end
+  end
+end

--- a/lib/fog/bin/riakcs.rb
+++ b/lib/fog/bin/riakcs.rb
@@ -1,0 +1,25 @@
+class RiakCS < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :provisioning
+        Fog::RiakCS::Provisioning
+      when :usage
+        Fog::RiakCS::Usage
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = class_for(key)
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::RiakCS.services
+    end
+  end
+end

--- a/lib/fog/bin/serverlove.rb
+++ b/lib/fog/bin/serverlove.rb
@@ -1,0 +1,29 @@
+class Serverlove < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Serverlove
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("Serverlove[:compute] is not recommended, use Compute[:serverlove] for portability")
+          Fog::Compute.new(:provider => 'Serverlove')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Serverlove.services
+    end
+  end
+end

--- a/lib/fog/bin/softlayer.rb
+++ b/lib/fog/bin/softlayer.rb
@@ -1,0 +1,53 @@
+#
+# Author:: Matt Eldridge (<matt.eldridge@us.ibm.com>)
+# © Copyright IBM Corporation 2014.
+#
+# LICENSE: MIT (http://opensource.org/licenses/MIT)
+#
+
+class Softlayer < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+        when :compute
+          Fog::Compute::Softlayer
+        when :dns
+          Fog::DNS::Softlayer
+        when :network
+          Fog::Network::Softlayer
+        when :storage
+          Fog::Storage::Softlayer
+        else
+          # @todo Replace most instances of ArgumentError with NotImplementedError
+          # @todo For a list of widely supported Exceptions, see:
+          # => http://www.zenspider.com/Languages/Ruby/QuickRef.html#35
+          raise ArgumentError, "Unsupported #{self} service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+                      when :compute
+                        Fog::Logger.warning("Softlayer[:compute] is not recommended, use Compute[:aws] for portability")
+                        Fog::Compute.new(:provider => :softlayer)
+                      when :dns
+                        Fog::Logger.warning("Softlayer[:dns] is not recommended, use DNS[:aws] for portability")
+                        Fog::DNS.new(:provider => :softlayer)
+                      when :network
+                        Fog::Network.new(:provider => :softlayer)
+                      when :storage
+                        Fog::Storage.new(:provider => :softlayer)
+                      else
+                        raise ArgumentError, "Unrecognized service: #{key.inspect}"
+                    end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Softlayer.services
+    end
+  end
+end
+

--- a/lib/fog/bin/vcloud.rb
+++ b/lib/fog/bin/vcloud.rb
@@ -1,0 +1,28 @@
+class Vcloud < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Vcloud::Compute
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Compute.new(:provider => 'Vcloud')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Vcloud.services
+    end
+  end
+end

--- a/lib/fog/bin/vcloud_director.rb
+++ b/lib/fog/bin/vcloud_director.rb
@@ -1,0 +1,28 @@
+class VcloudDirector < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::VcloudDirector
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Compute.new(:provider => 'VcloudDirector')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::VcloudDirector.services
+    end
+  end
+end

--- a/lib/fog/bin/vsphere.rb
+++ b/lib/fog/bin/vsphere.rb
@@ -1,0 +1,28 @@
+class Vsphere < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::Vsphere
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Compute.new(:provider => 'Vsphere')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Vsphere.services
+    end
+  end
+end

--- a/lib/fog/bin/xenserver.rb
+++ b/lib/fog/bin/xenserver.rb
@@ -1,0 +1,29 @@
+class XenServer < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :compute
+        Fog::Compute::XenServer
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :compute
+          Fog::Logger.warning("XenServer[:compute] is not recommended, use Compute[:xenserver] for portability")
+          Fog::Compute.new(:provider => 'XenServer')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::XenServer.services
+    end
+  end
+end

--- a/lib/fog/bin/zerigo.rb
+++ b/lib/fog/bin/zerigo.rb
@@ -1,0 +1,29 @@
+class Zerigo < Fog::Bin
+  class << self
+    def class_for(key)
+      case key
+      when :dns
+        Fog::DNS::Zerigo
+      else
+        raise ArgumentError, "Unrecognized service: #{key}"
+      end
+    end
+
+    def [](service)
+      @@connections ||= Hash.new do |hash, key|
+        hash[key] = case key
+        when :dns
+          Fog::Logger.warning("Zerigo[:dns] is not recommended, use DNS[:zerigo] for portability")
+          Fog::DNS.new(:provider => 'Zerigo')
+        else
+          raise ArgumentError, "Unrecognized service: #{key.inspect}"
+        end
+      end
+      @@connections[service]
+    end
+
+    def services
+      Fog::Zerigo.services
+    end
+  end
+end

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -2,7 +2,7 @@ ENV['FOG_RC']         = ENV['FOG_RC'] || File.expand_path('../.fog', __FILE__)
 ENV['FOG_CREDENTIAL'] = ENV['FOG_CREDENTIAL'] || 'default'
 
 require 'fog'
-require 'fog/core/bin' # for available_providers and registered_providers
+require 'fog/bin' # for available_providers and registered_providers
 
 Excon.defaults.merge!(:debug_request => true, :debug_response => true)
 


### PR DESCRIPTION
This reverts commit 44dacc062d645c002f1bf2b5729237c01137c63c.

See fog/fog#3302 for details of problems

Locally the Shindo tests fail due to changes introduced in
https://github.com/fog/fog/pull/3304
