### PR TITLE
Allow setting gateway option in CustomizationIPSettings

### DIFF
--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -161,8 +161,11 @@ module Fog
             end
             raise ArgumentError, "domain is required" unless cust_options.key?("domain")
             cust_domain = cust_options['domain']
-            cust_ip_settings = RbVmomi::VIM::CustomizationIPSettings.new(cust_options["ipsettings"]) if cust_options.key?("ipsettings")
-            cust_ip_settings.ip = RbVmomi::VIM::CustomizationFixedIp("ipAddress" => cust_options["ipsettings"]["ip"]) if cust_options.key?("ipsettings")
+            if cust_options.key?("ipsettings")
+              cust_ip_settings = RbVmomi::VIM::CustomizationIPSettings.new(cust_options["ipsettings"])
+              cust_ip_settings.ip = RbVmomi::VIM::CustomizationFixedIp("ipAddress" => cust_options["ipsettings"]["ip"])
+              cust_ip_settings.gateway = cust_options['ipsettings']['gateway'] if cust_options['ipsettings'].key?('gateway')
+            end
             cust_ip_settings ||= RbVmomi::VIM::CustomizationIPSettings.new("ip" => RbVmomi::VIM::CustomizationDhcpIpGenerator.new())
             cust_ip_settings.dnsDomain = cust_domain
             cust_global_ip_settings = RbVmomi::VIM::CustomizationGlobalIPSettings.new

--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -164,7 +164,7 @@ module Fog
             if cust_options.key?("ipsettings")
               cust_ip_settings = RbVmomi::VIM::CustomizationIPSettings.new(cust_options["ipsettings"])
               cust_ip_settings.ip = RbVmomi::VIM::CustomizationFixedIp("ipAddress" => cust_options["ipsettings"]["ip"])
-              cust_ip_settings.gateway = cust_options['ipsettings']['gateway'] if cust_options['ipsettings'].key?('gateway')
+              cust_ip_settings.gateway = cust_options['ipsettings']['gateway']
             end
             cust_ip_settings ||= RbVmomi::VIM::CustomizationIPSettings.new("ip" => RbVmomi::VIM::CustomizationDhcpIpGenerator.new())
             cust_ip_settings.dnsDomain = cust_domain


### PR DESCRIPTION
The "gateway" field of CustomizationIPSettings (http://pubs.vmware.com/vsphere-55/topic/com.vmware.wssdk.apiref.doc/vim.vm.customization.IPSettings.html) is mentioned in vm_clone but oddly never used, and causes an error if specified.

Tested against vSphere 5.5.