### PR TITLE
[AWS] Move key to class mapping to separate file

### DIFF
--- a/lib/fog/aws.rb
+++ b/lib/fog/aws.rb
@@ -1,3 +1,4 @@
+require 'fog/aws/service_mapper'
 require 'fog/aws/auto_scaling'
 require 'fog/aws/beanstalk'
 require 'fog/aws/cdn'

--- a/lib/fog/aws/service_mapper.rb
+++ b/lib/fog/aws/service_mapper.rb
@@ -1,0 +1,129 @@
+module Fog
+  module AWS
+    # @api private
+    #
+    # This is a temporary lookup helper for extracting into external module.
+    #
+    # Cleaner provider/service registration will replace this code.
+    #
+    class ServiceMapper
+      def self.class_for(key)
+        case key
+        when :auto_scaling
+          Fog::AWS::AutoScaling
+        when :beanstalk
+          Fog::AWS::ElasticBeanstalk
+        when :cdn
+          Fog::CDN::AWS
+        when :cloud_formation
+          Fog::AWS::CloudFormation
+        when :cloud_watch
+          Fog::AWS::CloudWatch
+        when :compute
+          Fog::Compute::AWS
+        when :data_pipeline
+          Fog::AWS::DataPipeline
+        when :ddb, :dynamodb
+          Fog::AWS::DynamoDB
+        when :dns
+          Fog::DNS::AWS
+        when :elasticache
+          Fog::AWS::Elasticache
+        when :elb
+          Fog::AWS::ELB
+        when :emr
+          Fog::AWS::EMR
+        when :glacier
+          Fog::AWS::Glacier
+        when :iam
+          Fog::AWS::IAM
+        when :redshift
+          Fog::AWS::Redshift
+        when :sdb, :simpledb
+          Fog::AWS::SimpleDB
+        when :ses
+          Fog::AWS::SES
+        when :sqs
+          Fog::AWS::SQS
+        when :eu_storage, :storage
+          Fog::Storage::AWS
+        when :rds
+          Fog::AWS::RDS
+        when :sns
+          Fog::AWS::SNS
+        when :sts
+          Fog::AWS::STS
+        else
+          # @todo Replace most instances of ArgumentError with NotImplementedError
+          # @todo For a list of widely supported Exceptions, see:
+          # => http://www.zenspider.com/Languages/Ruby/QuickRef.html#35
+          raise ArgumentError, "Unsupported #{self} service: #{key}"
+        end
+      end
+
+      def self.[](service)
+        @@connections ||= Hash.new do |hash, key|
+          hash[key] = case key
+                      when :auto_scaling
+                        Fog::AWS::AutoScaling.new
+                      when :beanstalk
+                        Fog::AWS::ElasticBeanstalk.new
+                      when :cdn
+                        Fog::Logger.warning("AWS[:cdn] is not recommended, use CDN[:aws] for portability")
+                        Fog::CDN.new(:provider => 'AWS')
+                      when :cloud_formation
+                        Fog::AWS::CloudFormation.new
+                      when :cloud_watch
+                        Fog::AWS::CloudWatch.new
+                      when :compute
+                        Fog::Logger.warning("AWS[:compute] is not recommended, use Compute[:aws] for portability")
+                        Fog::Compute.new(:provider => 'AWS')
+                      when :data_pipeline
+                        Fog::AWS::DataPipeline
+                      when :ddb, :dynamodb
+                        Fog::AWS::DynamoDB.new
+                      when :dns
+                        Fog::Logger.warning("AWS[:dns] is not recommended, use DNS[:aws] for portability")
+                        Fog::DNS.new(:provider => 'AWS')
+                      when :elasticache
+                        Fog::AWS::Elasticache.new
+                      when :elb
+                        Fog::AWS::ELB.new
+                      when :emr
+                        Fog::AWS::EMR.new
+                      when :glacier
+                        Fog::AWS::Glacier.new
+                      when :iam
+                        Fog::AWS::IAM.new
+                      when :redshift
+                        Fog::AWS::Redshift.new
+                      when :rds
+                        Fog::AWS::RDS.new
+                      when :eu_storage
+                        Fog::Storage.new(:provider => 'AWS', :region => 'eu-west-1')
+                      when :sdb, :simpledb
+                        Fog::AWS::SimpleDB.new
+                      when :ses
+                        Fog::AWS::SES.new
+                      when :sqs
+                        Fog::AWS::SQS.new
+                      when :storage
+                        Fog::Logger.warning("AWS[:storage] is not recommended, use Storage[:aws] for portability")
+                        Fog::Storage.new(:provider => 'AWS')
+                      when :sns
+                        Fog::AWS::SNS.new
+                      when :sts
+                        Fog::AWS::STS.new
+                      else
+                        raise ArgumentError, "Unrecognized service: #{key.inspect}"
+                      end
+        end
+        @@connections[service]
+      end
+
+      def self.services
+        Fog::AWS.services
+      end
+    end
+  end
+end

