### PR TITLE
adding option to set ovirt to use filtered API

### DIFF
--- a/lib/fog/ovirt/compute.rb
+++ b/lib/fog/ovirt/compute.rb
@@ -114,6 +114,7 @@ module Fog
           connection_opts[:ca_cert_store] = options[:ovirt_ca_cert_store]
           connection_opts[:ca_cert_file]  = options[:ovirt_ca_cert_file]
           connection_opts[:ca_no_verify]  = options[:ovirt_ca_no_verify]
+          connection_opts[:filtered_api]  = options[:ovirt_filtered_api]
 
           @client = OVIRT::Client.new(username, password, url, connection_opts)
         end


### PR DESCRIPTION
When the ovirt user is not an admin, the client must use the "filtered_api" flag, otherwise all requests fail. Adding the ovirt_filtered_api flag will allow usage of fog with non admin ovirt credentials.