### PR TITLE
[openstack|compute] added support for flavor extra_specs

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -98,6 +98,10 @@ module Fog
       request :create_flavor
       request :delete_flavor
 
+      # Flavor Actions
+      request :get_flavor_extra_specs
+      request :create_flavor_extra_specs
+
       # Flavor Access
       request :add_flavor_access
       request :remove_flavor_access

--- a/lib/fog/openstack/models/compute/flavor.rb
+++ b/lib/fog/openstack/models/compute/flavor.rb
@@ -13,6 +13,7 @@ module Fog
         attribute :links
         attribute :swap
         attribute :rxtx_factor
+        attribute :extra_specs
         attribute :ephemeral, :aliases => 'OS-FLV-EXT-DATA:ephemeral'
         attribute :is_public, :aliases => 'os-flavor-access:is_public'
         attribute :disabled, :aliases => 'OS-FLV-DISABLED:disabled'
@@ -38,6 +39,18 @@ module Fog
           requires :id
           service.delete_flavor(self.id)
           true
+        end
+
+        def extra_specs
+          service.get_flavor_extra_specs(self.id).body['extra_specs']
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
+        end
+
+        def create_extra_specs(extra_specs)
+          service.create_flavor_extra_specs(self.id, extra_specs)
+        rescue Fog::Compute::OpenStack::NotFound
+          nil
         end
       end
     end

--- a/lib/fog/openstack/requests/compute/create_flavor_extra_specs.rb
+++ b/lib/fog/openstack/requests/compute/create_flavor_extra_specs.rb
@@ -17,7 +17,7 @@ module Fog
       end
 
       class Mock
-        def create_flavor_extra_specs(attributes)
+        def create_flavor_extra_specs(flavor_ref, extra_specs)
           response = Excon::Response.new
           response.status = 200
           response.headers = {

--- a/lib/fog/openstack/requests/compute/create_flavor_extra_specs.rb
+++ b/lib/fog/openstack/requests/compute/create_flavor_extra_specs.rb
@@ -1,0 +1,38 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        def create_flavor_extra_specs(flavor_ref, extra_specs)
+          data = {
+            'extra_specs' => extra_specs
+          }
+
+          request(
+            :body => Fog::JSON.encode(data),
+            :expects => 200,
+            :method => 'POST',
+            :path     => "flavors/#{flavor_ref}/os-extra_specs"
+          )
+        end
+      end
+
+      class Mock
+        def create_flavor_extra_specs(attributes)
+          response = Excon::Response.new
+          response.status = 200
+          response.headers = {
+            "X-Compute-Request-Id" => "req-fdc6f99e-55a2-4ab1-8904-0892753828cf",
+            "Content-Type" => "application/json",
+            "Content-Length" => "356",
+            "Date" => Date.new
+          }
+          response.body = { "extra_specs" => {
+              "cpu_arch" => "x86_64"
+            }
+          }
+          response
+        end
+      end # mock
+    end # openstack
+  end # compute
+end # fog

--- a/lib/fog/openstack/requests/compute/get_flavor_extra_specs.rb
+++ b/lib/fog/openstack/requests/compute/get_flavor_extra_specs.rb
@@ -12,7 +12,7 @@ module Fog
       end
 
       class Mock
-        def get_flavor_extra_specs(host)
+        def get_flavor_extra_specs(flavor_ref)
           response = Excon::Response.new
           response.status = 200
           response.body = { "extra_specs" => {

--- a/lib/fog/openstack/requests/compute/get_flavor_extra_specs.rb
+++ b/lib/fog/openstack/requests/compute/get_flavor_extra_specs.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        def get_flavor_extra_specs(flavor_ref)
+          request(
+            :expects  => [200, 203],
+            :method   => 'GET',
+            :path     => "flavors/#{flavor_ref}/os-extra_specs"
+          )
+        end
+      end
+
+      class Mock
+        def get_flavor_extra_specs(host)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = { "extra_specs" => {
+              "cpu_arch" => "x86_64"
+            }
+          }
+          response
+        end
+      end # mock
+    end # openstack
+  end # compute
+end # fog

--- a/tests/openstack/requests/compute/flavor_tests.rb
+++ b/tests/openstack/requests/compute/flavor_tests.rb
@@ -49,6 +49,14 @@ Shindo.tests('Fog::Compute[:openstack] | flavor requests', ['openstack']) do
       Fog::Compute[:openstack].delete_flavor('100')
     end
 
+    tests('#get_flavor_extra_specs(flavor_ref)').data_matches_schema('extra_specs' => {'cpu_arch' => String}) do
+      Fog::Compute[:openstack].get_flavor_extra_specs("1").body
+    end
+
+    tests('#create_flavor_extra_specs(flavor_ref, extra_specs)').data_matches_schema('extra_specs' => {'cpu_arch' => String}) do
+      extra_specs = {:cpu_arch => 'x86_64'}
+      Fog::Compute[:openstack].create_flavor_extra_specs("1", extra_specs).body
+    end
   end
 
   tests('failure') do
@@ -72,6 +80,16 @@ Shindo.tests('Fog::Compute[:openstack] | flavor requests', ['openstack']) do
       Fog::Compute[:openstack].list_tenants_with_flavor_access(1234)
     end
 
+    tests('get_flavor_extra_specs(flavor_ref)').raises(Fog::Compute::OpenStack::NotFound) do
+      pending if Fog.mocking?
+      Fog::Compute[:openstack].get_flavor_extra_specs("1234").body
+    end
+
+    tests('create_flavor_extra_specs(flavor_ref)').raises(Fog::Compute::OpenStack::NotFound) do
+      pending if Fog.mocking?
+      extra_specs = {:cpu_arch => 'x86_64'}
+      Fog::Compute[:openstack].create_flavor_extra_specs("1234", extra_specs).body
+    end
   end
 
 end


### PR DESCRIPTION
Adds support for getting and creating extra_specs for an OpenStack
flavor.