### PR TITLE
[aws] get_topic_attributes handle nil values

### DIFF
--- a/lib/fog/aws/parsers/sns/get_topic_attributes.rb
+++ b/lib/fog/aws/parsers/sns/get_topic_attributes.rb
@@ -16,10 +16,10 @@ module Fog
               when 'SubscriptionsConfirmed', 'SubscriptionsDeleted', 'SubscriptionsPending'
                 @response['Attributes'][@key] = @value.rstrip.to_i
               else
-                @response['Attributes'][@key] = @value.rstrip
+                @response['Attributes'][@key] = (@value && @value.rstrip) || nil
               end
             when 'RequestId'
-              @response[name] = @value
+              @response[name] = @value.rstrip
             end
           end
         end


### PR DESCRIPTION
- also correctly `rstrip` `RequestId`
