### PR TITLE
[vSphere] List compute resources, orginally PR#1978

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -58,6 +58,8 @@ module Fog
       request :get_network
       request :list_datastores
       request :get_datastore
+      request :list_compute_resources
+      request :get_compute_resource
       request :list_templates
       request :get_template
       request :get_folder

--- a/lib/fog/vsphere/requests/compute/get_compute_resource.rb
+++ b/lib/fog/vsphere/requests/compute/get_compute_resource.rb
@@ -17,6 +17,23 @@ module Fog
 
       class Mock
         def get_compute_resource(name, datacenter_name)
+          {
+            :id=>"domain-s7", 
+            :name=>"fake-host", 
+            :totalCpu=>33504, 
+            :totalMemory=>154604142592, 
+            :numCpuCores=>12, 
+            :numCpuThreads=>24, 
+            :effectiveCpu=>32247, 
+            :effectiveMemory=>135733, 
+            :numHosts=>1, 
+            :numEffectiveHosts=>1, 
+            :overallStatus=>"gray", 
+            :overallCpuUsage=>15682, 
+            :overallMemoryUsage=>132755, 
+            :effective=>true, 
+            :isSingleHost=>true
+          }
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/get_compute_resource.rb
+++ b/lib/fog/vsphere/requests/compute/get_compute_resource.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def get_compute_resource(name, datacenter_name)
+          compute_resource = get_raw_compute_resource(name, datacenter_name)
+          raise(Fog::Compute::Vsphere::NotFound) unless compute_resource
+          compute_resource_attributes(compute_resource, datacenter_name)
+        end
+
+        protected
+
+        def get_raw_compute_resource(name, datacenter_name)
+          find_raw_datacenter(datacenter_name).find_compute_resource(name)
+        end
+      end
+
+      class Mock
+        def get_compute_resource(name, datacenter_name)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/list_compute_resources.rb
+++ b/lib/fog/vsphere/requests/compute/list_compute_resources.rb
@@ -50,7 +50,41 @@ module Fog
       end
       class Mock
         def list_compute_resources(filters = { })
-          []
+          [
+            {
+              :id=>"domain-s7", 
+              :name=>"fake-host", 
+              :totalCpu=>33504, 
+              :totalMemory=>154604142592, 
+              :numCpuCores=>12, 
+              :numCpuThreads=>24, 
+              :effectiveCpu=>32247, 
+              :effectiveMemory=>135733, 
+              :numHosts=>1, 
+              :numEffectiveHosts=>1, 
+              :overallStatus=>"gray", 
+              :overallCpuUsage=>15682, 
+              :overallMemoryUsage=>132755, 
+              :effective=>true, 
+              :isSingleHost=>true
+            }, {
+              :id=>"domain-s74", 
+              :name=>"fake-cluster", 
+              :totalCpu=>41484, 
+              :totalMemory=>51525996544, 
+              :numCpuCores=>12, 
+              :numCpuThreads=>24, 
+              :effectiveCpu=>37796, 
+              :effectiveMemory=>45115, 
+              :numHosts=>2, 
+              :numEffectiveHosts=>2, 
+              :overallStatus=>"gray", 
+              :overallCpuUsage=>584, 
+              :overallMemoryUsage=>26422, 
+              :effective=>true, 
+              :isSingleHost=>false
+            }
+          ]
         end
       end
     end

