### PR TITLE
Rackspace Neutron Security Groups & Rules

### DIFF
--- a/lib/fog/rackspace/models/networking_v2/security_group.rb
+++ b/lib/fog/rackspace/models/networking_v2/security_group.rb
@@ -1,0 +1,32 @@
+module Fog
+  module Rackspace
+    class NetworkingV2
+      class SecurityGroup < Fog::Model
+
+        identity :id
+
+        attribute :name
+        attribute :description
+        attribute :tenant_id
+
+        def save
+          data = unless self.id.nil?
+            service.update_security_group(self)
+          else
+            service.create_security_group(self)
+          end
+
+          merge_attributes(data.body['security_group'])
+          true
+        end
+
+        def destroy
+          requires :identity
+
+          service.delete_security_group(identity)
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/rackspace/models/networking_v2/security_group_rule.rb
+++ b/lib/fog/rackspace/models/networking_v2/security_group_rule.rb
@@ -1,0 +1,38 @@
+module Fog
+  module Rackspace
+    class NetworkingV2
+      class SecurityGroupRule < Fog::Model
+
+        identity :id
+
+        attribute :direction
+        attribute :ethertype
+        attribute :port_range_max
+        attribute :port_range_min
+        attribute :protocol
+        attribute :remote_group_id
+        attribute :remote_ip_prefix
+        attribute :security_group_id
+        attribute :tenant_id
+
+        def save
+          data = unless self.id.nil?
+            service.update_security_group_rule(self)
+          else
+            service.create_security_group_rule(self)
+          end
+
+          merge_attributes(data.body['security_group_rule'])
+          true
+        end
+
+        def destroy
+          requires :identity
+
+          service.delete_security_group_rule(identity)
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/rackspace/models/networking_v2/security_group_rules.rb
+++ b/lib/fog/rackspace/models/networking_v2/security_group_rules.rb
@@ -1,0 +1,23 @@
+require 'fog/rackspace/models/networking_v2/security_group_rule'
+
+module Fog
+  module Rackspace
+    class NetworkingV2
+      class SecurityGroupRules < Fog::Collection
+        model Fog::Rackspace::NetworkingV2::SecurityGroupRule
+
+        def all
+          data = service.list_security_group_rules.body['security_group_rules']
+          load(data)
+        end
+
+        def get(id)
+          data = service.show_security_group_rule(id).body['security_group_rule']
+          new(data)
+        rescue Fog::Rackspace::NetworkingV2::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/rackspace/models/networking_v2/security_groups.rb
+++ b/lib/fog/rackspace/models/networking_v2/security_groups.rb
@@ -1,0 +1,23 @@
+require 'fog/rackspace/models/networking_v2/security_group'
+
+module Fog
+  module Rackspace
+    class NetworkingV2
+      class SecurityGroups < Fog::Collection
+        model Fog::Rackspace::NetworkingV2::SecurityGroup
+
+        def all
+          data = service.list_security_groups.body['security_groups']
+          load(data)
+        end
+
+        def get(id)
+          data = service.show_security_group(id).body['security_group']
+          new(data)
+        rescue Fog::Rackspace::NetworkingV2::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/rackspace/networking_v2.rb
+++ b/lib/fog/rackspace/networking_v2.rb
@@ -31,9 +31,9 @@ module Fog
       end
 
       class InvalidImageStateException < InvalidStateException
-         def to_s
-           "Image should have transitioned to '#{desired_state}' not '#{current_state}'"
-         end
+        def to_s
+          "Image should have transitioned to '#{desired_state}' not '#{current_state}'"
+        end
       end
 
       requires :rackspace_username, :rackspace_api_key
@@ -54,6 +54,12 @@ module Fog
       model :port
       collection :ports
 
+      model :security_group
+      collection :security_groups
+
+      model :security_group_rule
+      collection :security_group_rules
+
       request_path 'fog/rackspace/requests/networking_v2'
       request :list_networks
       request :create_network
@@ -72,6 +78,17 @@ module Fog
       request :show_port
       request :update_port
       request :delete_port
+
+      request :list_security_groups
+      request :create_security_group
+      request :show_security_group
+      request :update_security_group
+      request :delete_security_group
+
+      request :list_security_group_rules
+      request :create_security_group_rule
+      request :show_security_group_rule
+      request :delete_security_group_rule
 
       class Mock < Fog::Rackspace::Service
         include Fog::Rackspace::MockData
@@ -128,10 +145,10 @@ module Fog
 
         def authenticate(options={})
           super({
-            :rackspace_api_key => @rackspace_api_key,
-            :rackspace_username => @rackspace_username,
-            :rackspace_auth_url => @rackspace_auth_url,
-            :connection_options => @connection_options
+                  :rackspace_api_key => @rackspace_api_key,
+                  :rackspace_username => @rackspace_username,
+                  :rackspace_auth_url => @rackspace_auth_url,
+                  :connection_options => @connection_options
           })
         end
 

