### PR TITLE
Fix broken VDI creation by doing a partial rollback

### DIFF
--- a/lib/fog/xenserver/requests/compute/create_vdi.rb
+++ b/lib/fog/xenserver/requests/compute/create_vdi.rb
@@ -3,35 +3,16 @@ module Fog
     class XenServer
       class Real
         def create_vdi( config )
-          raise ArgumentError.new('Invalid #config') if config.nil?
-          raise ArgumentError.new('Missing #virtual_size attribute') if config[:virtual_size].nil?
-          raise ArgumentError.new('Missing #read_only attribute') if config[:read_only].nil?
-          raise ArgumentError.new('Missing #type attribute') if config[:type].nil?
-          raise ArgumentError.new('Missing #sharable attribute') if config[:sharable].nil?
-          raise ArgumentError.new('Missing #other_config attribute') if config[:other_config].nil?
-          if config[:storage_repository].nil? || config[:SR].nil?
-            raise ArgumentError.new('Missing #storage_repository or #SR attribute')
-          end
-
-          if config[:storage_repository].present?
-            Fog::Logger.deprecation(
-                'The attribute #storage_repository is deprecated. Use #SR instead.'
-            )
-            config[:SR] = config[:storage_repository].reference
-          end
-          if config[:name].present?
-            Fog::Logger.deprecation(
-                'The attribute #name is deprecated. Use #name_label instead.'
-            )
-            config[:name_label] = config[:name]
-          end
-          if config[:description].present?
-            Fog::Logger.deprecation(
-                'The attribute storage_repository is deprecated. Use SR instead.'
-            )
-            config[:name_description] = config[:description]
-          end
-
+          raise ArgumentError.new('Invalid config') if config.nil?
+          raise ArgumentError.new('Missing virtual_size attribute') if config[:virtual_size].nil?
+          raise ArgumentError.new('Missing read_only attribute') if config[:read_only].nil?
+          raise ArgumentError.new('Missing type attribute') if config[:type].nil?
+          raise ArgumentError.new('Missing sharable attribute') if config[:sharable].nil?
+          raise ArgumentError.new('Missing other_config attribute') if config[:other_config].nil?
+          raise ArgumentError.new('Missing storage_repository attribute') if config[:storage_repository].nil?
+          config[:SR] = config[:storage_repository].reference
+          config[:name_label] = config[:name]
+          config[:name_description] = config[:description] if config[:description]
           config.reject! { |k,v| (k == :__sr) or (k == :storage_repository) }
           @connection.request({:parser => Fog::Parsers::XenServer::Base.new, :method => 'VDI.create'}, config )
         end


### PR DESCRIPTION
The previous change to create_vdi.rb breaks existing functionality even though it is supposed to be backwards compatible. This pull request reverts the change back to the previous working state.

## How does it break?

The condition `if config[:storage_repository].nil? || config[:SR].nil?` means that both `:storage_repository` _and_ `:SR` must be defined which is one too many.

When specifying `:SR` as part of a `compute.vdis.create :name => 'xxx', :SR => sr.reference, ...` it only appears as `:__sr` in `config` when inside the `create_vdi` method. I guess this is due to aliasing but it means that `:SR` is never defined in `config` and is thus always missing.

The `present?` method is not available in my runtime environment. It seems to be provided by Rails?

Ping: @plribeiro3000 