--- a/lib/fog/vsphere/requests/compute/list_compute_resources.rb
+++ b/lib/fog/vsphere/requests/compute/list_compute_resources.rb
@@ -1,0 +1,56 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def list_compute_resources(filters = { })
+          datacenter_name = filters[:datacenter]
+          # default to show all compute_resources
+          only_active = filters[:effective] || false
+          compute_resources = raw_compute_resources datacenter_name
+          
+          compute_resources.map do |compute_resource|
+            summary = compute_resource.summary
+            next if only_active and summary.numEffectiveHosts == 0
+            compute_resource_attributes(compute_resource, datacenter_name)
+          end.compact
+        end
+        
+        def raw_compute_resources(datacenter_name)
+          find_raw_datacenter(datacenter_name).find_compute_resource('').children
+        end
+
+        protected
+
+        def compute_resource_attributes compute_resource, datacenter
+          overall_usage = compute_resource.host.inject({:overallCpuUsage=>0, :overallMemoryUsage=>0}) do |sum, host|
+            {
+              :overallCpuUsage => sum[:overallCpuUsage]+host.summary.quickStats.overallCpuUsage, 
+              :overallMemoryUsage=> sum[:overallMemoryUsage]+host.summary.quickStats.overallMemoryUsage
+            }
+          end
+          {
+            :id                 =>   managed_obj_id(compute_resource),
+            :name               =>   compute_resource.name,
+            :totalCpu           =>   compute_resource.summary.totalCpu, 
+            :totalMemory        =>   compute_resource.summary.totalMemory,
+            :numCpuCores        =>   compute_resource.summary.numCpuCores, 
+            :numCpuThreads      =>   compute_resource.summary.numCpuThreads,
+            :effectiveCpu       =>   compute_resource.summary.effectiveCpu,
+            :effectiveMemory    =>   compute_resource.summary.effectiveMemory,
+            :numHosts           =>   compute_resource.summary.numHosts,
+            :numEffectiveHosts  =>   compute_resource.summary.numEffectiveHosts,
+            :overallStatus      =>   compute_resource.summary.overallStatus,
+            :overallCpuUsage    =>   overall_usage[:overallCpuUsage],
+            :overallMemoryUsage =>   overall_usage[:overallMemoryUsage]
+          }
+        end
+
+      end
+      class Mock
+        def list_compute_resources(filters = { })
+          []
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vsphere/requests/compute/list_compute_resources.rb
+++ b/lib/fog/vsphere/requests/compute/list_compute_resources.rb
@@ -24,8 +24,8 @@ module Fog
         def compute_resource_attributes compute_resource, datacenter
           overall_usage = compute_resource.host.inject({:overallCpuUsage=>0, :overallMemoryUsage=>0}) do |sum, host|
             {
-              :overallCpuUsage => sum[:overallCpuUsage]+host.summary.quickStats.overallCpuUsage, 
-              :overallMemoryUsage=> sum[:overallMemoryUsage]+host.summary.quickStats.overallMemoryUsage
+              :overallCpuUsage => sum[:overallCpuUsage]+(host.summary.quickStats.overallCpuUsage || 0), 
+              :overallMemoryUsage=> sum[:overallMemoryUsage]+(host.summary.quickStats.overallMemoryUsage || 0)
             }
           end
           {

--- a/lib/fog/vsphere/requests/compute/list_compute_resources.rb
+++ b/lib/fog/vsphere/requests/compute/list_compute_resources.rb
@@ -42,7 +42,8 @@ module Fog
             :overallStatus      =>   compute_resource.summary.overallStatus,
             :overallCpuUsage    =>   overall_usage[:overallCpuUsage],
             :overallMemoryUsage =>   overall_usage[:overallMemoryUsage],
-            :effective          =>   compute_resource.summary.numEffectiveHosts > 0
+            :effective          =>   compute_resource.summary.numEffectiveHosts > 0,
+            :isSingleHost       =>   compute_resource.summary.numHosts == 1
           }
         end
 

--- a/lib/fog/vsphere/requests/compute/list_compute_resources.rb
+++ b/lib/fog/vsphere/requests/compute/list_compute_resources.rb
@@ -41,7 +41,8 @@ module Fog
             :numEffectiveHosts  =>   compute_resource.summary.numEffectiveHosts,
             :overallStatus      =>   compute_resource.summary.overallStatus,
             :overallCpuUsage    =>   overall_usage[:overallCpuUsage],
-            :overallMemoryUsage =>   overall_usage[:overallMemoryUsage]
+            :overallMemoryUsage =>   overall_usage[:overallMemoryUsage],
+            :effective          =>   compute_resource.summary.numEffectiveHosts > 0
           }
         end
 


### PR DESCRIPTION
@nirvdrum 

I created a new feature branch to filter out the unrelated commits. Please let me know any question.

Descriptions quoted from #1978:
This patch is to add list/get compute resources of vsphere functions to fog.

Usage:
to list all compute resources: compute.list_compute_resources
to just list effective compute resources(poweron + connected + not in maintenance state) : compute.list_compute_resources({:effective => true})
to get compute resources by name: compute.get_compute_resource('xxx.xxx.xxx.xxx')
to determine if the returned compute resource is single host, check the attribute 'isSingleHost'

Notice:
Vsphere abstracts clusters and hosts that don't belong to any cluster evenly as compute resource, so the return result may refer to either cluster or single host. If you want to get only hosts or clusters, you can use attribute 'isSingleHost' to determine the type.