--- a/lib/fog/rackspace/requests/networking_v2/create_security_group.rb
+++ b/lib/fog/rackspace/requests/networking_v2/create_security_group.rb
@@ -1,0 +1,12 @@
+class Fog::Rackspace::NetworkingV2::Real
+  def create_security_group(security_group)
+    data = {:security_group => security_group.attributes}
+
+    request(
+      :method  => 'POST',
+      :body    => Fog::JSON.encode(data),
+      :path    => "security-groups",
+      :expects => 201
+    )
+  end
+end

--- a/lib/fog/rackspace/requests/networking_v2/create_security_group_rule.rb
+++ b/lib/fog/rackspace/requests/networking_v2/create_security_group_rule.rb
@@ -1,0 +1,12 @@
+class Fog::Rackspace::NetworkingV2::Real
+  def create_security_group_rule(security_group_rule)
+    data = {:security_group_rule => security_group_rule.attributes}
+
+    request(
+      :method  => 'POST',
+      :body    => Fog::JSON.encode(data),
+      :path    => "security-group-rules",
+      :expects => 201
+    )
+  end
+end

--- a/lib/fog/rackspace/requests/networking_v2/delete_security_group.rb
+++ b/lib/fog/rackspace/requests/networking_v2/delete_security_group.rb
@@ -1,0 +1,5 @@
+class Fog::Rackspace::NetworkingV2::Real
+  def delete_security_group(id)
+    request(:method => 'DELETE', :path => "security-groups/#{id}", :expects => 204)
+  end
+end

--- a/lib/fog/rackspace/requests/networking_v2/delete_security_group_rule.rb
+++ b/lib/fog/rackspace/requests/networking_v2/delete_security_group_rule.rb
@@ -1,0 +1,5 @@
+class Fog::Rackspace::NetworkingV2::Real
+  def delete_security_group_rule(id)
+    request(:method => 'DELETE', :path => "security-group-rules/#{id}", :expects => 204)
+  end
+end

--- a/lib/fog/rackspace/requests/networking_v2/list_security_group_rules.rb
+++ b/lib/fog/rackspace/requests/networking_v2/list_security_group_rules.rb
@@ -1,0 +1,5 @@
+class Fog::Rackspace::NetworkingV2::Real
+  def list_security_group_rules
+    request(:method => 'GET', :path => 'security-group-rules', :expects => 200)
+  end
+end

--- a/lib/fog/rackspace/requests/networking_v2/list_security_groups.rb
+++ b/lib/fog/rackspace/requests/networking_v2/list_security_groups.rb
@@ -1,0 +1,5 @@
+class Fog::Rackspace::NetworkingV2::Real
+  def list_security_groups
+    request(:method => 'GET', :path => 'security-groups', :expects => 200)
+  end
+end

--- a/lib/fog/rackspace/requests/networking_v2/show_security_group.rb
+++ b/lib/fog/rackspace/requests/networking_v2/show_security_group.rb
@@ -1,0 +1,5 @@
+class Fog::Rackspace::NetworkingV2::Real
+  def show_security_group(id)
+    request(:method => 'GET', :path => "security-groups/#{id}", :expects => 200)
+  end
+end

--- a/lib/fog/rackspace/requests/networking_v2/show_security_group_rule.rb
+++ b/lib/fog/rackspace/requests/networking_v2/show_security_group_rule.rb
@@ -1,0 +1,5 @@
+class Fog::Rackspace::NetworkingV2::Real
+  def show_security_group_rule(id)
+    request(:method => 'GET', :path => "security-group-rules/#{id}", :expects => 200)
+  end
+end

--- a/lib/fog/rackspace/requests/networking_v2/update_security_group.rb
+++ b/lib/fog/rackspace/requests/networking_v2/update_security_group.rb
@@ -1,0 +1,12 @@
+class Fog::Rackspace::NetworkingV2::Real
+  def update_security_group(security_group)
+    data = {:security_group => {:name => security_group.name}}
+
+    request(
+      :method  => 'PUT',
+      :body    => Fog::JSON.encode(data),
+      :path    => "security-groups/#{security_group.id}",
+      :expects => 200
+    )
+  end
+end


### PR DESCRIPTION
This pull adds SecurityGroup and SecurityGroupRules for Neutron at Rackspace.
http://developer.openstack.org/api-ref-networking-v2.html

Tests exist in an external repo and will be merged in.
![fog-test 2015-03-09 16-33-48](https://cloud.githubusercontent.com/assets/2805/6563780/135c1d06-c67a-11e4-9f89-a659d8598db1.jpg)
