### PR TITLE
[HP|storage] Add support for headers to get_object

### DIFF
--- a/lib/fog/hp/requests/storage/get_object.rb
+++ b/lib/fog/hp/requests/storage/get_object.rb
@@ -8,17 +8,19 @@ module Fog
         # * container<~String> - Name of container to look in
         # * object<~String> - Name of object to look for
         #
-        def get_object(container, object, &block)
+        def get_object(container, object, options = {}, &block)
           if block_given?
             response = request(
               :response_block  => block,
-              :expects  => 200,
+              :expects  => [200, 206],
+              :headers  => options,
               :method   => 'GET',
               :path     => "#{Fog::HP.escape(container)}/#{Fog::HP.escape(object)}"
             )
           else
             response = request({
-              :expects  => 200,
+              :expects  => [200, 206],
+              :headers  => options,
               :method   => 'GET',
               :path     => "#{Fog::HP.escape(container)}/#{Fog::HP.escape(object)}"
             }, false, &block)


### PR DESCRIPTION
This allows specifying a Range header, which in turn results in a 206 response status.