### PR TITLE
Added vsphere_debug flag for stderr debugging

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -7,6 +7,7 @@ module Fog
       requires :vsphere_username, :vsphere_password, :vsphere_server
       recognizes :vsphere_port, :vsphere_path, :vsphere_ns
       recognizes :vsphere_rev, :vsphere_ssl, :vsphere_expected_pubkey_hash
+      recognizes :vsphere_debug
 
       model_path 'fog/vsphere/models/compute'
       model :server
@@ -381,6 +382,7 @@ module Fog
           @vsphere_ns       = options[:vsphere_ns] || 'urn:vim25'
           @vsphere_rev      = options[:vsphere_rev] || '4.0'
           @vsphere_ssl      = options[:vsphere_ssl] || true
+          @vsphere_debug    = options[:vsphere_debug] || false
           @vsphere_expected_pubkey_hash = options[:vsphere_expected_pubkey_hash]
           @vsphere_must_reauthenticate = false
           @vsphere_is_vcenter = nil
@@ -422,7 +424,8 @@ module Fog
                                              :ns   => @vsphere_ns,
                                              :rev  => @vsphere_rev,
                                              :ssl  => @vsphere_ssl,
-                                             :insecure => bad_cert
+                                             :insecure => bad_cert,
+                                             :debug => @vsphere_debug
               break
             rescue OpenSSL::SSL::SSLError
               raise if bad_cert


### PR DESCRIPTION
Unfortunately rbvmomi does not support environment variables, this is the only
way how to pass debug flag in to see request/reply on the STDERR.