### PR TITLE
[rackspace] fix minor typo in get_object_https_url

### DIFF
--- a/lib/fog/rackspace/requests/storage/get_object_https_url.rb
+++ b/lib/fog/rackspace/requests/storage/get_object_https_url.rb
@@ -21,7 +21,7 @@ module Fog
         # http://docs.rackspace.com/files/api/v1/cf-devguide/content/Create_TempURL-d1a444.html
         def get_object_https_url(container, object, expires, options = {})
           if @rackspace_temp_url_key.nil?
-            raise ArgumentError, "Storage must my instantiated with the :rackspace_temp_url_key option"
+            raise ArgumentError, "Storage must be instantiated with the :rackspace_temp_url_key option"
           end
 
           method         = options[:method] || 'GET'


### PR DESCRIPTION
Ran into this error, figured I might as well fix the typo.