### PR TITLE
[google] Add support for JSON key format

### DIFF
--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -4,7 +4,8 @@ module Fog
   module Compute
     class Google < Fog::Service
       requires :google_project
-      recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string, :google_client
+      recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string,
+                 :google_client, :google_json_key_location, :google_json_key_string
 
       GOOGLE_COMPUTE_API_VERSION     = 'v1'
       GOOGLE_COMPUTE_BASE_URL        = 'https://www.googleapis.com/compute/'

--- a/lib/fog/google/dns.rb
+++ b/lib/fog/google/dns.rb
@@ -4,7 +4,8 @@ module Fog
   module DNS
     class Google < Fog::Service
       requires :google_project
-      recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string, :google_client
+      recognizes :app_name, :app_version, :google_client_email, :google_key_location, :google_key_string,
+                 :google_client, :google_json_key_location, :google_json_key_string
 
       GOOGLE_DNS_API_VERSION     = 'v1beta1'
       GOOGLE_DNS_BASE_URL        = 'https://www.googleapis.com/dns/'

--- a/lib/fog/google/monitoring.rb
+++ b/lib/fog/google/monitoring.rb
@@ -5,7 +5,7 @@ module Fog
     class Monitoring < Fog::Service
       requires :google_project
       recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
-                 :app_name, :app_version
+                 :app_name, :app_version, :google_json_key_location, :google_json_key_string
 
       GOOGLE_MONITORING_API_VERSION    = 'v2beta1'
       GOOGLE_MONITORING_BASE_URL       = 'https://www.googleapis.com/cloudmonitoring/'

--- a/lib/fog/google/sql.rb
+++ b/lib/fog/google/sql.rb
@@ -5,7 +5,7 @@ module Fog
     class SQL < Fog::Service
       requires :google_project
       recognizes :google_client_email, :google_key_location, :google_key_string, :google_client,
-                 :app_name, :app_version
+                 :app_name, :app_version, :google_json_key_location, :google_json_key_string
 
       GOOGLE_SQL_API_VERSION    = 'v1beta3'
       GOOGLE_SQL_BASE_URL       = 'https://www.googleapis.com/sql/'


### PR DESCRIPTION
This fixes #3413.

@erjohnso, @icco I'm not sure if P12 format is deprecated, so I didn't add any *warning* message. We can add it later if it's finally deprecated.