### PR TITLE
OpenStack Compute list methods unified interface

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -178,6 +178,7 @@ module Fog
 
       # Volume
       request :list_volumes
+      request :list_volumes_detail
       request :create_volume
       request :get_volume_details
       request :delete_volume
@@ -185,8 +186,10 @@ module Fog
       request :detach_volume
       request :get_server_volumes
 
+      # Snapshot
       request :create_volume_snapshot
       request :list_snapshots
+      request :list_snapshots_detail
       request :get_snapshot_details
       request :delete_snapshot
 

--- a/lib/fog/openstack/models/compute/addresses.rb
+++ b/lib/fog/openstack/models/compute/addresses.rb
@@ -7,9 +7,11 @@ module Fog
       class Addresses < Fog::Collection
         model Fog::Compute::OpenStack::Address
 
-        def all
-          load(service.list_all_addresses.body['floating_ips'])
+        def all(options = {})
+          load(service.list_all_addresses(options).body['floating_ips'])
         end
+
+        alias_method :summary, :all
 
         def get(address_id)
           if address = service.get_address(address_id).body['floating_ip']

--- a/lib/fog/openstack/models/compute/aggregates.rb
+++ b/lib/fog/openstack/models/compute/aggregates.rb
@@ -7,9 +7,10 @@ module Fog
       class Aggregates < Fog::Collection
         model Fog::Compute::OpenStack::Aggregate
 
-        def all(parameters=nil)
-          load(service.list_aggregates(parameters).body['aggregates'])
+        def all(options = {})
+          load(service.list_aggregates(options).body['aggregates'])
         end
+
         alias_method :summary, :all
 
         def find_by_id(id)

--- a/lib/fog/openstack/models/compute/flavors.rb
+++ b/lib/fog/openstack/models/compute/flavors.rb
@@ -12,6 +12,11 @@ module Fog
           load(data)
         end
 
+        def summary(options = {})
+          data = service.list_flavors(options).body['flavors']
+          load(data)
+        end
+
         def get(flavor_id)
           data = service.get_flavor_details(flavor_id).body['flavor']
           new(data)

--- a/lib/fog/openstack/models/compute/hosts.rb
+++ b/lib/fog/openstack/models/compute/hosts.rb
@@ -7,10 +7,12 @@ module Fog
       class Hosts < Fog::Collection
         model Fog::Compute::OpenStack::Host
 
-        def all
-          data = service.list_hosts.body['hosts']
+        def all(options = {})
+          data = service.list_hosts(options).body['hosts']
           load(data)
         end
+
+        alias_method :summary, :all
 
         def get(host_name)
           if host = service.get_host_details(host_name).body['host']

--- a/lib/fog/openstack/models/compute/images.rb
+++ b/lib/fog/openstack/models/compute/images.rb
@@ -26,6 +26,8 @@ module Fog
           images
         end
 
+        alias_method :summary, :all
+
         def get(image_id)
           data = service.get_image_details(image_id).body['image']
           new(data)

--- a/lib/fog/openstack/models/compute/key_pairs.rb
+++ b/lib/fog/openstack/models/compute/key_pairs.rb
@@ -7,13 +7,15 @@ module Fog
       class KeyPairs < Fog::Collection
         model Fog::Compute::OpenStack::KeyPair
 
-        def all
+        def all(options = {})
           items = Array.new
-          service.list_key_pairs.body['keypairs'].each do |kp|
+          service.list_key_pairs(options).body['keypairs'].each do |kp|
             items = items + kp.values
           end
           load(items)
         end
+
+        alias_method :summary, :all
 
         def get(key_pair_name)
           if key_pair_name

--- a/lib/fog/openstack/models/compute/security_groups.rb
+++ b/lib/fog/openstack/models/compute/security_groups.rb
@@ -7,9 +7,11 @@ module Fog
       class SecurityGroups < Fog::Collection
         model Fog::Compute::OpenStack::SecurityGroup
 
