### PR TITLE
[google|compute] Adding start_server and stop_server

### DIFF
--- a/lib/fog/google/compute.rb
+++ b/lib/fog/google/compute.rb
@@ -147,6 +147,8 @@ module Fog
       request :delete_server_access_config
       request :update_url_map
       request :validate_url_map
+      request :start_server
+      request :stop_server
 
       model_path 'fog/google/models/compute'
       model :server

--- a/lib/fog/google/models/compute/server.rb
+++ b/lib/fog/google/models/compute/server.rb
@@ -129,6 +129,20 @@ module Fog
           Fog::Compute::Google::Operations.new(:service => service).get(data.body['name'], data.body['zone'])
         end
 
+        def start
+          requires :identity, :zone
+
+          data = service.start_server(identity, zone_name)
+          Fog::Compute::Google::Operations.new(:service => service).get(data.body['name'], data.body['zone'])
+        end
+
+        def stop
+          requires :identity, :zone
+
+          data = service.stop_server(identity, zone_name)
+          Fog::Compute::Google::Operations.new(:service => service).get(data.body['name'], data.body['zone'])
+        end
+
         def serial_port_output
           requires :identity, :zone
 

--- a/lib/fog/google/requests/compute/start_server.rb
+++ b/lib/fog/google/requests/compute/start_server.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def start_server(identity, zone_name)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def start_server(identity, zone_name)
+          api_method = @compute.instances.start
+          parameters = {
+            'project' => @project,
+            'zone' => zone_name,
+            'instance' => identity,
+          }
+
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/google/requests/compute/stop_server.rb
+++ b/lib/fog/google/requests/compute/stop_server.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class Google
+      class Mock
+        def stop_server(identity, zone_name)
+          Fog::Mock.not_implemented
+        end
+      end
+
+      class Real
+        def stop_server(identity, zone_name)
+          api_method = @compute.instances.stop
+          parameters = {
+            'project' => @project,
+            'zone' => zone_name,
+            'instance' => identity,
+          }
+
+          request(api_method, parameters)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Implements the following APIs:

 - https://cloud.google.com/compute/docs/reference/latest/instances/start
 - https://cloud.google.com/compute/docs/reference/latest/instances/stop