### PR TITLE
Use fog-core 1.27.4 and above

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
 
   ## List your runtime dependencies here. Runtime dependencies are those
   ## that are needed for an end user to actually USE your code.
-  s.add_dependency("fog-core", "~> 1.27", ">= 1.27.3")
+  s.add_dependency("fog-core", "~> 1.27", ">= 1.27.4")
   s.add_dependency("fog-json")
   s.add_dependency("fog-xml", "~> 0.1.1")
 


### PR DESCRIPTION
fog-core version 1.27.4 includes this bug fix:
https://github.com/fog/fog-core/commit/58556e4b1e65d2ac8dd177c531dd8a23929d39e3

Without that fix, Fog fails with:

    NoMethodError:
           undefined method `redisplay_progressbar' for Fog::Formatador:Class