### PR TITLE
vm_clone used regular virtual switches no matter what type of portgroup ...

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -124,7 +124,7 @@ module Fog
                 nic_backing_info = RbVmomi::VIM::VirtualEthernetCardDistributedVirtualPortBackingInfo(
                     :port => RbVmomi::VIM::DistributedVirtualSwitchPortConnection( 
                                                                                   :portgroupKey => network.key, 
-                                                                                  :switchUuid => network.config.distributedVirtualSwitch.uuid,
+                                                                                  :switchUuid => network.config.distributedVirtualSwitch.uuid
                                                                                  ) 
                 )
             else


### PR DESCRIPTION
...was named, changed it to look up and handle distributed virtual switches correctly. @nirvdrum 