### PR TITLE
Vsphere - customizing interfaces and disks when cloning from template

### DIFF
--- a/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
+++ b/lib/fog/vsphere/requests/compute/list_vm_interfaces.rb
@@ -28,8 +28,8 @@ module Fog
   #macAddress: "00:50:56:a9:00:28",
   #unitNumber: 7,
   #
-        def list_vm_interfaces(vm_id)
-          get_vm_ref(vm_id).config.hardware.device.grep(RbVmomi::VIM::VirtualEthernetCard).map do |nic|
+        def list_vm_interfaces(vm_id, datacenter = nil)
+          get_vm_ref(vm_id, datacenter).config.hardware.device.grep(RbVmomi::VIM::VirtualEthernetCard).map do |nic|
             {
               :name    => nic.deviceInfo.label,
               :mac     => nic.macAddress,


### PR DESCRIPTION
After this patch, the clone_vm accepts interfaces and volumes options, taking
interface resp. volume objects to modify the ones defined in the template.
This allows to customize all the interfaces (not just changing the
network_label on one of them), as well as increasing the size of the volumes
and adding or removing them.