### PR TITLE
Include ovirt_ca_no_verify option.

### DIFF
--- a/lib/fog/ovirt/compute.rb
+++ b/lib/fog/ovirt/compute.rb
@@ -5,7 +5,7 @@ module Fog
     class Ovirt < Fog::Service
       requires   :ovirt_username, :ovirt_password
       recognizes :ovirt_url,      :ovirt_server,  :ovirt_port, :ovirt_api_path, :ovirt_datacenter,
-                 :ovirt_ca_cert_store, :ovirt_ca_cert_file
+                 :ovirt_ca_cert_store, :ovirt_ca_cert_file, :ovirt_ca_no_verify
 
       model_path 'fog/ovirt/models/compute'
       model      :server


### PR DESCRIPTION
Add support for rbovirt ca_no_verify connection option through ovirt_ca_no_verify.

I tried to look around at the test cases to figure out how to add a test case for the new option, but couldn't find a good way to do that. No tests added. All current mock tests for ovirt pass.
