### PR TITLE
[Xenserver] Fix Xenserver VDI creation, take two

### DIFF
--- a/lib/fog/xenserver/requests/compute/create_vdi.rb
+++ b/lib/fog/xenserver/requests/compute/create_vdi.rb
@@ -25,7 +25,7 @@ module Fog
             Fog::Logger.deprecation(
                 'The attribute #__sr is deprecated. Use #SR instead.'
             )
-            config[:SR] = config[:__sr].reference
+            config[:SR] = config[:__sr]
           end
 
           unless config[:name].nil?


### PR DESCRIPTION
Treat `:__sr` as a String representing an opaque reference instead of treating it as a model object of type StorageRepository.

So now when invoking `compute.vdis.create` you can either provide :storage_repository or :SR.

    # The new way
    vdi = compute.vdis.create :name_label => 'my-disk',
                           :SR => sr.reference
    
    # The deprecated way
    vdi = compute.vdis.create :name_label => 'my-disk',
                           :storage_repository => sr

See the discussions in #3469 and #3468.

cc @plribeiro3000 