### PR TITLE
Remove command gem update from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,3 @@ notifications:
     on_success: always
     on_failure: always
     use_notice: false
-
-before_install:
-  - gem update --system #  todo: workaround for https://github.com/rubygems/rubygems/pull/763


### PR DESCRIPTION
This were being executed to fix an issue related to rubygems
(rubygems/rubygems#763).
This was fixed and merged 1 year ago.
