### PR TITLE
fixes issue #3458 - search vm also by 'raw_datacenter.find_vm'

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
+++ b/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
@@ -20,7 +20,7 @@ module Fog
                  else
                    # try to find based on VM name
                    if dc
-                     get_vm_by_name(id, dc)
+                     get_vm_by_name(id, dc) || raw_datacenter.find_vm(id)
                    else
                      raw_datacenters.map { |d| get_vm_by_name(id, d["name"])}.compact.first
                    end

--- a/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
@@ -28,8 +28,8 @@ module Fog
   #macAddress: "00:50:56:a9:00:28",
   #unitNumber: 7,
   #
-        def list_vm_interfaces(vm_id)
-          get_vm_ref(vm_id).config.hardware.device.grep(RbVmomi::VIM::VirtualEthernetCard).map do |nic|
+        def list_vm_interfaces(vm_id, dc=nil)
+          get_vm_ref(vm_id, dc).config.hardware.device.grep(RbVmomi::VIM::VirtualEthernetCard).map do |nic|
             {
               :name    => nic.deviceInfo.label,
               :mac     => nic.macAddress,


### PR DESCRIPTION
Searches vm either with ```get_vm_by_name``` or ```raw_datacenter.find_vm``` 