### PR TITLE
[vSphere]: Add full path to cluster

### DIFF
--- a/lib/fog/vsphere/models/compute/cluster.rb
+++ b/lib/fog/vsphere/models/compute/cluster.rb
@@ -9,6 +9,7 @@ module Fog
         attribute :num_host
         attribute :num_cpu_cores
         attribute :overall_status
+        attribute :full_path
 
         def resource_pools(filters = { })
           self.attributes[:resource_pools] ||= id.nil? ? [] : service.resource_pools({

--- a/lib/fog/vsphere/requests/compute/list_clusters.rb
+++ b/lib/fog/vsphere/requests/compute/list_clusters.rb
@@ -31,11 +31,17 @@ module Fog
           {
             :id             => managed_obj_id(cluster),
             :name           => cluster.name,
+            :full_path      => cluster_path(cluster, datacenter_name),
             :num_host       => cluster.summary.numHosts,
             :num_cpu_cores  => cluster.summary.numCpuCores,
             :overall_status => cluster.summary.overallStatus,
             :datacenter     => datacenter_name || parent_attribute(cluster.path, :datacenter)[1],
           }
+        end
+
+        def cluster_path(cluster, datacenter_name)
+          datacenter = find_raw_datacenter(datacenter_name)
+          cluster.pretty_path.gsub(/(#{datacenter.name}|#{datacenter.hostFolder.name})\//,'')
         end
       end
 


### PR DESCRIPTION
The reason for adding full path:
refs: [foreman bug #8581](http://projects.theforeman.org/issues/8581)
When trying to create a new vm, and the cluster in under a folder:
DataCenter -> Folder -> Cluster
The creation will fail, as it is not finding the cluster.
In order to find the cluster, apparently we need to provide the path including the folders. (the issue is actually an issue with rbvmomi, but not trying to change that, atm.)
So, when trying to create a vm, when I have provided "Cluster" as my cluster it failed to create the vm (`unknown method 'resourcePool' for nil class`). When I have provided "Folder/Cluster" the vm was created.
Initially, I have planned to change the `name` attribute to return the full path (folder/cluster) as if it has no folders above it will return only the cluster - but am not sure if it will break others code.
With the new attribute, in Foreman, I am going to change to something like [psuedo:] `cluster.name = cluster.pull_path`, so I'll be able to create the vm from foreman.
