### PR TITLE
[aws|put_object] guard against non-us_ascii x-amz-meta-* values

### DIFF
--- a/lib/fog/aws/requests/storage/put_object.rb
+++ b/lib/fog/aws/requests/storage/put_object.rb
@@ -26,6 +26,7 @@ module Fog
         # @see http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTObjectPUT.html
 
         def self.conforming_to_us_ascii!(keys, hash)
+          return if RUBY_VERSION =~ /^1\.8\./
           keys.each do |k|
             v = hash[k]
             if !v.encode(::Encoding::US_ASCII, :undef => :replace).eql?(v)

--- a/tests/aws/requests/storage/object_tests.rb
+++ b/tests/aws/requests/storage/object_tests.rb
@@ -18,6 +18,12 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
       Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file)
     end
 
+    if RUBY_VERSION =~ /^1\.8\./
+      tests("#put_object('#{@directory.identity}', 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'}").succeeds do
+        Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'})
+      end
+    end
+
     tests("#copy_object('#{@directory.identity}', 'fog_object', '#{@directory.identity}', 'fog_other_object')").succeeds do
       Fog::Storage[:aws].copy_object(@directory.identity, 'fog_object', @directory.identity, 'fog_other_object')
     end
@@ -126,8 +132,10 @@ Shindo.tests('AWS::Storage | object requests', ['aws']) do
       Fog::Storage[:aws].put_object(fognonbucket, 'fog_non_object', lorem_file)
     end
 
-    tests("#put_object('#{@directory.identity}', 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'}").raises(Excon::Errors::BadRequest) do
-      Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'})
+    unless RUBY_VERSION =~ /^1\.8\./
+      tests("#put_object('#{@directory.identity}', 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'}").raises(Excon::Errors::BadRequest) do
+        Fog::Storage[:aws].put_object(@directory.identity, 'fog_object', lorem_file, {'x-amz-meta-json' => 'ä'})
+      end
     end
 
     tests("#copy_object('#{fognonbucket}', 'fog_object', '#{@directory.identity}', 'fog_other_object')").raises(Excon::Errors::NotFound) do


### PR DESCRIPTION
This is a follow up to the discussion in #2942.

As http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html states

>  Each name, value pair must conform to US-ASCII when using REST.

This constraint is especially hard get, since sending non-us_ascii characters in a `x-amz-meta-*` header value simply results in a signing error.
