### PR TITLE
[vsphere] Fix nested folders in get virtual machine

### DIFF
--- a/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
+++ b/lib/fog/vsphere/requests/compute/get_virtual_machine.rb
@@ -31,9 +31,10 @@ module Fog
         def get_vm_by_name(name, dc)
           vms = raw_list_all_virtual_machines(dc)
 
-          if name.include?('/')
-            folder, basename = name.split('/')
-            vms.keep_if { |v| v["name"] == basename && v.parent["name"] == folder }.first
+         if name.include?('/')
+            folder = File.dirname(name)
+            basename = File.basename(name)
+            vms.keep_if { |v| v["name"] == basename && v.parent.pretty_path.include?(folder) }.first
           else
             vms.keep_if { |v| v["name"] == name }.first
           end


### PR DESCRIPTION
Currently when trying to look up a template in a nested folder (e.g. "Templates/Update/New") we get a NotFound error:

```bash
/Users/asebastian/.rvm/gems/ruby-2.2.2/gems/fog-1.30.0/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:28:in `get_vm_ref': Templates/Update/New/ubuntu-1204-t was not found (Fog::Compute::Vsphere::NotFound)
	from /Users/asebastian/.rvm/gems/ruby-2.2.2/gems/fog-1.30.0/lib/fog/vsphere/requests/compute/get_virtual_machine.rb:7:in `get_virtual_machine'
	from test_get_virtual_machine.rb:12:in `initialize'
	from test_get_virtual_machine.rb:23:in `new'
	from test_get_virtual_machine.rb:23:in `<main>'
```

This pull request enables a user to find a virtual machine which resides in a (deeply) nested folder.