### PR TITLE
[glesys] fix URL encoding of API parameter values

### DIFF
--- a/lib/fog/glesys/compute.rb
+++ b/lib/fog/glesys/compute.rb
@@ -121,7 +121,7 @@ module Fog
         end
 
         def urlencode(hash)
-          hash.to_a.map! { |k, v| "#{k}=#{v.to_s}" }.join("&")
+          hash.to_a.map! { |k, v| "#{k}=#{CGI.escape(v.to_s)}" }.join("&")
         end
       end
     end


### PR DESCRIPTION
Despite the name, the urlencode function does not actually apply URL encoding. This change fixes that.