### PR TITLE
Hash#reject! returns nil if no changes were made; it is not correct beha...

### DIFF
--- a/lib/fog/xenserver/requests/compute/create_server.rb
+++ b/lib/fog/xenserver/requests/compute/create_server.rb
@@ -85,7 +85,7 @@ module Fog
 
         def create_server( name_label, template = nil, networks = [], extra_args = {})
           if name_label.is_a?(Hash)
-            config = name_label.reject! { |_k,v| v.nil? }
+            config = name_label.reject { |_k,v| v.nil? }
             ref = @connection.request({:parser => Fog::Parsers::XenServer::Base.new, :method => 'VM.create' }, config)
           else
             Fog::Logger.deprecation(

--- a/lib/fog/xenserver/requests/compute/create_vbd.rb
+++ b/lib/fog/xenserver/requests/compute/create_vbd.rb
@@ -4,7 +4,7 @@ module Fog
       class Real
         def create_vbd( vm_ref, vdi_ref = '', config = {} )
           if vm_ref.is_a?(Hash)
-            default_config = vm_ref.reject! { |_k,v| v.nil? }
+            default_config = vm_ref.reject { |_k,v| v.nil? }
           else
             Fog::Logger.deprecation(
                 'This api is deprecated. The only expected param is a hash of attributes.'

--- a/lib/fog/xenserver/requests/compute/create_vif.rb
+++ b/lib/fog/xenserver/requests/compute/create_vif.rb
@@ -6,7 +6,7 @@ module Fog
           raise ArgumentError.new('Invalid vm_ref') if vm_ref.nil?
           raise ArgumentError.new('Invalid network_ref') if network_ref.nil?
           if vm_ref.is_a?(Hash)
-            vif_config = vm_ref.reject! { |_k,v| v.nil? }
+            vif_config = vm_ref.reject { |_k,v| v.nil? }
           else
             vm_ref = vm_ref.reference if vm_ref.kind_of? Fog::Model
             network_ref = network_ref.reference if network_ref.kind_of? Fog::Model


### PR DESCRIPTION
`Hash#reject!` returns `nil` if no changes were made; it is not correct behaviour for config assignment

If there is not any `nil` value in `Hash`, nil is returned instead of expected configuration and thus it subsequent API call fails.