### PR TITLE
[openstack] create_volume: add metadata option

### DIFF
--- a/lib/fog/openstack/models/volume/volume.rb
+++ b/lib/fog/openstack/models/volume/volume.rb
@@ -8,6 +8,7 @@ module Fog
 
         attribute :display_name,        :aliases => 'displayName'
         attribute :display_description, :aliases => 'displayDescription'
+        attribute :metadata
         attribute :status
         attribute :size
         attribute :volume_type,         :aliases => ['volumeType', 'type']

--- a/lib/fog/openstack/requests/volume/create_volume.rb
+++ b/lib/fog/openstack/requests/volume/create_volume.rb
@@ -12,7 +12,7 @@ module Fog
           }
 
           vanilla_options = [:snapshot_id, :imageRef, :volume_type,
-            :source_volid, :availability_zone]
+            :source_volid, :availability_zone, :metadata]
           vanilla_options.select{|o| options[o]}.each do |key|
             data['volume'][key] = options[key]
           end
@@ -34,6 +34,7 @@ module Fog
               'id'                  => Fog::Mock.random_numbers(2),
               'display_name'        => name,
               'display_description' => description,
+              'metadata'            => options['metadata'] || {},
               'size'                => size,
               'status'              => 'creating',
               'snapshot_id'         => options[:snapshot_id] || nil,


### PR DESCRIPTION
analogous to [create_server](https://github.com/fog/fog/blob/master/lib/fog/openstack/requests/compute/create_server.rb#L14) the metadata option can be also used at create_volume (see [api-ref-v1](http://developer.openstack.org/api-ref-blockstorage-v1.html#createVolume) and [api-ref-v2](http://developer.openstack.org/api-ref-blockstorage-v2.html#createVolume))