### PR TITLE
include core in identity_v3 mock

### DIFF
--- a/lib/fog/openstack/identity_v3.rb
+++ b/lib/fog/openstack/identity_v3.rb
@@ -119,6 +119,7 @@ module Fog
         request :delete_policy
 
         class Mock
+          include Fog::OpenStack::Core
           def initialize(options={})
 
           end


### PR DESCRIPTION
Fixes "undefined method `credentials' for #<Fog::Identity::OpenStack::V3::Mock>" in tests.