### PR TITLE
Fix misbehavior around connection to slave node in pool

### DIFF
--- a/lib/fog/xenserver/compute.rb
+++ b/lib/fog/xenserver/compute.rb
@@ -11,7 +11,7 @@ module Fog
       requires :xenserver_url
       recognizes :xenserver_defaults
       recognizes :xenserver_timeout
-	  recognizes :xenserver_redirect_to_master
+      recognizes :xenserver_redirect_to_master
 
       model_path 'fog/xenserver/models/compute'
       model :blob
@@ -114,28 +114,28 @@ module Fog
       request :snapshot_revert
 
       class Real
-          
+
         attr_reader :connection
 
         def initialize(options={})
-          @host        				= options[:xenserver_url]
-          @username    				= options[:xenserver_username]
-          @password    				= options[:xenserver_password]
-          @defaults    				= options[:xenserver_defaults] || {}
-          @timeout     				= options[:xenserver_timeout] || 30
-		  @redirect_to_master     	= options[:xenserver_redirect_to_master] || false
-		  @connection  				= Fog::XenServer::Connection.new(@host, @timeout)
-		  
+          @host                 = options[:xenserver_url]
+          @username             = options[:xenserver_username]
+          @password             = options[:xenserver_password]
+          @defaults             = options[:xenserver_defaults] || {}
+          @timeout              = options[:xenserver_timeout] || 30
+          @redirect_to_master   = options[:xenserver_redirect_to_master] || false
+          @connection           = Fog::XenServer::Connection.new(@host, @timeout)
+
           if @redirect_to_master == false
-				@connection  = Fog::XenServer::Connection.new(@host, @timeout)
-			  elsif @redirect_to_master == true
-				host_master  = @connection.find_pool_master(@username, @password)
-				  if host_master && host_master!= @host
-					@host = host_master;
-					@connection  = Fog::XenServer::Connection.new(@host, @timeout)
-				  end
+            @connection  = Fog::XenServer::Connection.new(@host, @timeout)
+          elsif @redirect_to_master == true
+            host_master  = @connection.find_pool_master(@username, @password)
+            if host_master && host_master!= @host
+              @host = host_master
+              @connection  = Fog::XenServer::Connection.new(@host, @timeout)
+            end
           end
-			@connection.authenticate(@username, @password)
+          @connection.authenticate(@username, @password)
         end
 
         def reload

--- a/lib/fog/xenserver/core.rb
+++ b/lib/fog/xenserver/core.rb
@@ -25,14 +25,14 @@ module Fog
         @credentials = authenticate( username, password )
         response = @factory.call('host.get_all_records', @credentials)
         if response['Status'] == "Failure" 
-			if response['ErrorDescription'][0] == "HOST_IS_SLAVE" 
-				ip_address 	= 	response['ErrorDescription'][1]
-				ip_address	=	ip_address.chomp
-				valid = !(IPAddr.new(ip_address) rescue nil).nil?
-				if valid 
-					response['ErrorDescription'][1]
-				end
-			end
+          if response['ErrorDescription'][0] == "HOST_IS_SLAVE"
+            ip_address  = response['ErrorDescription'][1]
+            ip_address  = ip_address.chomp
+            valid = !(IPAddr.new(ip_address) rescue nil).nil?
+            if valid
+              response['ErrorDescription'][1]
+            end
+          end
         end
       end
 


### PR DESCRIPTION
The idea behind this fix is following:
if u connect to slave node xenserver logic should redirect you to your master, so this code give u this ability. 
Since with current code if u change you master everything stops working since in front of slave it is not possible to perform any commands. 