-        def all
-          load(service.list_security_groups.body['security_groups'])
+        def all(options = {})
+          load(service.list_security_groups(options).body['security_groups'])
         end
+
+        alias_method :summary, :all
 
         def get(security_group_id)
           if security_group_id

--- a/lib/fog/openstack/models/compute/servers.rb
+++ b/lib/fog/openstack/models/compute/servers.rb
@@ -20,6 +20,8 @@ module Fog
           load(data)
         end
 
+        alias_method :summary, :all
+
         # Creates a new server and populates ssh keys
         # @return [Fog::Compute::OpenStack::Server]
         # @raise [Fog::Compute::OpenStack::NotFound] - HTTP 404

--- a/lib/fog/openstack/models/compute/services.rb
+++ b/lib/fog/openstack/models/compute/services.rb
@@ -7,12 +7,15 @@ module Fog
       class Services < Fog::Collection
         model Fog::Compute::OpenStack::Service
 
-        def all(parameters=nil)
-          load(service.list_services(parameters).body['services'])
+        def all(options = {})
+          load(service.list_services(options).body['services'])
         end
 
-        def details(parameters=nil)
-          load(service.list_services(parameters).body['services'])
+        alias_method :summary, :all
+
+        def details(options = {})
+          Fog::Logger.deprecation('Calling OpenStack[:compute].services.details is deprecated, use .services.all')
+          load(service.list_services(options).body['services'])
         end
       end
     end

--- a/lib/fog/openstack/models/compute/snapshots.rb
+++ b/lib/fog/openstack/models/compute/snapshots.rb
@@ -7,8 +7,21 @@ module Fog
       class Snapshots < Fog::Collection
         model Fog::Compute::OpenStack::Snapshot
 
-        def all(detailed=true)
-          load(service.list_snapshots(detailed).body['snapshots'])
+        def all(options = {})
+          if !options.is_a?(Hash)
+            if options
+              Fog::Logger.deprecation('Calling OpenStack[:compute].snapshots.all(true) is deprecated, use .snapshots.all')
+            else
+              Fog::Logger.deprecation('Calling OpenStack[:compute].snapshots.all(false) is deprecated, use .snapshots.summary')
+            end
+            load(service.list_snapshots(options).body['snapshots'])
+          else
+            load(service.list_snapshots_detail(options).body['snapshots'])
+          end
+        end
+
+        def summary(options = {})
+          load(service.list_snapshots(options).body['snapshots'])
         end
 
         def get(snapshot_id)

--- a/lib/fog/openstack/models/compute/volumes.rb
+++ b/lib/fog/openstack/models/compute/volumes.rb
@@ -7,8 +7,21 @@ module Fog
       class Volumes < Fog::Collection
         model Fog::Compute::OpenStack::Volume
 
-        def all(detailed=true)
-          load(service.list_volumes(detailed).body['volumes'])
+        def all(options = true)
+          if !options.is_a?(Hash)
+            if options
+              Fog::Logger.deprecation('Calling OpenStack[:compute].volumes.all(true) is deprecated, use .volumes.all')
+            else
+              Fog::Logger.deprecation('Calling OpenStack[:compute].volumes.all(false) is deprecated, use .volumes.summary')
+            end
+            load(service.list_volumes(options).body['volumes'])
+          else
+            load(service.list_volumes_detail(options).body['volumes'])
+          end
+        end
+
+        def summary(options = {})
+          load(service.list_volumes(options).body['volumes'])
         end
 
         def get(volume_id)

