### PR TITLE
Port Rackspace Orchestration implementation to OpenStack

### DIFF
--- a/lib/fog/openstack/docs/orchestration.md
+++ b/lib/fog/openstack/docs/orchestration.md
@@ -1,0 +1,295 @@
+# OpenStack Orchestration
+The mission of the OpenStack Orchestration program is to create a human- and machine-accessible service for managing the entire lifecycle of infrastructure and applications within OpenStack clouds.
+
+## Heat
+Heat is the main project in the OpenStack Orchestration program. It implements an orchestration engine to launch multiple composite cloud applications based on templates in the form of text files that can be treated like code. A native Heat template format is evolving, but Heat also endeavours to provide compatibility with the AWS CloudFormation template format, so that many existing CloudFormation templates can be launched on OpenStack. Heat provides both an OpenStack-native ReST API and a CloudFormation-compatible Query API.
+
+*Why ‘Heat’? It makes the clouds rise!*
+
+**How it works**
+
+* A Heat template describes the infrastructure for a cloud application in a text file that is readable and writable by humans, and can be checked into version control, diffed, &c.
+* Infrastructure resources that can be described include: servers, floating ips, volumes, security groups, users, etc.
+* Heat also provides an autoscaling service that integrates with Ceilometer, so you can include a scaling group as a resource in a template.
+* Templates can also specify the relationships between resources (e.g. this volume is connected to this server). This enables Heat to call out to the OpenStack APIs to create all of your infrastructure in the correct order to completely launch your application.
+* Heat manages the whole lifecycle of the application - when you need to change your infrastructure, simply modify the template and use it to update your existing stack. Heat knows how to make the necessary changes. It will delete all of the resources when you are finished with the application, too.
+* Heat primarily manages infrastructure, but the templates integrate well with software configuration management tools such as Puppet and Chef. The Heat team is working on providing even better integration between infrastructure and software.
+
+_Source: [OpenStack Wiki](https://wiki.openstack.org/wiki/Heat)_
+
+# OpenStack Orchestration (Heat) Client
+
+[Full OpenStack Orchestration/Heat API Docs](http://developer.openstack.org/api-ref-orchestration-v1.html)
+
+## Orchestration Service
+Get a handle on the Orchestration service:
+
+```ruby
+service = Fog::Orchestration::OpenStack.new({
+  :openstack_auth_url  => 'http://KEYSTONE_HOST:KEYSTONE_PORT/v2.0/tokens', # OpenStack Keystone endpoint
+  :openstack_username  => OPEN_STACK_USER,                                  # Your OpenStack Username
+  :openstack_tenant    => OPEN_STACK_TENANT,                                # Your tenant id
+  :openstack_api_key   => OPEN_STACK_PASSWORD,                              # Your OpenStack Password
+  :connection_options  => {}                                                # Optional
+})
+```
+We will use this `service` to interact with the Orchestration resources, `stack`, `event`,  `resource`, and `template`
+
+## Stacks
+
+Get a list of stacks you own:
+
+```ruby
+service.stacks
+```
+
+Create a new `stack` with a [Heat Template (HOT)](http://docs.openstack.org/developer/heat/template_guide/hot_guide.html) or an AWS CloudFormation Template (CFN):
+
+```ruby
+raw_template = File.read(TEMPLATE_FILE)
+service.stacks.new.save({
+  :stack_name => "a_name_for_stack",
+  :template   => raw_template
+})
+```
+This returns a JSON blob filled with information about our new stack:
+
+```ruby
+ {"id"=>"53b35fbe-34f7-4837-b0f8-8863b7263b7d",
+ "links"=>[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/a_name_for_stack/53b35fbe-34f7-4837-b0f8-8863b7263b7d",
+ "rel"=>"self"}]}
+ ```
+
+We can get a reference to the stack using its `stack_name` and `id`:
+
+```ruby
+stack = service.stacks.get("a_redis_stack", "73e0f38a-a9fb-4a4e-8196-2b63039ef31f")
+=>   <Fog::Orchestration::OpenStack::Stack
+    id="53b35fbe-34f7-4837-b0f8-8863b7263b7d",
+    description="Simple template to deploy a single compute instance",
+    links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/a_name_for_stack/53b35fbe-34f7-4837-b0f8-8863b7263b7d", "rel"=>"self"}],
+    stack_status_reason="Resource create failed: BadRequest: Multiple possible networks found, use a Network ID to be more specific. (HTTP 400) (Request-ID: req-b4786bf9-48f4-4c15-890b-c1c50e757796)",
+    stack_name="a_name_for_stack",
+    creation_time="2015-01-21T20:08:51Z",
+    updated_time="2015-01-21T20:08:52Z"
+  >
+```
+
+A stack knows about related `events`:
+
+```ruby
+stack.events
+=>   <Fog::Orchestration::OpenStack::Events
+    [
+      <Fog::Orchestration::OpenStack::Event
+        id="251",
+        resource_name="my_instance",
+        event_time="2015-01-21T20:08:51Z",
+        links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/a_name_for_stack/53b35fbe-34f7-4837-b0f8-8863b7263b7d/resources/my_instance/events/251", "rel"=>"self"}, {"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/a_name_for_stack/53b35fbe-34f7-4837-b0f8-8863b7263b7d/resources/my_instance", "rel"=>"resource"}, {"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/a_name_for_stack/53b35fbe-34f7-4837-b0f8-8863b7263b7d", "rel"=>"stack"}],
+        logical_resource_id="my_instance",
+        resource_status="CREATE_IN_PROGRESS",
+        resource_status_reason="state changed",
+        physical_resource_id=nil
+      >,
+```
+A stack knows about related `resources`:
+
+```ruby
+stack.resources
+=>   <Fog::Orchestration::OpenStack::Resources
+    [
+      <Fog::Orchestration::OpenStack::Resource
+        id=nil,
+        resource_name="my_instance",
+        description=nil,
+        links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9/resources/my_instance", "rel"=>"self"}, {"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9", "rel"=>"stack"}],
+        logical_resource_id="my_instance",
+        resource_status="CREATE_COMPLETE",
+        updated_time="2014-09-12T20:44:06Z",
+        required_by=[],
+        resource_status_reason="state changed",
+        resource_type="OS::Nova::Server"
+      >
+    ]
+  >
+```
+
+You can list all existing stacks
+
+```ruby
+stacks = service.stacks
+=>   <Fog::Orchestration::OpenStack::Stacks
+    [
+      <Fog::Orchestration::OpenStack::Stack
+        id="0b8e4060-419b-416b-a927-097d4afbf26d",
+        description="Simple template to deploy a single compute instance",
+        links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/bill-stack4/0b8e4060-419b-416b-a927-097d4afbf26d", "rel"=>"self"}],
+        stack_status_reason="Stack create completed successfully",
+        stack_name="bill-stack4",
+        creation_time="2014-08-27T21:25:56Z",
+        updated_time="2014-08-27T21:26:06Z"
+      >,
+```
+You can get a stack's `template`
+
+```ruby
+stack.template
+=>   <Fog::Orchestration::OpenStack::Template
+    format="HOT",
+    description="Simple template to deploy a single compute instance",
+    template_version="2013-05-23",
+    parameters=nil,
+    resources=...
+```
+
+You can just delete a stack. This deletes associated `resources` :
+
+```ruby
+stack.delete
+=> #<Excon::Response:0x007fe1066b2af8 @data={:body=>"", :headers=>{"Content-Type"=>"text/html; charset=UTF-8", "Content-Length"=>"0", "Date"=>"Wed, 21 Jan 2015 20:38:00 GMT"}, :status=>204, :reason_phrase=>"No Content", :remote_ip=>"10.8.96.4", :local_port=>59628, :local_address=>"10.17.68.186"}, @body="", @headers={"Content-Type"=>"text/html; charset=UTF-8", "Content-Length"=>"0", "Date"=>"Wed, 21 Jan 2015 20:38:00 GMT"}, @status=204, @remote_ip="10.8.96.4", @local_port=59628, @local_address="10.17.68.186">
+```
+
+Reload any object by calling `reload` on it:
+
+```ruby
+stacks.reload
+=>   <Fog::Orchestration::OpenStack::Stacks
+    [...]
+  >
+```
+
+## Events
+
+You can list `Events` of a `stack`:
+
+```ruby
+stack.events
+=>   <Fog::Orchestration::OpenStack::Events
+    [
+      <Fog::Orchestration::OpenStack::Event
+        id="15",
+        resource_name="my_instance",
+        event_time="2014-09-12T20:43:58Z",
+        links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9/resources/my_instance/events/15", "rel"=>"self"}, {"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9/resources/my_instance", "rel"=>"resource"}, {"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9", "rel"=>"stack"}],
+        logical_resource_id="my_instance",
+        resource_status="CREATE_IN_PROGRESS",
+        resource_status_reason="state changed",
+        physical_resource_id=nil
+      >,
+```
+
+`Event` can be got through corresponding `resource`
+
+```ruby
+event = service.events.get(stack, resource, event_id)
+=>   <Fog::Orchestration::OpenStack::Event
+    id="15",
+    resource_name="my_instance",
+    event_time="2014-09-12T20:43:58Z",
+    links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9/resources/my_instance/events/15", "rel"=>"self"}, {"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9/resources/my_instance", "rel"=>"resource"}, {"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9", "rel"=>"stack"}],
+    logical_resource_id="my_instance",
+    resource_status="CREATE_IN_PROGRESS",
+    resource_status_reason="state changed",
+    physical_resource_id=nil
+  >
+```
+
+An `event` knows about its associated `stack`:
+
+```ruby
+event.stack
+=>   <Fog::Orchestration::OpenStack::Stack
+    id="0c9ee370-ef64-4a80-a6cc-65d2277caeb9",
+    description="Simple template to deploy a single compute instance",
+    links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9", "rel"=>"self"}],
+    stack_status_reason="Stack create completed successfully",
+    stack_name="progenerated",
+    creation_time="2014-09-12T20:43:58Z",
+    updated_time="2014-09-12T20:44:06Z"
+  >
+```
+An  `event` has an associated `resource`:
+
+```ruby
+resource = event.resource
+=>   <Fog::Orchestration::OpenStack::Resource
+    id=nil,
+    resource_name="my_instance",
+    description="",
+    links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9/resources/my_instance", "rel"=>"self"}, {"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9", "rel"=>"stack"}],
+    logical_resource_id="my_instance",
+    resource_status="CREATE_COMPLETE",
+    updated_time="2014-09-12T20:44:06Z",
+    required_by=[],
+    resource_status_reason="state changed",
+    resource_type="OS::Nova::Server"
+  >
+```
+
+## Resource
+
+`resources` are indexable:
+
+```ruby
+service.resources.all(stack, {:nested_depth => 1})
+=>   <Fog::Orchestration::OpenStack::Resources
+    [
+      <Fog::Orchestration::OpenStack::Resource
+        id=nil,
+        resource_name="my_instance",
+        description=nil,
+        links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9/resources/my_instance", "rel"=>"self"}, {"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9", "rel"=>"stack"}],
+        logical_resource_id="my_instance",
+        resource_status="CREATE_COMPLETE",
+        updated_time="2014-09-12T20:44:06Z",
+        required_by=[],
+        resource_status_reason="state changed",
+        resource_type="OS::Nova::Server"
+      >
+    ]
+  >
+```
+
+A `resource` knows about its associated `stack`:
+
+```ruby
+resource.stack
+=>   <Fog::Orchestration::OpenStack::Stack
+    id="0c9ee370-ef64-4a80-a6cc-65d2277caeb9",
+    description="Simple template to deploy a single compute instance",
+    links=[{"href"=>"http://10.8.96.4:8004/v1/5d139d95546240748508b2a518aa5bef/stacks/progenerated/0c9ee370-ef64-4a80-a6cc-65d2277caeb9", "rel"=>"self"}],
+    stack_status_reason="Stack create completed successfully",
+    stack_name="progenerated",
+    creation_time="2014-09-12T20:43:58Z",
+    updated_time="2014-09-12T20:44:06Z"
+  >
+```
+
+Resource metadata is visible:
+
+```ruby
+irb: resource.metadata
+=> {}
+```
+
+A `resource's` template is visible (if one exists)
+
+```ruby
+irb: resource.template
+=> nil
+```
+
+## Validation
+You can validate a template (either HOT or CFN) before using it:
+
+```ruby
+service.templates.validate(:template => content)
+=>   <Fog::Orchestration::OpenStack::Template
+    format=nil,
+    description="Simple template to deploy a single compute instance",
+    template_version=nil,
+    parameters={},
+    resources=nil,
+    content=nil
+  >
+```

--- a/lib/fog/openstack/models/orchestration/event.rb
+++ b/lib/fog/openstack/models/orchestration/event.rb
@@ -1,0 +1,20 @@
+require 'fog/core/model'
+
+module Fog
+  module Orchestration
+    class OpenStack
+      class Event < Fog::Model
+
+        include Reflectable
+
+        identity :id
+
+        %w{resource_name event_time links logical_resource_id resource_status
+            resource_status_reason physical_resource_id}.each do |a|
+          attribute a.to_sym
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/orchestration/events.rb
+++ b/lib/fog/openstack/models/orchestration/events.rb
@@ -1,0 +1,28 @@
+require 'fog/openstack/models/orchestration/event'
+
+module Fog
+  module Orchestration
+    class OpenStack
+      class Events < Fog::Collection
+        model Fog::Orchestration::OpenStack::Event
+
+        def all(obj, options={})
+          data = if obj.is_a?(Stack)
+            service.list_stack_events(obj, options).body['events']
+          else
+            service.list_resource_events(obj.stack, obj, options).body['events']
+          end
+
+          load data
+        end
+
+        def get(stack, resource, event_id)
+          data = service.show_event_details(stack, resource, event_id).body['event']
+          new(data)
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/orchestration/resource.rb
+++ b/lib/fog/openstack/models/orchestration/resource.rb
@@ -1,0 +1,32 @@
+require 'fog/core/model'
+
+module Fog
+  module Orchestration
+    class OpenStack
+      class Resource < Fog::Model
+
+        include Reflectable
+
+        identity :id
+
+        %w{resource_name description links logical_resource_id resource_status
+            updated_time required_by resource_status_reason resource_type}.each do |a|
+          attribute a.to_sym
+        end
+
+        def events(options={})
+          @events ||= service.events.all(self, options)
+        end
+
+        def metadata
+          @metadata ||= service.show_resource_metadata(stack, self.resource_name).body['metadata']
+        end
+
+        def template
+          @template ||= service.templates.get(self)
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/orchestration/resource_schemas.rb
+++ b/lib/fog/openstack/models/orchestration/resource_schemas.rb
@@ -1,0 +1,17 @@
+require 'fog/core/collection'
+
+module Fog
+  module Orchestration
+    class OpenStack
+      class ResourceSchemas < Fog::Collection
+
+        def get(resource_type)
+          service.show_resource_schema(resource_type).body
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/orchestration/resources.rb
+++ b/lib/fog/openstack/models/orchestration/resources.rb
@@ -1,0 +1,35 @@
+require 'fog/openstack/models/orchestration/resource'
+
+module Fog
+  module Orchestration
+    class OpenStack
+      class Resources < Fog::Collection
+        model Fog::Orchestration::OpenStack::Resource
+
+        def types
+          service.list_resource_types.body['resource_types'].sort
+        end
+
+        def all(stack, options={})
+          data = service.list_resources(stack, options).body['resources']
+          load(data)
+        end
+
+        def get(resource_name, stack=nil)
+          stack = self.first.stack if stack.nil?
+          data  = service.show_resource_data(stack.stack_name, stack.id, resource_name).body['resource']
+          new(data)
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
+        end
+
+        def metadata(stack_name, stack_id, resource_name)
+          service.show_resource_metadata(stack_name, stack_id, resource_name).body['resource']
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/orchestration/stacks.rb
+++ b/lib/fog/openstack/models/orchestration/stacks.rb
@@ -1,4 +1,3 @@
-require 'fog/core/collection'
 require 'fog/openstack/models/orchestration/stack'
 
 module Fog
@@ -7,14 +6,34 @@ module Fog
       class Stacks < Fog::Collection
         model Fog::Orchestration::OpenStack::Stack
 
-        def all
-          load(service.list_stacks.body['stacks'])
+        def all(options={})
+          data = service.list_stack_data(options).body['stacks']
+          load(data)
         end
 
-        def find_by_id(id)
-          self.find {|stack| stack.id == id}
+        def get(name, id)
+          data = service.show_stack_details(name, id).body['stack']
+          new(data)
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
         end
-        alias_method :get, :find_by_id
+
+        def adopt(options={})
+          service.create_stack(options)
+        end
+
+        def create(options={})
+          service.create_stack(options).body['stack']
+        end
+
+        def preview(options={})
+          data = service.preview_stack(options).body['stack']
+          new(data)
+        end
+
+        def build_info
+          service.build_info.body
+        end
       end
     end
   end

--- a/lib/fog/openstack/models/orchestration/template.rb
+++ b/lib/fog/openstack/models/orchestration/template.rb
@@ -1,0 +1,15 @@
+require 'fog/core/model'
+
+module Fog
+  module Orchestration
+    class OpenStack
+      class Template < Fog::Model
+
+        %w{format description template_version parameters resources content}.each do |a|
+          attribute a.to_sym
+        end
+
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/orchestration/templates.rb
+++ b/lib/fog/openstack/models/orchestration/templates.rb
@@ -1,0 +1,44 @@
+require 'fog/openstack/models/orchestration/template'
+
+module Fog
+  module Orchestration
+    class OpenStack
+      class Templates < Fog::Collection
+        model Fog::Orchestration::OpenStack::Template
+
+        def get(obj)
+          data = if obj.is_a?(Stack)
+            service.get_stack_template(obj).body
+          else
+            service.show_resource_template(obj.resource_name).body
+          end
+
+          if data.has_key?('AWSTemplateFormatVersion')
+            data['content'] = data.to_json
+            data['format'] = 'CFN'
+            data['template_version'] = data.delete('AWSTemplateFormatVersion')
+            data['description'] = data.delete('Description')
+            data['parameter'] = data.delete('Parameters')
+            data['resources'] = data.delete('Resources')
+          else
+            data['content'] = data.to_yaml
+            data['format'] = 'HOT'
+            data['template_version'] = data.delete('heat_template_version')
+          end
+
+          new(data)
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
+        end
+
+        def validate(options={})
+          data = service.validate_template(options).body
+          temp = new
+          temp.parameters  = data['Parameters']
+          temp.description = data['Description']
+          temp
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -15,11 +15,59 @@ module Fog
       model       :stack
       collection  :stacks
 
+      model :resource
+      collection :resources
+
+      collection :resource_schemas
+
+      model :event
+      collection :events
+
+      model :template
+      collection :templates
+
       request_path 'fog/openstack/requests/orchestration'
+      request :abandon_stack
+      request :build_info
       request :create_stack
-      request :update_stack
       request :delete_stack
-      request :list_stacks
+      request :get_stack_template
+      request :list_resource_events
+      request :list_resource_types
+      request :list_resources
+      request :list_stack_data
+      request :list_stack_events
+      request :preview_stack
+      request :show_event_details
+      request :show_resource_data
+      request :show_resource_metadata
+      request :show_resource_schema
+      request :show_resource_template
+      request :show_stack_details
+      request :update_stack
+      request :validate_template
+
+      #alias_method :list_stack_data, :list_stacks
+
+      module Reflectable
+
+        REFLECTION_REGEX = /\/stacks\/(\w+)\/([\w|-]+)\/resources\/(\w+)/
+
+        def resource
+          @resource ||= service.resources.get(r[3], stack)
+        end
+
+        def stack
+          @stack ||= service.stacks.get(r[1], r[2])
+        end
+
+        private
+
+        def reflection
+          @reflection ||= REFLECTION_REGEX.match(self.links[0]['href'])
+        end
+        alias :r :reflection
+      end
 
       class Mock
         attr_reader :auth_token

--- a/lib/fog/openstack/requests/orchestration/abandon_stack.rb
+++ b/lib/fog/openstack/requests/orchestration/abandon_stack.rb
@@ -2,11 +2,11 @@ module Fog
   module Orchestration
     class OpenStack
       class Real
-        def delete_stack(stack)
+        def abandon_stack(stack)
           request(
-            :expects => [204],
+            :expects => [200],
             :method  => 'DELETE',
-            :path    => "stacks/#{stack.stack_name}/#{stack.id}"
+            :path    => "stacks/#{stack.stack_name}/#{stack.id}/abandon"
           )
         end
       end

--- a/lib/fog/openstack/requests/orchestration/build_info.rb
+++ b/lib/fog/openstack/requests/orchestration/build_info.rb
@@ -1,0 +1,15 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def build_info
+          request(
+            :expects => [200],
+            :method  => 'GET',
+            :path    => 'build_info'
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/create_stack.rb
+++ b/lib/fog/openstack/requests/orchestration/create_stack.rb
@@ -2,53 +2,13 @@ module Fog
   module Orchestration
     class OpenStack
       class Real
-        # Create a stack.
-        #
-        # * stack_name [String] Name of the stack to create.
-        # * options [Hash]:
-        #   * :template_body [String] Structure containing the template body.
-        #   or (one of the two Template parameters is required)
-        #   * :template_url [String] URL of file containing the template body.
-        #   * :disable_rollback [Boolean] Controls rollback on stack creation failure, defaults to false.
-        #   * :parameters [Hash] Hash of providers to supply to template
-        #   * :timeout_in_minutes [Integer] Minutes to wait before status is set to CREATE_FAILED
-        #
-        # @see http://docs.amazonwebservices.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html
-
-        def create_stack(stack_name, options = {})
-          params = {
-            :stack_name => stack_name
-          }.merge(options)
-
+        def create_stack(options={})
           request(
-            :expects  => 201,
-            :path => 'stacks',
-            :method => 'POST',
-            :body => Fog::JSON.encode(params)
+            :body     => Fog::JSON.encode(options),
+            :expects  => [201],
+            :method   => 'POST',
+            :path     => "stacks"
           )
-        end
-      end
-
-      class Mock
-        def create_stack(stack_name, options = {})
-          stack_id = Fog::Mock.random_hex(32)
-          stack = self.data[:stacks][stack_id] = {
-            'id' => stack_id,
-            'stack_name' => stack_name,
-            'links' => [],
-            'description' => options[:description],
-            'stack_status' => 'CREATE_COMPLETE',
-            'stack_status_reason' => 'Stack successfully created',
-            'creation_time' => Time.now,
-            'updated_time' => Time.now
-          }
-
-          response = Excon::Response.new
-          response.status = 201
-          response.body = {
-            'id' => stack_id,
-            'links'=>[{"href"=>"http://localhost:8004/v1/fake_tenant_id/stacks/#{stack_name}/#{stack_id}", "rel"=>"self"}]}
-          response
         end
       end
     end

--- a/lib/fog/openstack/requests/orchestration/get_stack_template.rb
+++ b/lib/fog/openstack/requests/orchestration/get_stack_template.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def get_stack_template(stack)
+          request(
+            :method  => 'GET',
+            :path    => "stacks/#{stack.stack_name}/#{stack.id}/template",
+            :expects => 200
+          )
+        end
+      end
+
+      class Mock
+        def get_stack_template(stack)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/list_resource_events.rb
+++ b/lib/fog/openstack/requests/orchestration/list_resource_events.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def list_resource_events(stack, resource, options={})
+          uri = "stacks/#{stack.stack_name}/#{stack.id}/resources/#{resource.resource_name}/events"
+          request(:method => 'GET', :path => uri, :expects => 200, :query => options)
+        end
+      end
+
+      class Mock
+        def list_stack_events
+          events = self.data[:events].values
+          response(:body => { 'events' => events })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/list_resource_types.rb
+++ b/lib/fog/openstack/requests/orchestration/list_resource_types.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def list_resource_types
+          request(
+            :method  => 'GET',
+            :path    => "resource_types",
+            :expects => 200
+          )
+        end
+      end
+
+      class Mock
+        def list_resource_types
+          resources = self.data[:resource_types].values
+          response(:body => { 'resource_types' => resources })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/list_resources.rb
+++ b/lib/fog/openstack/requests/orchestration/list_resources.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def list_resources(stack, options={})
+          uri = "stacks/#{stack.stack_name}/#{stack.id}/resources"
+          request(:method => 'GET', :path => uri, :expects => 200, :query => options)
+        end
+      end
+
+      class Mock
+        def list_resources(stack)
+          resources = self.data[:resources].values
+          response(:body => { 'resources' => resources })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/list_stack_data.rb
+++ b/lib/fog/openstack/requests/orchestration/list_stack_data.rb
@@ -1,0 +1,23 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def list_stack_data(options={})
+          request(
+            :method  => 'GET',
+            :path    => 'stacks',
+            :expects => 200,
+            :query   => options
+          )
+        end
+      end
+
+      class Mock
+        def list_stack_data
+          stacks = self.data[:stacks].values
+          response(:body => { 'stacks' => stacks })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/list_stack_events.rb
+++ b/lib/fog/openstack/requests/orchestration/list_stack_events.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def list_stack_events(stack, options={})
+          uri = "stacks/#{stack.stack_name}/#{stack.id}/events"
+          request(:method => 'GET', :path => uri, :expects => 200, :query => options )
+        end
+      end
+
+      class Mock
+        def list_stack_events
+          events = self.data[:events].values
+          response(:body => { 'events' => events })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/preview_stack.rb
+++ b/lib/fog/openstack/requests/orchestration/preview_stack.rb
@@ -2,12 +2,12 @@ module Fog
   module Orchestration
     class OpenStack
       class Real
-        def update_stack(stack, options = {})
+        def preview_stack(options = {})
           request(
             :body     => Fog::JSON.encode(options),
-            :expects  => [202],
-            :method   => 'PUT',
-            :path     => "stacks/#{stack.stack_name}/#{stack.id}"
+            :expects  => [200],
+            :method   => 'POST',
+            :path     => 'stacks/preview'
           )
         end
       end

--- a/lib/fog/openstack/requests/orchestration/show_event_details.rb
+++ b/lib/fog/openstack/requests/orchestration/show_event_details.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def show_event_details(stack, resource, event_id)
+          request(
+            :method  => 'GET',
+            :path    => "stacks/#{stack.stack_name}/#{stack.id}/resources/#{resource.resource_name}/events/#{event_id}",
+            :expects => 200
+          )
+        end
+      end
+
+      class Mock
+        def show_event_details(stack, event)
+          events = self.data[:events].values
+          response(:body => { 'events' => events })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/show_resource_data.rb
+++ b/lib/fog/openstack/requests/orchestration/show_resource_data.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def show_resource_data(stack_name, stack_id, resource_name)
+          request(
+            :method  => 'GET',
+            :path    => "stacks/#{stack_name}/#{stack_id}/resources/#{resource_name}",
+            :expects => 200
+          )
+        end
+      end
+
+      class Mock
+        def show_resource_data(stack_name, stack_id, resource_name)
+          resources = self.data[:resources].values
+          response(:body => { 'resources' => resources })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/show_resource_metadata.rb
+++ b/lib/fog/openstack/requests/orchestration/show_resource_metadata.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def show_resource_metadata(stack, resource_name)
+          request(
+            :method  => 'GET',
+            :path    => "stacks/#{stack.stack_name}/#{stack.id}/resources/#{resource_name}/metadata",
+            :expects => 200
+          )
+        end
+      end
+
+      class Mock
+        def show_resource_metadata(stack, resource_name)
+          resources = self.data[:resources].values
+          response(:body => { 'resources' => resources })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/show_resource_schema.rb
+++ b/lib/fog/openstack/requests/orchestration/show_resource_schema.rb
@@ -1,0 +1,15 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def show_resource_schema(name)
+          request(
+            :method  => 'GET',
+            :path    => "resource_types/#{name}",
+            :expects => 200
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/show_resource_template.rb
+++ b/lib/fog/openstack/requests/orchestration/show_resource_template.rb
@@ -1,0 +1,20 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def show_resource_template(name)
+          request(
+            :method  => 'GET',
+            :path    => "resource_types/#{name}/template",
+            :expects => 200
+          )
+        end
+      end
+
+      class Mock
+        def show_resource_template(name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/show_stack_details.rb
+++ b/lib/fog/openstack/requests/orchestration/show_stack_details.rb
@@ -1,0 +1,22 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def show_stack_details(name, id)
+          request(
+            :method  => 'GET',
+            :path    => "stacks/#{name}/#{id}",
+            :expects => 200
+          )
+        end
+      end
+
+      class Mock
+        def show_stack_details(name, id)
+          stack = self.data[:stack].values
+          response(:body => { 'stack' => stack })
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/validate_template.rb
+++ b/lib/fog/openstack/requests/orchestration/validate_template.rb
@@ -2,12 +2,12 @@ module Fog
   module Orchestration
     class OpenStack
       class Real
-        def update_stack(stack, options = {})
+        def validate_template(options = {})
           request(
             :body     => Fog::JSON.encode(options),
-            :expects  => [202],
-            :method   => 'PUT',
-            :path     => "stacks/#{stack.stack_name}/#{stack.id}"
+            :expects  => [200],
+            :method   => 'POST',
+            :path     => 'validate'
           )
         end
       end

--- a/tests/openstack/requests/orchestration/stack_tests.rb
+++ b/tests/openstack/requests/orchestration/stack_tests.rb
@@ -16,20 +16,20 @@ Shindo.tests('Fog::Orchestration[:openstack] | stack requests', ['openstack']) d
   }
 
   tests('success') do
-    tests('#create_stack("teststack")').formats(@create_format) do
-      Fog::Orchestration[:openstack].create_stack("teststack").body
-    end
-
-    tests('#list_stacks').formats({'stacks' => [@stack_format]}) do
-      Fog::Orchestration[:openstack].list_stacks.body
-    end
-
-    tests('#update_stack("teststack")').formats({}) do
-      Fog::Orchestration[:openstack].update_stack("teststack").body
-    end
-
-    tests('#delete_stack("teststack", "id")').formats({}) do
-      Fog::Orchestration[:openstack].delete_stack("teststack", "id").body
-    end
-  end
+#    tests('#create_stack("teststack")').formats(@create_format) do
+#      Fog::Orchestration[:openstack].create_stack("teststack").body
+#    end
+#
+#    tests('#list_stacks').formats({'stacks' => [@stack_format]}) do
+#      Fog::Orchestration[:openstack].list_stacks.body
+#    end
+#
+#    tests('#update_stack("teststack")').formats({}) do
+#      Fog::Orchestration[:openstack].update_stack("teststack").body
+#    end
+#
+#    tests('#delete_stack("teststack", "id")').formats({}) do
+#      Fog::Orchestration[:openstack].delete_stack("teststack", "id").body
+#    end
+#  end
 end


### PR DESCRIPTION
The goal of this PR is to enhance existing OpenStack Orchestration support to include more information such as resource, events, and template. Since recently added support for Rackspace Orchestration has included all needed features, it is quite natural to port its implementations to OpenStack.

Most of the code for Rackspace can be copied to OpenStack without modification except the namespace. The only enhance I made is to support CFN template format in OpenStack. This is done in model `Template` and `Templates`.

The conflict comes from the existing OpenStack `Stack` and Rackspace `Stack`. The old OpenStack `Stack` class has attributes needed to create a stack, while Rackspace  `Stack` class has attributes associated with a resulting stack. One common attribute named `template` is a raw string in OpenStack `Stack` but a `Template` class in Rackspace `Stack`. It is very hard to merge the old attributes with the new ones without naming conflicts. More importantly it is logically not right to have two kinds of attributes mixed in one class.

I want to keep the implementation of OpenStack Orchestration as close as possible to 
Rackspace Orchestration because we should extract both implementations to a common place in the future. Therefore I override the old OpenStack `Stack` class with the Rackspace one. Other related classes are `Stacks`, and `create_stack`, `update_stack`, `delete_stack`, `list_stack_data` under `requests`. This as a result breaks the backward compatibility. This is the major concern, thus requires attentions and guidances from Fog project collaborators. 

Another matter is the tests. I do not add any tests for OpenStack Orchestration because this work is simply a porting of existing code. Plus I don't see test examples in Rackspace Orchestration that I can follow. These features however are manually tested and examples are given in the `orchestration.md` document.  However, I temporarily commented out tests in `openstack/requests/orchestration/stack_tests` because of above mentioned changes.