### PR TITLE
Do not double encode image query

### DIFF
--- a/lib/fog/openstack/requests/image/list_public_images_detailed.rb
+++ b/lib/fog/openstack/requests/image/list_public_images_detailed.rb
@@ -5,7 +5,7 @@ module Fog
         def list_public_images_detailed(attribute=nil, query=nil)
           path = 'images/detail'
           if attribute
-            query = { attribute => URI::encode(query) }
+            query = { attribute => query }
           else
             query = {}
           end


### PR DESCRIPTION
Assume at the request level that the query is encoded already.