### PR TITLE
[vCloud Director] VM name and storage profile configuration on vApp instantiate.

### DIFF
--- a/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
+++ b/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
@@ -61,6 +61,21 @@ module Fog
             }
             # The template
             xml.Source(:href => options[:template_uri])
+            # Use of sourceItems for configuring VM's during instantiation.
+            # NOTE: Name and storage profile configuration supported so far.
+            # http://pubs.vmware.com/vca/index.jsp?topic=%2Fcom.vmware.vcloud.api.doc_56%2FGUID-BF9B790D-512E-4EA1-99E8-6826D4B8E6DC.html
+            (options[:vms_config] || []).each do |vm_config|
+              next unless vm_config[:href]
+              xml.SourcedItem {
+                xml.Source(:href => vm_config[:href])
+                xml.VmGeneralParams{
+                  xml.Name(vm_config[:name]) if vm_config[:name]
+                }
+                if storage_href = vm_config[:storage_profile_href]
+                  xml.StorageProfile(:href => storage_href)
+                end
+              }
+            end
             xml.AllEULAsAccepted("true")
           }
         end


### PR DESCRIPTION
Patch that adds the functionality of modifying the name and the storage profile of the VM's contained in the VApp template (catalog_item class) during instantiation.

As an example of use: 


        options = {
          vdc_id: VDC_ID, network_id: NETWORK_ID,
          # New section that allows to configure name and disk type
          vms_config: [
            {
              href: VM_SOURCE_HREF,
              storage_profile_href: STORAGE_PROFILE_HREF,
              name: "My VM name"
            }
          ]
        }

        catalog_item.instantiate(display_name, options)


If you do not add the vms_config the behavior is the same one than the current one. 

It is based on [this documentation](http://pubs.vmware.com/vca/index.jsp?topic=%2Fcom.vmware.vcloud.api.doc_56%2FGUID-BF9B790D-512E-4EA1-99E8-6826D4B8E6DC.html).
 
Regards,
Miguel

