### PR TITLE
Remove the "ovirt_ca_cert_store" option

### DIFF
--- a/lib/fog/ovirt/compute.rb
+++ b/lib/fog/ovirt/compute.rb
@@ -5,7 +5,7 @@ module Fog
     class Ovirt < Fog::Service
       requires   :ovirt_username, :ovirt_password
       recognizes :ovirt_url,      :ovirt_server,  :ovirt_port, :ovirt_api_path, :ovirt_datacenter,
-                 :ovirt_ca_cert_store, :ovirt_ca_cert_file, :ovirt_ca_no_verify
+                 :ovirt_ca_cert_file, :ovirt_ca_no_verify
 
       model_path 'fog/ovirt/models/compute'
       model      :server
@@ -111,7 +111,6 @@ module Fog
 
           connection_opts = {}
           connection_opts[:datacenter_id] = options[:ovirt_datacenter]
-          connection_opts[:ca_cert_store] = options[:ovirt_ca_cert_store]
           connection_opts[:ca_cert_file]  = options[:ovirt_ca_cert_file]
           connection_opts[:ca_no_verify]  = options[:ovirt_ca_no_verify]
           connection_opts[:filtered_api]  = options[:ovirt_filtered_api]


### PR DESCRIPTION
This option is intended to pass a certificate store containing the
accepted CA certificates, but the underlying "rbovirt" library is about
to remove it because it can only be used with HTTP libraries that
directly support these OpenSSL objects. See here for details:

  https://github.com/abenari/rbovirt/pull/55

As an alternative to this "ovirt_ca_cert_store" the already existing
"ovirt_ca_cert_file" can be used, with the same functinality. Actually
the "ovirt_ca_cert_store" parameter isn't currently used in the fog code

Signed-off-by: Juan Hernandez <juan.hernandez@redhat.com>