### PR TITLE
Remove duplicate openstack_region key

### DIFF
--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -193,7 +193,6 @@ module Fog
               :openstack_api_key  => @openstack_api_key,
               :openstack_username => @openstack_username,
               :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_region   => @openstack_region,
               :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
               :openstack_service_type => @openstack_service_type,
               :openstack_service_name => @openstack_service_name,


### PR DESCRIPTION
When running fog in my Rails app under Ruby 2.2.0, I receive the following warning:

`.bundle/ruby/2.2.0/gems/fog-1.27.0/lib/fog/openstack/volume.rb:191: warning: duplicated key at line 196 ignored: :openstack_region`

I removed the duplicate line.