### PR TITLE
Only show HTTPS bucket name warning when not using path_style

### DIFF
--- a/lib/fog/aws/storage.rb
+++ b/lib/fog/aws/storage.rb
@@ -139,7 +139,7 @@ module Fog
 
         def signed_url(params, expires)
           #convert expires from a point in time to a delta to now
-          now = Fog::Time.now          
+          now = Fog::Time.now
 
           expires = expires.to_i - now.to_i
           params[:headers] ||= {}
@@ -224,10 +224,10 @@ module Fog
               if COMPLIANT_BUCKET_NAMES !~ bucket_name
                 Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) is not a valid dns name, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
                 path_style = true
-              elsif scheme == 'https' && bucket_name =~ /\./
+              elsif scheme == 'https' && !path_style && bucket_name =~ /\./
                 Fog::Logger.warning("fog: the specified s3 bucket name(#{bucket_name}) contains a '.' so is not accessible over https as a virtual hosted bucket, which will negatively impact performance.  For details see: http://docs.amazonwebservices.com/AmazonS3/latest/dev/BucketRestrictions.html")
                 path_style = true
-              end  
+              end
             end
 
             if path_style
@@ -520,7 +520,7 @@ module Fog
             end
             signature_components = @signer.signature_components(params, date, params[:headers]['x-amz-content-sha256'])
             params[:headers]['Authorization'] = @signer.components_to_header(signature_components)
-            
+
             if params[:body].respond_to?(:read)
               body = params.delete :body
               params[:request_block] = S3Streamer.new(body, signature_components['X-Amz-Signature'], @signer, date)
@@ -580,7 +580,7 @@ module Fog
             if body.respond_to?(:binmode)
               body.binmode
             end
-            
+
             if body.respond_to?(:pos=)
               body.pos = 0
             end


### PR DESCRIPTION
Using S3 to host a static website requires you to use dots in the bucket name.
As a result, the logs from using a gem like middleman-s3_sync are littered with
warnings. middleman-s3_sync uses path_style by default, so the warning isn't
really needed.

This changerRemoves the warning about using dot in bucket names if it is
already configured to use path style. This shows a deliberate (and probably
knowledgeable) choice.
