### PR TITLE
Fog::OpenStack::Compute: remove assumption about endpoint URL format

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -368,7 +368,7 @@ module Fog
                 'Accept' => 'application/json',
                 'X-Auth-Token' => @auth_token
               }.merge!(params[:headers] || {}),
-              :path     => "#{@path}/#{@tenant_id}/#{params[:path]}",
+              :path     => "#{@path}/#{params[:path]}",
               :query    => params[:query]
             }))
           rescue Excon::Errors::Unauthorized => error
@@ -429,7 +429,7 @@ module Fog
 
           uri = URI.parse(@openstack_management_url)
           @host   = uri.host
-          @path, @tenant_id = uri.path.scan(/(\/.*)\/(.*)/).flatten
+          @path   = uri.path
 
           @path.sub!(/\/$/, '')
           unless @path.match(/1\.1|v2/)

--- a/lib/fog/openstack/requests/compute/list_tenants_with_flavor_access.rb
+++ b/lib/fog/openstack/requests/compute/list_tenants_with_flavor_access.rb
@@ -16,7 +16,7 @@ module Fog
           response = Excon::Response.new
           response.status = 200
           response.body = {
-            "flavor_access" => [{ "tenant_id" => @tenant_id.to_s, "flavor_id" => flavor_ref.to_s }]
+            "flavor_access" => [{ "tenant_id" => Fog::Mock.random_hex(33), "flavor_id" => flavor_ref.to_s }]
           }
           response
         end


### PR DESCRIPTION
The reference implementation's endpoint URL ends with the tenant ID,
but that's not a requirement for the service to work. I work with
software that has differently-formatted endpoint URLs that don't
contain tenant IDs at all.

Review is much appreciated.