### PR TITLE
OpenStack port: add security groups to model and update request

### DIFF
--- a/lib/fog/openstack/models/network/port.rb
+++ b/lib/fog/openstack/models/network/port.rb
@@ -15,6 +15,7 @@ module Fog
         attribute :device_owner
         attribute :device_id
         attribute :tenant_id
+        attribute :security_groups
 
         def initialize(attributes)
           # Old 'connection' is renamed as service and should be used instead

--- a/lib/fog/openstack/requests/network/update_port.rb
+++ b/lib/fog/openstack/requests/network/update_port.rb
@@ -6,7 +6,7 @@ module Fog
           data = { 'port' => {} }
 
           vanilla_options = [:name, :fixed_ips, :admin_state_up, :device_owner,
-                             :device_id]
+                             :device_id, :security_groups]
           vanilla_options.select{ |o| options.key?(o) }.each do |key|
             data['port'][key] = options[key]
           end
@@ -24,11 +24,12 @@ module Fog
         def update_port(port_id, options = {})
           response = Excon::Response.new
           if port = list_ports.body['ports'].find { |_| _['id'] == port_id }
-            port['name']           = options[:name]
-            port['fixed_ips']      = options[:fixed_ips]
-            port['admin_state_up'] = options[:admin_state_up]
-            port['device_owner']   = options[:device_owner]
-            port['device_id']      = options[:device_id]
+            port['name']              = options[:name]
+            port['fixed_ips']         = options[:fixed_ips]
+            port['admin_state_up']    = options[:admin_state_up]
+            port['device_owner']      = options[:device_owner]
+            port['device_id']         = options[:device_id]
+            port['security_groups']   = options[:security_groups]
             response.body = { 'port' => port }
             response.status = 200
             response

--- a/lib/fog/openstack/requests/network/update_port.rb
+++ b/lib/fog/openstack/requests/network/update_port.rb
@@ -25,11 +25,11 @@ module Fog
           response = Excon::Response.new
           if port = list_ports.body['ports'].find { |_| _['id'] == port_id }
             port['name']              = options[:name]
-            port['fixed_ips']         = options[:fixed_ips]
+            port['fixed_ips']         = options[:fixed_ips] || []
             port['admin_state_up']    = options[:admin_state_up]
             port['device_owner']      = options[:device_owner]
             port['device_id']         = options[:device_id]
-            port['security_groups']   = options[:security_groups]
+            port['security_groups']   = options[:security_groups] || []
             response.body = { 'port' => port }
             response.status = 200
             response


### PR DESCRIPTION
The security groups option is already there in the [create-request](https://github.com/fog/fog/blob/master/lib/fog/openstack/requests/network/create_port.rb#L13), it can also be used in the update_request (see [api-ref](http://developer.openstack.org/api-ref-networking-v2.html#updatePort)) and be shown in the related model