--- a/lib/fog/aws/service_mapper.rb
+++ b/lib/fog/aws/service_mapper.rb
@@ -79,7 +79,7 @@ module Fog
                         Fog::Logger.warning("AWS[:compute] is not recommended, use Compute[:aws] for portability")
                         Fog::Compute.new(:provider => 'AWS')
                       when :data_pipeline
-                        Fog::AWS::DataPipeline
+                        Fog::AWS::DataPipeline.new
                       when :ddb, :dynamodb
                         Fog::AWS::DynamoDB.new
                       when :dns

--- a/lib/fog/bin/aws.rb
+++ b/lib/fog/bin/aws.rb
@@ -1,121 +1,13 @@
 class AWS < Fog::Bin
-  class << self
-    def class_for(key)
-      case key
-      when :auto_scaling
-        Fog::AWS::AutoScaling
-      when :beanstalk
-        Fog::AWS::ElasticBeanstalk
-      when :cdn
-        Fog::CDN::AWS
-      when :cloud_formation
-        Fog::AWS::CloudFormation
-      when :cloud_watch
-        Fog::AWS::CloudWatch
-      when :compute
-        Fog::Compute::AWS
-      when :data_pipeline
-        Fog::AWS::DataPipeline
-      when :ddb, :dynamodb
-        Fog::AWS::DynamoDB
-      when :dns
-        Fog::DNS::AWS
-      when :elasticache
-        Fog::AWS::Elasticache
-      when :elb
-        Fog::AWS::ELB
-      when :emr
-        Fog::AWS::EMR
-      when :glacier
-        Fog::AWS::Glacier
-      when :iam
-        Fog::AWS::IAM
-      when :redshift
-        Fog::AWS::Redshift
-      when :sdb, :simpledb
-        Fog::AWS::SimpleDB
-      when :ses
-        Fog::AWS::SES
-      when :sqs
-        Fog::AWS::SQS
-      when :eu_storage, :storage
-        Fog::Storage::AWS
-      when :rds
-        Fog::AWS::RDS
-      when :sns
-        Fog::AWS::SNS
-      when :sts
-        Fog::AWS::STS
-      else
-        # @todo Replace most instances of ArgumentError with NotImplementedError
-        # @todo For a list of widely supported Exceptions, see:
-        # => http://www.zenspider.com/Languages/Ruby/QuickRef.html#35
-        raise ArgumentError, "Unsupported #{self} service: #{key}"
-      end
-    end
+  def self.services
+    Fog::AWS::ServiceMapper.services
+  end
 
-    def [](service)
-      @@connections ||= Hash.new do |hash, key|
-        hash[key] = case key
-        when :auto_scaling
-          Fog::AWS::AutoScaling.new
-        when :beanstalk
-          Fog::AWS::ElasticBeanstalk.new
-        when :cdn
-          Fog::Logger.warning("AWS[:cdn] is not recommended, use CDN[:aws] for portability")
-          Fog::CDN.new(:provider => 'AWS')
-        when :cloud_formation
-          Fog::AWS::CloudFormation.new
-        when :cloud_watch
-          Fog::AWS::CloudWatch.new
-        when :compute
-          Fog::Logger.warning("AWS[:compute] is not recommended, use Compute[:aws] for portability")
-          Fog::Compute.new(:provider => 'AWS')
-        when :data_pipeline
-          Fog::AWS::DataPipeline
-        when :ddb, :dynamodb
-          Fog::AWS::DynamoDB.new
-        when :dns
-          Fog::Logger.warning("AWS[:dns] is not recommended, use DNS[:aws] for portability")
-          Fog::DNS.new(:provider => 'AWS')
-        when :elasticache
-          Fog::AWS::Elasticache.new
-        when :elb
-          Fog::AWS::ELB.new
-        when :emr
-          Fog::AWS::EMR.new
-        when :glacier
-          Fog::AWS::Glacier.new
-        when :iam
-          Fog::AWS::IAM.new
-        when :redshift
-          Fog::AWS::Redshift.new
-        when :rds
-          Fog::AWS::RDS.new
-        when :eu_storage
-          Fog::Storage.new(:provider => 'AWS', :region => 'eu-west-1')
-        when :sdb, :simpledb
-          Fog::AWS::SimpleDB.new
-        when :ses
-          Fog::AWS::SES.new
-        when :sqs
-          Fog::AWS::SQS.new
-        when :storage
-          Fog::Logger.warning("AWS[:storage] is not recommended, use Storage[:aws] for portability")
-          Fog::Storage.new(:provider => 'AWS')
-        when :sns
-          Fog::AWS::SNS.new
-        when :sts
-          Fog::AWS::STS.new
-        else
-          raise ArgumentError, "Unrecognized service: #{key.inspect}"
-        end
-      end
-      @@connections[service]
-    end
+  def self.[](key)
+    Fog::AWS::ServiceMapper[key]
+  end
 
-    def services
-      Fog::AWS.services
-    end
+  def self.class_for(key)
+    Fog::AWS::ServiceMapper.class_for(key)
   end
 end

