### PR TITLE
Add spec_helper and coverage

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -80,6 +80,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rbvmomi")
   s.add_development_dependency("rubocop") if RUBY_VERSION > "1.9"
   s.add_development_dependency("shindo", "~> 0.3.4")
+  s.add_development_dependency("simplecov")
   s.add_development_dependency("thor")
   s.add_development_dependency("yard")
 

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -72,6 +72,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("fission")
   s.add_development_dependency("google-api-client", "~> 0.6", ">= 0.6.2")
   s.add_development_dependency("minitest")
+  s.add_development_dependency("minitest-stub-const")
   s.add_development_dependency("opennebula")
   s.add_development_dependency("pry")
   s.add_development_dependency("rake")

--- a/spec/fog/account_spec.rb
+++ b/spec/fog/account_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Account do
   Fog::Account.providers.each do |provider|

--- a/spec/fog/billing_spec.rb
+++ b/spec/fog/billing_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Billing do
   Fog::Billing.providers.each do |provider|

--- a/spec/fog/bin/atmos_spec.rb
+++ b/spec/fog/bin/atmos_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/aws_spec.rb
+++ b/spec/fog/bin/aws_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/baremetalcloud_spec.rb
+++ b/spec/fog/bin/baremetalcloud_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/bluebox_spec.rb
+++ b/spec/fog/bin/bluebox_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/brightbox_spec.rb
+++ b/spec/fog/bin/brightbox_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/clodo_spec.rb
+++ b/spec/fog/bin/clodo_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/cloudsigma_spec.rb
+++ b/spec/fog/bin/cloudsigma_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/cloudstack_spec.rb
+++ b/spec/fog/bin/cloudstack_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/digitalocean_spec.rb
+++ b/spec/fog/bin/digitalocean_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/dnsimple_spec.rb
+++ b/spec/fog/bin/dnsimple_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/dnsmadeeasy_spec.rb
+++ b/spec/fog/bin/dnsmadeeasy_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/dreamhost_spec.rb
+++ b/spec/fog/bin/dreamhost_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin/dynect_spec.rb
+++ b/spec/fog/bin/dynect_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 require "helpers/bin"
 

--- a/spec/fog/bin_spec.rb
+++ b/spec/fog/bin_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 require "fog/bin"
 
 describe Fog do

--- a/spec/fog/cdn_spec.rb
+++ b/spec/fog/cdn_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::CDN do
   Fog::CDN.providers.each do |provider|

--- a/spec/fog/compute_spec.rb
+++ b/spec/fog/compute_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Compute do
   Fog::Compute.providers.each do |provider|

--- a/spec/fog/dns_spec.rb
+++ b/spec/fog/dns_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::DNS do
   Fog::DNS.providers.each do |provider|

--- a/spec/fog/identity_spec.rb
+++ b/spec/fog/identity_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Identity do
   Fog::Identity.providers.each do |provider|

--- a/spec/fog/image_spec.rb
+++ b/spec/fog/image_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Image do
   Fog::Image.providers.each do |provider|

--- a/spec/fog/metering_spec.rb
+++ b/spec/fog/metering_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Metering do
   Fog::Metering.providers.each do |provider|

--- a/spec/fog/monitoring_spec.rb
+++ b/spec/fog/monitoring_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Monitoring do
   Fog::Monitoring.providers.each do |provider|

--- a/spec/fog/network_spec.rb
+++ b/spec/fog/network_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Network do
   Fog::Network.providers.each do |provider|

--- a/spec/fog/orchestration_spec.rb
+++ b/spec/fog/orchestration_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Orchestration do
   Fog::Orchestration.providers.each do |provider|

--- a/spec/fog/storage_spec.rb
+++ b/spec/fog/storage_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Storage do
   Fog::Storage.providers.each do |provider|

--- a/spec/fog/support_spec.rb
+++ b/spec/fog/support_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Support do
   Fog::Support.providers.each do |provider|

--- a/spec/fog/volume_spec.rb
+++ b/spec/fog/volume_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::Volume do
   Fog::Volume.providers.each do |provider|

--- a/spec/fog/vpn_spec.rb
+++ b/spec/fog/vpn_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 describe Fog::VPN do
   Fog::VPN.providers.each do |provider|

--- a/spec/fog/xml/connection_spec.rb
+++ b/spec/fog/xml/connection_spec.rb
@@ -1,5 +1,4 @@
-require "minitest/autorun"
-require "fog"
+require "spec_helper"
 
 # @note This is going to be part of fog-xml eventually
 describe Fog::XML::Connection do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require "minitest/autorun"
+require "minitest/spec"
+require "minitest/stub_const"
+
+$LOAD_PATH.unshift "lib"
+
+require "fog"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,11 @@
+if ENV["COVERAGE"]
+  require "simplecov"
+
+  SimpleCov.start do
+    add_filter "/spec/"
+  end
+end
+
 require "minitest/autorun"
 require "minitest/spec"
 require "minitest/stub_const"


### PR DESCRIPTION
To help DRY out specs and making it easier to introduce coverage
this rejiggs the specs to use a simple `spec_helper` rather than
all having repeated requires.