### PR TITLE
[ovirt] Implement alias attribute for Fog::Compute::Ovirt::Volume class

### DIFF
--- a/lib/fog/ovirt/models/compute/volume.rb
+++ b/lib/fog/ovirt/models/compute/volume.rb
@@ -16,6 +16,7 @@ module Fog
         attribute :size_gb
         attribute :status
         attribute :quota
+        attribute :alias
 
         def size_gb
           attributes[:size_gb] ||= attributes[:size].to_i / DISK_SIZE_TO_GB if attributes[:size]


### PR DESCRIPTION
Implement `alias` attribute for `Fog::Compute::Ovirt::Volume` class according to https://github.com/abenari/rbovirt/pull/66.