### PR TITLE
Allow passing query options to snapshots endpoint.

### DIFF
--- a/lib/fog/openstack/requests/volume/list_snapshots.rb
+++ b/lib/fog/openstack/requests/volume/list_snapshots.rb
@@ -2,18 +2,19 @@ module Fog
   module Volume
     class OpenStack
       class Real
-        def list_snapshots(detailed=true)
+        def list_snapshots(detailed=true, options={})
           path = detailed ? 'snapshots/detail' : 'snapshots'
           request(
             :expects  => 200,
             :method   => 'GET',
-            :path     => path
+            :path     => path,
+            :query    => options
           )
         end
       end
 
       class Mock
-        def list_snapshots(detailed=true)
+        def list_snapshots(detailed=true, options={})
           response = Excon::Response.new
           response.status = 200
           response.body = {


### PR DESCRIPTION
This is so we can pass `all_tenants: true` to the endpoint and get a full list of snapshots for the platform.