### PR TITLE
This limits 1.8.7 to use `activesupport-v3.2.21`

### DIFF
--- a/gemfiles/Gemfile-ruby-1.8.7
+++ b/gemfiles/Gemfile-ruby-1.8.7
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem 'activesupport', '~> 3.2'
 gem 'nokogiri', '~>1.5.11'
 gem 'mime-types', '~>1.16'
 gem 'rest-client', '~> 1.6.7'


### PR DESCRIPTION
Versions greater than 4.0 dropped 1.8.7 support but it appears the
Travis build environment just updated so this appeared.
