### PR TITLE
[GleSYS] Xen is deprecated use VMware instead

### DIFF
--- a/lib/fog/glesys/models/compute/server.rb
+++ b/lib/fog/glesys/models/compute/server.rb
@@ -58,9 +58,9 @@ module Fog
 
           options = {
             :datacenter     => datacenter   || "Falkenberg",
-            :platform       => platform     || "Xen",
+            :platform       => platform     || "OpenVz",
             :hostname       => hostname,
-            :templatename   => templatename || "Debian-6 x64",
+            :templatename   => templatename || "Debian 7.0 64-bit",
             :disksize       => disksize     || "10",
             :memorysize     => memorysize   || "512",
             :cpucores       => cpucores     || "1",

--- a/tests/glesys/requests/compute/helper.rb
+++ b/tests/glesys/requests/compute/helper.rb
@@ -114,7 +114,7 @@ class Glesys
               'unit'  => Fog::Nullable::String
             },
             'cpu'       => {
-              'usage' => Fog::Nullable::Integer,
+              'usage' => Fog::Nullable::Float,
               'max'   => Fog::Nullable::Integer,
               'unit'  => Fog::Nullable::String
             },

--- a/tests/glesys/requests/compute/helper.rb
+++ b/tests/glesys/requests/compute/helper.rb
@@ -28,7 +28,6 @@ class Glesys
           'server' => {
             'managedhosting'  => String,
             'cost'            => {
-              'amount'      =>  Float,
               'timeperiod'  => String,
               'currency'    => String
             },

--- a/tests/glesys/requests/compute/server_tests.rb
+++ b/tests/glesys/requests/compute/server_tests.rb
@@ -4,11 +4,11 @@ Shindo.tests('Fog::Compute[:glesys] | server requests', ['glesys']) do
     @hostname = "fog-#{Time.now.to_i}"
 
     @create = ":hostname => #@hostname, :rootpassword => 'pw#{Time.now.to_i}', "+
-    ":datacenter => 'Falkenberg', :platform => 'Xen', :templatename => 'Debian-6 x64', "+
+    ":datacenter => 'Falkenberg', :platform => 'VMware', :templatename => 'Debian 7.0 64-bit', "+
     ":disksize => '10', :memorysize => '512', :cpucores => '1', :transfer => '500', :bandwidth => '10'"
 
     @create_vz = ":hostname => #@hostname, :rootpassword => 'pw#{Time.now.to_i}', "+
-    ":datacenter => 'Stockholm', :platform => 'OpenVZ', :templatename => 'Debian 6.0 64-bit', "+
+    ":datacenter => 'Stockholm', :platform => 'OpenVZ', :templatename => 'Debian 7.0 64-bit', "+
     ":disksize => '10', :memorysize => '256', :cpucores => '2', :transfer => '500', :bandwidth => '10'"
 
   tests('success') do
@@ -22,10 +22,11 @@ Shindo.tests('Fog::Compute[:glesys] | server requests', ['glesys']) do
       pending if Fog.mocking?
       vm =  Fog::Compute[:glesys].create(
               :hostname     => @hostname,
+              :description  => "Fog test server",
               :rootpassword => "pw#{Time.now.to_i}",
               :datacenter   => "Falkenberg",
-              :platform     => "Xen",
-              :templatename => "Debian-6 x64",
+              :platform     => "VMware",
+              :templatename => "Debian 7.0 64-bit",
               :disksize     => "10",
               :memorysize   => "512",
               :cpucores     => "1",
@@ -86,7 +87,7 @@ Shindo.tests('Fog::Compute[:glesys] | server requests', ['glesys']) do
               :rootpassword => "pw#{Time.now.to_i}",
               :datacenter   => "Stockholm",
               :platform     => "OpenVZ",
-              :templatename => "Debian 6.0 64-bit",
+              :templatename => "Debian 7.0 64-bit",
               :disksize     => "10",
               :memorysize   => "256",
               :cpucores     => "2",


### PR DESCRIPTION
GleSYS has deprecated their Xen Platform and VMware is now recommended instead.

* Change the default values when creating a server to use Debian 7 64-bit on OpenVZ.
* Change the tests to create severs on OpenVZ and VMWare instead of OpenVZ and Xen.
* Update the test so they are consistent with the GleSYS API.