### PR TITLE
OpenStack allow domains to be optional fix warning

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -10,6 +10,7 @@ module Fog
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region,
                  :openstack_endpoint_type,
+                 :openstack_project_name,
                  :openstack_project_domain, :openstack_user_domain
 
       ## MODELS

--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -177,7 +177,7 @@ module Fog
     def self.authenticate_v3(options, connection_options = {})
       uri                   = options[:openstack_auth_uri]
       tenant_name           = options[:openstack_tenant]
-      project_name           = options[:openstack_project_name]
+      project_name          = options[:openstack_project_name]
       service_type          = options[:openstack_service_type]
       service_name          = options[:openstack_service_name]
       identity_service_type = options[:openstack_identity_service_type]
@@ -349,7 +349,7 @@ module Fog
       end
       auth_token  = options[:openstack_auth_token] || options[:unscoped_token]
       uri         = options[:openstack_auth_uri]
-      userdomain  = options[:openstack_user_domain] || options[:openstack_domain]
+      userdomain  = options[:openstack_user_domain] || options[:openstack_domain] || 'Default'
       project_domain  = options[:openstack_project_domain]  || options[:openstack_domain] || 'Default'
 
       connection = Fog::Core::Connection.new(uri.to_s, false, connection_options)
@@ -364,9 +364,6 @@ module Fog
           :methods => ["password"],
           :password => {
             :user => {
-              :domain => {
-                :name => userdomain
-              },
               :name => username,
               :password => api_key
             }
@@ -381,11 +378,18 @@ module Fog
         else
           request_body[:auth][:scope] = {
             :project => {
-              :domain => {
-                :name => project_domain
-              },
               :name => tenant_name
             }
+          }
+        end
+        unless userdomain.to_s.empty?
+          request_body[:auth][:identity][:password][:user][:domain] = {
+                  :name => userdomain
+          }
+        end
+        unless project_domain.to_s.empty?
+          request_body[:auth][:scope][:project][:domain] = {
+                :name => project_domain
           }
         end
       end

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -11,6 +11,7 @@ module Fog
                  :openstack_tenant_id,
                  :openstack_api_key, :openstack_username, :openstack_endpoint_type,
                  :current_user, :current_tenant, :openstack_region,
+                 :openstack_project_name,
                  :openstack_project_domain, :openstack_user_domain
 
       ## MODELS


### PR DESCRIPTION
Allow project and user domains to be optional and make
openstack_project_name a valid option with no warning.