### PR TITLE
Fix invalid request exception,

### DIFF
--- a/lib/fog/bare_metal_cloud/compute.rb
+++ b/lib/fog/bare_metal_cloud/compute.rb
@@ -75,7 +75,7 @@ module Fog
           end
 
           begin
-            response = @connection.request(params.merge!({:host => @host}))
+            response = @connection.request(params)
           rescue Excon::Errors::HTTPStatusError => error
             raise case error
             when Excon::Errors::NotFound


### PR DESCRIPTION
This change fixes the following exception.

```
$ knife baremetalcloud list servers -x xxxx -P xxxx
[excon][WARNING] Invalid Excon request keys: :host
/Users/msamaratunga/.rvm/gems/ruby-2.1.5/gems/excon-0.42.1/lib/excon/connection.rb:356:in `validate_params'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5/gems/excon-0.42.1/lib/excon/connection.rb:203:in `request'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5/gems/fog-1.23.0/lib/fog/xml/sax_parser_connection.rb:35:in `request'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5/gems/fog-1.23.0/lib/fog/xml/connection.rb:17:in `request'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5/gems/fog-1.23.0/lib/fog/bare_metal_cloud/compute.rb:79:in `request'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5/gems/fog-1.23.0/lib/fog/bare_metal_cloud/requests/compute/list_servers.rb:24:in `list_servers'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5/gems/knife-bmc-0.0.1/lib/chef/knife/baremetalcloud_list_servers.rb:64:in `run'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5@global/gems/chef-12.0.3/lib/chef/knife.rb:417:in `block in run_with_pretty_exceptions'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5@global/gems/chef-12.0.3/lib/chef/local_mode.rb:38:in `with_server_connectivity'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5@global/gems/chef-12.0.3/lib/chef/knife.rb:416:in `run_with_pretty_exceptions'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5@global/gems/chef-12.0.3/lib/chef/knife.rb:213:in `run'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5@global/gems/chef-12.0.3/lib/chef/application/knife.rb:139:in `run'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5@global/gems/chef-12.0.3/bin/knife:25:in `<top (required)>'
/Users/msamaratunga/.rvm/rubies/ruby-2.1.5/bin/knife:23:in `load'
/Users/msamaratunga/.rvm/rubies/ruby-2.1.5/bin/knife:23:in `<main>'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `eval'
/Users/msamaratunga/.rvm/gems/ruby-2.1.5/bin/ruby_executable_hooks:15:in `<main>'
```