--- a/spec/fog/bin/aws_spec.rb
+++ b/spec/fog/bin/aws_spec.rb
@@ -7,4 +7,93 @@ describe AWS do
   include Fog::BinSpec
 
   let(:subject) { AWS }
+
+  KEY_CLASS_MAPPING = {
+    :auto_scaling => Fog::AWS::AutoScaling,
+    :beanstalk => Fog::AWS::ElasticBeanstalk,
+    :cdn => Fog::CDN::AWS,
+    :cloud_formation => Fog::AWS::CloudFormation,
+    :cloud_watch => Fog::AWS::CloudWatch,
+    :compute => Fog::Compute::AWS,
+    :data_pipeline => Fog::AWS::DataPipeline,
+    :ddb => Fog::AWS::DynamoDB,
+    :dynamodb => Fog::AWS::DynamoDB,
+    :dns => Fog::DNS::AWS,
+    :elasticache => Fog::AWS::Elasticache,
+    :elb => Fog::AWS::ELB,
+    :emr => Fog::AWS::EMR,
+    :glacier => Fog::AWS::Glacier,
+    :iam => Fog::AWS::IAM,
+    :redshift => Fog::AWS::Redshift,
+    :sdb => Fog::AWS::SimpleDB,
+    :simpledb => Fog::AWS::SimpleDB,
+    :ses => Fog::AWS::SES,
+    :sqs => Fog::AWS::SQS,
+    :eu_storage => Fog::Storage::AWS,
+    :storage => Fog::Storage::AWS,
+    :rds => Fog::AWS::RDS,
+    :sns => Fog::AWS::SNS,
+    :sts => Fog::AWS::STS
+  }
+
+  describe "#services" do
+    it "includes all services" do
+      assert_includes AWS.services, :auto_scaling
+      assert_includes AWS.services, :beanstalk
+      assert_includes AWS.services, :cdn
+      assert_includes AWS.services, :cloud_formation
+      assert_includes AWS.services, :cloud_watch
+      assert_includes AWS.services, :compute
+      assert_includes AWS.services, :data_pipeline
+      assert_includes AWS.services, :dynamodb
+      assert_includes AWS.services, :dns
+      assert_includes AWS.services, :elasticache
+      assert_includes AWS.services, :elb
+      assert_includes AWS.services, :emr
+      assert_includes AWS.services, :glacier
+      assert_includes AWS.services, :iam
+      assert_includes AWS.services, :redshift
+      assert_includes AWS.services, :rds
+      assert_includes AWS.services, :simpledb
+      assert_includes AWS.services, :ses
+      assert_includes AWS.services, :sqs
+      assert_includes AWS.services, :storage
+      assert_includes AWS.services, :sns
+      assert_includes AWS.services, :sts
+    end
+  end
+
+  describe "#class_for" do
+    describe "when key exists" do
+      it "maps to correct class" do
+        KEY_CLASS_MAPPING.each do |key, klass|
+          assert_equal klass, AWS.class_for(key)
+        end
+      end
+    end
+
+    describe "when key does not exist" do
+      it "raises ArgumentError" do
+        assert_raises(ArgumentError) { AWS.class_for(:bad_key) }
+      end
+    end
+  end
+
+  describe "#[]" do
+    describe "when service is recognised" do
+      it "returns correct instance" do
+        KEY_CLASS_MAPPING.each do |key, klass|
+          klass.stub(:new, true) do
+            assert klass, AWS[key]
+          end
+        end
+      end
+    end
+
+    describe "when service is not recognised" do
+      it "raises ArgumentError" do
+        assert_raises(ArgumentError) { AWS[:bad_service] }
+      end
+    end
+  end
 end

--- a/spec/fog/bin/aws_spec.rb
+++ b/spec/fog/bin/aws_spec.rb
@@ -83,8 +83,8 @@ describe AWS do
     describe "when service is recognised" do
       it "returns correct instance" do
         KEY_CLASS_MAPPING.each do |key, klass|
-          klass.stub(:new, true) do
-            assert klass, AWS[key]
+          klass.stub(:new, "#{klass} instance") do
+            assert_equal "#{klass} instance", AWS[key]
           end
         end
       end


### PR DESCRIPTION
This was triggered by #3376

This is a workaround for moving the provider specific code into `fog-aws`
whilst not cluttering the module with the "bin" behaviour.

The bin behaviour usually relates to starting `fog` from the command line
and using it interactively when having a `AWS` class seemed like a nice idea.

The `AWS` namespace should rightly be available to the AWS SDK (uses `Aws`)
so this is being deprecated however each implementation has been done
standalone.

Each top level class basically includes lookup tables between a key and the class
that should be returned.

Whilst I am working on fixing the provider/service registration in `fog-core` this
is a potential fix to put these back into the modules control.

I foresee that `lib/fog/bin/aws.rb` will disappear in 2.0 and `Fog::AWS::ServiceMapper`
will have it's functionality replaced by core components so also likely to go.

/cc @lanej @plribeiro3000
/cc @mdarby - I think this may also be a short term solution for `fog-rackspace`
