### PR TITLE
[Xenserver] Fix Xenserver VDI creation

### DIFF
--- a/lib/fog/xenserver/requests/compute/create_vdi.rb
+++ b/lib/fog/xenserver/requests/compute/create_vdi.rb
@@ -9,25 +9,35 @@ module Fog
           raise ArgumentError.new('Missing #type attribute') if config[:type].nil?
           raise ArgumentError.new('Missing #sharable attribute') if config[:sharable].nil?
           raise ArgumentError.new('Missing #other_config attribute') if config[:other_config].nil?
-          if config[:storage_repository].nil? || config[:SR].nil?
-            raise ArgumentError.new('Missing #storage_repository or #SR attribute')
+
+          if config[:storage_repository].nil? && config[:SR].nil? && config[:__sr].nil?
+            raise ArgumentError.new('Missing StorageRepository reference.')
           end
 
-          if config[:storage_repository].present?
+          unless config[:storage_repository].nil?
             Fog::Logger.deprecation(
                 'The attribute #storage_repository is deprecated. Use #SR instead.'
             )
             config[:SR] = config[:storage_repository].reference
           end
-          if config[:name].present?
+
+          unless config[:__sr].nil?
+            Fog::Logger.deprecation(
+                'The attribute #__sr is deprecated. Use #SR instead.'
+            )
+            config[:SR] = config[:__sr].reference
+          end
+
+          unless config[:name].nil?
             Fog::Logger.deprecation(
                 'The attribute #name is deprecated. Use #name_label instead.'
             )
             config[:name_label] = config[:name]
           end
-          if config[:description].present?
+
+          unless config[:description].nil?
             Fog::Logger.deprecation(
-                'The attribute storage_repository is deprecated. Use SR instead.'
+                'The attribute #description is deprecated. Use #name_description instead.'
             )
             config[:name_description] = config[:description]
           end


### PR DESCRIPTION
When adding deprecations in https://github.com/fog/fog/pull/3357 the request to create VDI was broked.
This changes fixes the bad logic and add support for both cases (old and new api)
which means it is backwards compatible.

See https://github.com/fog/fog/pull/3468 for more info

cc/ @kongslund 