### PR TITLE
[ovirt] Fix update_interface method

### DIFF
--- a/lib/fog/ovirt/requests/compute/update_interface.rb
+++ b/lib/fog/ovirt/requests/compute/update_interface.rb
@@ -1,19 +1,32 @@
 module Fog
   module Compute
     class Ovirt
-      class Real
-        def update_interface(id, options)
+
+      module Shared
+        def check_arguments(id, options)
           raise ArgumentError, "instance id is a required parameter" unless id
           raise ArgumentError, "interface id is a required parameter for update-interface" unless options.key? :id
+        end
+      end
 
-          client.update_interface(id, options)
+      class Real
+        extend ::Fog::Compute::Ovirt::Shared
+
+        def update_interface(id, options)
+          check_arguments(id, options)
+
+          interface_id = options[:id]
+          options.delete(:id)
+
+          client.update_interface(id, interface_id, options)
         end
       end
 
       class Mock
+        extend ::Fog::Compute::Ovirt::Shared
+
         def update_interface(id, options)
-          raise ArgumentError, "instance id is a required parameter" unless id
-          raise ArgumentError, "interface id is a required parameter for update-interface" unless options.key? :id
+          check_arguments(id, options)
           true
         end
       end


### PR DESCRIPTION
It seems that uderlying `OVIRT::Client#update_interface` method has evolved and the parameters of this method have been changed. Because of this, an exception is thrown whenever `Fog::Compute::Ovirt::Real#update_interface` is called. This PR amends this.