### PR TITLE
Upgraded fog-core to version 1.30

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md]
 
-  s.add_dependency("fog-core", "~> 1.27", ">= 1.27.4")
+  s.add_dependency("fog-core", "~> 1.30")
   s.add_dependency("fog-json")
   s.add_dependency("fog-xml", "~> 0.1.1")
 


### PR DESCRIPTION
We are using Fog in our application and are trying to eliminate the verbose warnings that older versions of Excon output. Since the master branch of Fog has fog-core locked to 1.27, the locked version of Excon is too low and the bug is present. We have upgraded the fog-core dependency to 1.30 in order to upgrade Excon.