### PR TITLE
[vCloud Director] Fixing Unrecognized argument: path warning message

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -44,7 +44,7 @@ module Fog
       class TaskError < Fog::VcloudDirector::Errors::TaskError; end
 
       requires :vcloud_director_username, :vcloud_director_password, :vcloud_director_host
-      recognizes :vcloud_director_api_version, :vcloud_director_show_progress
+      recognizes :vcloud_director_api_version, :vcloud_director_show_progress, :path
 
       secrets :vcloud_director_password
 


### PR DESCRIPTION
If you set the path option during instantiation, the console returns an"Unrecognized argument: path warning message". 

This commit removes that warning message.

![selection_379](https://cloud.githubusercontent.com/assets/24523/7424941/ff69a42e-ef5c-11e4-8e66-417cebc8d4be.png)
