### PR TITLE
[vsphere] Use traverse to get resource pools, fixes #3579

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_resource_pool.rb
+++ b/lib/fog/vsphere/requests/compute/get_resource_pool.rb
@@ -13,7 +13,7 @@ module Fog
         def get_raw_resource_pool(name, cluster_name, datacenter_name)
           dc      = find_raw_datacenter(datacenter_name)
           cluster = dc.find_compute_resource(cluster_name)
-          name.nil? ? cluster.resourcePool : cluster.resourcePool.find( name)
+          name.nil? ? cluster.resourcePool : cluster.resourcePool.traverse(name)
         end
       end
 


### PR DESCRIPTION
This uses the traverse method instead of find, fixing issues with nested resource pools. Fixes #3579 