### PR TITLE
zone.id instead of zone.domain for record.destroy

### DIFF
--- a/lib/fog/dnsmadeeasy/models/dns/record.rb
+++ b/lib/fog/dnsmadeeasy/models/dns/record.rb
@@ -28,7 +28,7 @@ module Fog
         end
 
         def destroy
-          service.delete_record(zone.domain, identity)
+          service.delete_record(zone.id, identity)
           true
         end
 


### PR DESCRIPTION
domain=nil for me... but id looks good

```
dme.zones.find{ |z| z.id == 'foo.instantinfrastructure.com'}.records.find_all{|r| r.name=='foo' && r.type=='A'}.first.zone
=>   <Fog::DNS::DNSMadeEasy::Zone
    id="foo.instantinfrastructure.com",
    domain=nil,
    gtd_enabled=nil,
    nameservers=nil
  >
```