### PR TITLE
Host and port options support for create_temp_url

### DIFF
--- a/lib/fog/hp/storage.rb
+++ b/lib/fog/hp/storage.rb
@@ -300,6 +300,15 @@ module Fog
           @hp_secret_key = options[:hp_secret_key]
           @hp_tenant_id = options[:hp_tenant_id]
           @os_account_meta_temp_url_key = options[:os_account_meta_temp_url_key]
+
+          @hp_storage_uri = options[:hp_auth_uri]
+
+          uri = URI.parse(@hp_storage_uri)
+          @host   = uri.host
+          @path   = uri.path
+          @persistent = options[:persistent] || false
+          @port   = uri.port
+          @scheme = uri.scheme
         end
 
         def data

--- a/lib/fog/hp/storage.rb
+++ b/lib/fog/hp/storage.rb
@@ -158,7 +158,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         def get_object_https_url(container, object, expires, options = {})
-          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "https", :port => 443))
+          create_temp_url(container, object, expires, "GET", {:port => 443}.merge(options).merge(:scheme => "https"))
         end
 
         # Get an expiring object http url
@@ -172,7 +172,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         def get_object_http_url(container, object, expires, options = {})
-          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "http", :port => 80))
+          create_temp_url(container, object, expires, "GET", {:port => 80}.merge(options).merge(:scheme => "http"))
         end
 
         # Get an object http url expiring in the given amount of seconds

--- a/lib/fog/hp/storage.rb
+++ b/lib/fog/hp/storage.rb
@@ -256,10 +256,7 @@ module Fog
               :host => host,
               :port => port,
               :path => encoded_path,
-              :query => URI.encode_www_form(
-                  :temp_url_sig => signature,
-                  :temp_url_expires => expires
-              )
+              :query => "temp_url_sig=#{signature}&temp_url_expires=#{expires}"
           }
           URI::Generic.build(temp_url_options).to_s
         end

--- a/lib/fog/hp/storage.rb
+++ b/lib/fog/hp/storage.rb
@@ -158,7 +158,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         def get_object_https_url(container, object, expires, options = {})
-          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "https"))
+          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "https", :port => 443))
         end
 
         # Get an expiring object http url
@@ -172,7 +172,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         def get_object_http_url(container, object, expires, options = {})
-          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "http"))
+          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "http", :port => 80))
         end
 
         # Get an object http url expiring in the given amount of seconds

--- a/lib/fog/openstack/requests/storage/get_object_http_url.rb
+++ b/lib/fog/openstack/requests/storage/get_object_http_url.rb
@@ -13,7 +13,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         def get_object_http_url(container, object, expires, options = {})
-          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "http", :port => 80))
+          create_temp_url(container, object, expires, "GET", {:port => 80}.merge(options).merge(:scheme => "http"))
         end
       end
     end

--- a/lib/fog/openstack/requests/storage/get_object_http_url.rb
+++ b/lib/fog/openstack/requests/storage/get_object_http_url.rb
@@ -13,7 +13,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         def get_object_http_url(container, object, expires, options = {})
-          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "http"))
+          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "http", :port => 80))
         end
       end
     end

--- a/lib/fog/openstack/requests/storage/get_object_https_url.rb
+++ b/lib/fog/openstack/requests/storage/get_object_https_url.rb
@@ -23,8 +23,10 @@ module Fog
         # * object<~String> - Name of object to get expiring url for
         # * expires<~Time> - An expiry time for this url
         # * method<~String> - The method to use for accessing the object (GET, PUT, HEAD)
-        # * scheme<~String> - The scheme to use (http, https)
         # * options<~Hash> - An optional options hash
+        #   * 'scheme'<~String> - The scheme to use (http, https)
+        #   * 'host'<~String> - The host to use
+        #   * 'port'<~Integer> - The port to use
         #
         # ==== Returns
         # * response<~Excon::Response>:
@@ -37,6 +39,8 @@ module Fog
           raise ArgumentError, "Storage must be instantiated with the :openstack_temp_url_key option" if @openstack_temp_url_key.nil?
 
           scheme = options[:scheme] || @scheme
+          host = options[:host] || @host
+          port = options[:port] || @port
 
           # POST not allowed
           allowed_methods = %w{GET PUT HEAD}
@@ -54,8 +58,8 @@ module Fog
 
           temp_url_options = {
             :scheme => scheme,
-            :host => @host,
-            :port => @port,
+            :host => host,
+            :port => port,
             :path => object_path_escaped,
             :query => URI.encode_www_form(
               :temp_url_sig => sig,

--- a/lib/fog/openstack/requests/storage/get_object_https_url.rb
+++ b/lib/fog/openstack/requests/storage/get_object_https_url.rb
@@ -61,10 +61,7 @@ module Fog
             :host => host,
             :port => port,
             :path => object_path_escaped,
-            :query => URI.encode_www_form(
-              :temp_url_sig => sig,
-              :temp_url_expires => expires
-            )
+            :query => "temp_url_sig=#{sig}&temp_url_expires=#{expires}"
           }
           URI::Generic.build(temp_url_options).to_s
         end

--- a/lib/fog/openstack/requests/storage/get_object_https_url.rb
+++ b/lib/fog/openstack/requests/storage/get_object_https_url.rb
@@ -13,7 +13,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         def get_object_https_url(container, object, expires, options = {})
-          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "https", :port => 443))
+          create_temp_url(container, object, expires, "GET", {:port => 443}.merge(options).merge(:scheme => "https"))
         end
 
         # creates a temporary url

--- a/lib/fog/openstack/requests/storage/get_object_https_url.rb
+++ b/lib/fog/openstack/requests/storage/get_object_https_url.rb
@@ -13,7 +13,7 @@ module Fog
         # * response<~Excon::Response>:
         #   * body<~String> - url for object
         def get_object_https_url(container, object, expires, options = {})
-          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "https"))
+          create_temp_url(container, object, expires, "GET", options.merge(:scheme => "https", :port => 443))
         end
 
         # creates a temporary url

--- a/tests/helpers/mock_helper.rb
+++ b/tests/helpers/mock_helper.rb
@@ -40,6 +40,7 @@ if Fog.mock?
     :hp_secret_key                    => 'hp_secret_key',
     :hp_tenant_id                     => 'hp_tenant_id',
     :hp_avl_zone                      => 'hp_avl_zone',
+    :hp_auth_uri                      => 'http://hp/v2.0/tokens',
     :os_account_meta_temp_url_key     => 'os_account_meta_temp_url_key',
     :ibm_username                     => 'ibm_username',
     :ibm_password                     => 'ibm_password',


### PR DESCRIPTION
I reused working code for building URL from `lib/fog/openstack/requests/storage/get_object_https_url.rb` in `lib/fog/hp/storage.rb` to add support for port there and to keep identical interface for both `create_temp_url` methods. I have not tested hp storage, but the fixes are trivial.