### PR TITLE
[GleSYS] server/create: sync required and optional args with API spec

### DIFF
--- a/lib/fog/glesys/models/compute/server.rb
+++ b/lib/fog/glesys/models/compute/server.rb
@@ -74,13 +74,11 @@ module Fog
               :disksize       => disksize     || "10",
               :memorysize     => memorysize   || "512",
               :cpucores       => cpucores     || "1",
-              :rootpassword   => rootpassword,
-              :transfer       => transfer     || "500",
-              :bandwidth      => bandwidth    || "10",
+              :rootpassword   => rootpassword
             }
 
             # optional options when creating a server:
-            [:ip, :ipv6, :description].each do |k|
+            [:description, :ip, :ipv6, :transfer, :bandwidth, :campaigncode, :sshkeyids, :sshkey].each do |k|
               options[k] = attributes[k] if attributes[k]
             end
 


### PR DESCRIPTION
This syncs the list of required and optional arguments for the server/create command with the API specification:
https://github.com/GleSYS/API/wiki/Full-API-Documentation#servercreate
