### PR TITLE
OpenStack Baremetal list methods unified interface

### DIFF
--- a/lib/fog/openstack/models/baremetal/chassis_collection.rb
+++ b/lib/fog/openstack/models/baremetal/chassis_collection.rb
@@ -7,12 +7,12 @@ module Fog
       class ChassisCollection < Fog::Collection
         model Fog::Baremetal::OpenStack::Chassis
 
-        def all
-          load(service.list_chassis.body['chassis'])
+        def all(options = {})
+          load(service.list_chassis(options).body['chassis'])
         end
 
-        def details(parameters=nil)
-          load(service.list_chassis_detailed(parameters).body['chassis'])
+        def details(options = {})
+          load(service.list_chassis_detailed(options).body['chassis'])
         end
 
         def find_by_uuid(uuid)

--- a/lib/fog/openstack/models/baremetal/drivers.rb
+++ b/lib/fog/openstack/models/baremetal/drivers.rb
@@ -7,9 +7,11 @@ module Fog
       class Drivers < Fog::Collection
         model Fog::Baremetal::OpenStack::Driver
 
-        def all
-          load(service.list_drivers.body['drivers'])
+        def all(options = {})
+          load(service.list_drivers(options).body['drivers'])
         end
+
+        alias_method :details, :all
 
         def find_by_name(name)
           new(service.get_driver(name).body)

--- a/lib/fog/openstack/models/baremetal/nodes.rb
+++ b/lib/fog/openstack/models/baremetal/nodes.rb
@@ -7,12 +7,12 @@ module Fog
       class Nodes < Fog::Collection
         model Fog::Baremetal::OpenStack::Node
 
-        def all
-          load(service.list_nodes.body['nodes'])
+        def all(options = {})
+          load(service.list_nodes(options).body['nodes'])
         end
 
-        def details(parameters=nil)
-          load(service.list_nodes_detailed(parameters).body['nodes'])
+        def details(options = {})
+          load(service.list_nodes_detailed(options).body['nodes'])
         end
 
         def find_by_uuid(uuid)

--- a/lib/fog/openstack/models/baremetal/ports.rb
+++ b/lib/fog/openstack/models/baremetal/ports.rb
@@ -7,12 +7,12 @@ module Fog
       class Ports < Fog::Collection
         model Fog::Baremetal::OpenStack::Port
 
-        def all
-          load(service.list_ports.body['ports'])
+        def all(options = {})
+          load(service.list_ports(options).body['ports'])
         end
 
-        def details(parameters=nil)
-          load(service.list_ports_detailed(parameters).body['ports'])
+        def details(options = {})
+          load(service.list_ports_detailed(options).body['ports'])
         end
 
         def find_by_uuid(uuid)

--- a/lib/fog/openstack/requests/baremetal/list_chassis.rb
+++ b/lib/fog/openstack/requests/baremetal/list_chassis.rb
@@ -2,18 +2,12 @@ module Fog
   module Baremetal
     class OpenStack
       class Real
-        def list_chassis(parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
+        def list_chassis(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
             :path    => 'chassis',
-            :query   => query
+            :query   => options
           )
         end
       end # class Real

--- a/lib/fog/openstack/requests/baremetal/list_chassis_detailed.rb
+++ b/lib/fog/openstack/requests/baremetal/list_chassis_detailed.rb
@@ -2,24 +2,18 @@ module Fog
   module Baremetal
     class OpenStack
       class Real
-        def list_chassis_detailed(parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
+        def list_chassis_detailed(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
             :path    => 'chassis/detail',
-            :query   => query
+            :query   => options
           )
         end
       end # class Real
 
       class Mock
-        def list_chassis_detailed(parameters=nil)
+        def list_chassis_detailed(options = {})
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = { "chassis" => self.data[:chassis_collection] }

--- a/lib/fog/openstack/requests/baremetal/list_drivers.rb
+++ b/lib/fog/openstack/requests/baremetal/list_drivers.rb
@@ -2,17 +2,18 @@ module Fog
   module Baremetal
     class OpenStack
       class Real
-        def list_drivers
+        def list_drivers(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
-            :path    => 'drivers'
+            :path    => 'drivers',
+            :query   => options
           )
         end
       end # class Real
 
       class Mock
-        def list_drivers
+        def list_drivers(options = {})
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = { "drivers" => self.data[:drivers] }

--- a/lib/fog/openstack/requests/baremetal/list_nodes.rb
+++ b/lib/fog/openstack/requests/baremetal/list_nodes.rb
@@ -2,24 +2,18 @@ module Fog
   module Baremetal
     class OpenStack
       class Real
-        def list_nodes(parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
+        def list_nodes(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
             :path    => 'nodes',
-            :query   => query
+            :query   => options
           )
         end
       end # class Real
 
       class Mock
-        def list_nodes(parameters=nil)
+        def list_nodes(options = {})
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = {

--- a/lib/fog/openstack/requests/baremetal/list_nodes_detailed.rb
+++ b/lib/fog/openstack/requests/baremetal/list_nodes_detailed.rb
@@ -2,24 +2,18 @@ module Fog
   module Baremetal
     class OpenStack
       class Real
-        def list_nodes_detailed(parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
+        def list_nodes_detailed(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
             :path    => 'nodes/detail',
-            :query   => query
+            :query   => options
           )
         end
       end # class Real
 
       class Mock
-        def list_nodes_detailed(parameters=nil)
+        def list_nodes_detailed(options = {})
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = { "nodes" => self.data[:nodes] }

--- a/lib/fog/openstack/requests/baremetal/list_ports.rb
+++ b/lib/fog/openstack/requests/baremetal/list_ports.rb
@@ -2,24 +2,18 @@ module Fog
   module Baremetal
     class OpenStack
       class Real
-        def list_ports(parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
+        def list_ports(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
             :path    => 'ports',
-            :query   => query
+            :query   => options
           )
         end
       end # class Real
 
       class Mock
-        def list_ports(parameters=nil)
+        def list_ports(options = {})
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = {

--- a/lib/fog/openstack/requests/baremetal/list_ports_detailed.rb
+++ b/lib/fog/openstack/requests/baremetal/list_ports_detailed.rb
@@ -2,24 +2,18 @@ module Fog
   module Baremetal
     class OpenStack
       class Real
-        def list_ports_detailed(parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
+        def list_ports_detailed(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
             :path    => 'ports/detail',
-            :query   => query
+            :query   => options
           )
         end
       end # class Real
 
       class Mock
-        def list_ports_detailed(parameters=nil)
+        def list_ports_detailed(options = {})
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = { "ports" => self.data[:ports] }


### PR DESCRIPTION
We need to move all list methods to unified interface, where
only Hash is passed as a first argument. The hash can have
specific fields, that will be recognized and deleted. Rest
of the Hash goes directly to request :query.

This way we can start using the list methods the same. Which
is very important for handling e.g. pagination, filtering,
etc.

All changes are made backwards compatible, with deprecation
warnings, when old interface is used.