--- a/lib/fog/openstack/requests/compute/list_aggregates.rb
+++ b/lib/fog/openstack/requests/compute/list_aggregates.rb
@@ -2,24 +2,18 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def list_aggregates(parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
+        def list_aggregates(options = {})
           request(
             :expects => [200, 203],
             :method  => 'GET',
             :path    => 'os-aggregates',
-            :query   => query
+            :query   => options
           )
         end
       end
 
       class Mock
-        def list_aggregates(parameters=nil)
+        def list_aggregates(options = {})
           response = Excon::Response.new
           response.status = 200
           response.body = {'aggregates' => [{

--- a/lib/fog/openstack/requests/compute/list_all_addresses.rb
+++ b/lib/fog/openstack/requests/compute/list_all_addresses.rb
@@ -2,17 +2,18 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def list_all_addresses
+        def list_all_addresses(options = {})
           request(
             :expects  => [200, 203],
             :method   => 'GET',
-            :path     => "os-floating-ips.json"
+            :path     => "os-floating-ips.json",
+            :query    => options
           )
         end
       end
 
       class Mock
-        def list_all_addresses
+        def list_all_addresses(options = {})
           response = Excon::Response.new
           response.status = 200
           response.headers = {

--- a/lib/fog/openstack/requests/compute/list_flavors.rb
+++ b/lib/fog/openstack/requests/compute/list_flavors.rb
@@ -2,17 +2,18 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def list_flavors
+        def list_flavors(options = {})
           request(
-            :expects  => [200, 203],
-            :method   => 'GET',
-            :path     => 'flavors.json'
+            :expects => [200, 203],
+            :method  => 'GET',
+            :path    => 'flavors.json',
+            :query   => options
           )
         end
       end
 
       class Mock
-        def list_flavors
+        def list_flavors(options = {})
           response = Excon::Response.new
           response.status = 200
           response.body = {

--- a/lib/fog/openstack/requests/compute/list_hosts.rb
+++ b/lib/fog/openstack/requests/compute/list_hosts.rb
@@ -2,17 +2,18 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def list_hosts
+        def list_hosts(options = {})
           request(
             :expects  => [200, 203],
             :method   => 'GET',
-            :path     => 'os-hosts.json'
+            :path     => 'os-hosts.json',
+            :query    => options
           )
         end
       end
 
       class Mock
-        def list_hosts
+        def list_hosts(options = {})
           response = Excon::Response.new
           response.status = 200
           response.body = { "hosts" => [

--- a/lib/fog/openstack/requests/compute/list_key_pairs.rb
+++ b/lib/fog/openstack/requests/compute/list_key_pairs.rb
@@ -2,17 +2,18 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def list_key_pairs
+        def list_key_pairs(options = {})
           request(
             :expects  => [200, 203],
             :method   => 'GET',
-            :path     => 'os-keypairs.json'
+            :path     => 'os-keypairs.json',
+            :query    => options
           )
         end
       end
 
       class Mock
-        def list_key_pairs
+        def list_key_pairs(options = {})
           response = Excon::Response.new
           response.status = 200
           response.headers = {

--- a/lib/fog/openstack/requests/compute/list_security_groups.rb
+++ b/lib/fog/openstack/requests/compute/list_security_groups.rb
@@ -2,15 +2,28 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def list_security_groups(server_id = nil)
+        def list_security_groups(options = {})
           path = "os-security-groups.json"
+
+          if options.is_a?(Hash)
+            server_id = options.delete(:server_id)
+            query = options
+          elsif
+            # Backwards compatibility layer, only server_id was passed as first parameter previously
+            Fog::Logger.deprecation('Calling OpenStack[:compute].list_security_groups(server_id) is deprecated, use .list_security_groups(:server_id => value) instead')
+            server_id = options
+            query = {}
+          end
+
           if server_id
             path = "servers/#{server_id}/#{path}"
           end
+
           request(
             :expects  => [200],
             :method   => 'GET',
-            :path     => path
+            :path     => path,
+            :query    => query
           )
         end
       end

--- a/lib/fog/openstack/requests/compute/list_snapshots.rb
+++ b/lib/fog/openstack/requests/compute/list_snapshots.rb
@@ -2,18 +2,32 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def list_snapshots(detailed=true)
-          path = detailed ? 'os-snapshots/detail' : 'os-snapshots'
+        def list_snapshots(options = true)
+          if options.is_a?(Hash)
+            path = 'os-snapshots'
+            query = options
+          else
+            # Backwards compatibility layer, when 'detailed' boolean was sent as first param
+            if options
+              Fog::Logger.deprecation('Calling OpenStack[:compute].list_snapshots(true) is deprecated, use .list_snapshots_detail instead')
+            else
+              Fog::Logger.deprecation('Calling OpenStack[:compute].list_snapshots(false) is deprecated, use .list_snapshots({}) instead')
+            end
+            path = options ? 'os-snapshots/detail' : 'os-snapshots'
+            query = {}
+          end
+
           request(
             :expects  => 200,
             :method   => 'GET',
-            :path     => path
+            :path     => path,
+            :query    => query
           )
         end
       end
 
       class Mock
-        def list_snapshots(detailed=true)
+        def list_snapshots(options = true)
           response = Excon::Response.new
           response.status = 200
           response.body = {

--- a/lib/fog/openstack/requests/compute/list_snapshots_detail.rb
+++ b/lib/fog/openstack/requests/compute/list_snapshots_detail.rb
@@ -1,0 +1,27 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        def list_snapshots_detail(options = {})
+          request(
+            :expects  => 200,
+            :method   => 'GET',
+            :path     => 'os-snapshots/detail',
+            :query    => options
+          )
+        end
+      end
+
+      class Mock
+        def list_snapshots_detail(options = {})
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            'snapshots' => [get_snapshot_details.body["snapshot"]]
+          }
+          response
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/compute/list_volumes.rb
+++ b/lib/fog/openstack/requests/compute/list_volumes.rb
@@ -2,18 +2,32 @@ module Fog
   module Compute
     class OpenStack
       class Real
-        def list_volumes(detailed=true)
-          path = detailed ? 'os-volumes/detail' : 'os-volumes'
+        def list_volumes(options = true)
+          if options.is_a?(Hash)
+            path = 'os-volumes'
+            query = options
+          else
+            # Backwards compatibility layer, when 'detailed' boolean was sent as first param
+            if options
+              Fog::Logger.deprecation('Calling OpenStack[:compute].list_volumes(true) is deprecated, use .list_volumes_detail instead')
+            else
+              Fog::Logger.deprecation('Calling OpenStack[:compute].list_volumes(false) is deprecated, use .list_volumes({}) instead')
+            end
+            path = options ? 'os-volumes/detail' : 'os-volumes'
+            query = {}
+          end
+
           request(
             :expects  => 200,
             :method   => 'GET',
-            :path     => path
+            :path     => path,
+            :query    => query
           )
         end
       end
 
       class Mock
-        def list_volumes(detailed=true)
+        def list_volumes(options = true)
           Excon::Response.new(
             :body   => { 'volumes' => self.data[:volumes].values },
             :status => 200

--- a/lib/fog/openstack/requests/compute/list_volumes_detail.rb
+++ b/lib/fog/openstack/requests/compute/list_volumes_detail.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        def list_volumes_detail(options = {})
+          request(
+            :expects  => 200,
+            :method   => 'GET',
+            :path     => 'os-volumes/detail',
+            :query    => options
+          )
+        end
+      end
+
+      class Mock
+        def list_volumes_detail(options = {})
+          Excon::Response.new(
+            :body   => { 'volumes' => self.data[:volumes].values },
+            :status => 200
+          )
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
We need to move all list methods to unified interface, where
only Hash is passed as a first argument. The hash can have
specific fields, that will be recognized and deleted. Rest
of the Hash goes directly to request :query.

This way we can start using the list methods the same. Which
is very important for handling e.g. pagination, filtering,
etc.

All changes are made backwards compatible, with deprecation
warnings, when old interface is used.