### PR TITLE
OpenStack Keystone list methods unified interface

### DIFF
--- a/lib/fog/openstack/models/identity_v2/ec2_credentials.rb
+++ b/lib/fog/openstack/models/identity_v2/ec2_credentials.rb
@@ -10,13 +10,16 @@ module Fog
 
           attribute :user
 
-          def all
+          def all(options = {})
             user_id = user ? user.id : nil
 
-            ec2_credentials = service.list_ec2_credentials(user_id)
+            options[:user_id] = user_id
+            ec2_credentials = service.list_ec2_credentials(options)
 
             load(ec2_credentials.body['credentials'])
           end
+
+          alias_method :details, :all
 
           def create(attributes = {})
             if user then

--- a/lib/fog/openstack/models/identity_v2/roles.rb
+++ b/lib/fog/openstack/models/identity_v2/roles.rb
@@ -8,9 +8,11 @@ module Fog
         class Roles < Fog::Collection
           model Fog::Identity::OpenStack::V2::Role
 
-          def all
-            load(service.list_roles.body['roles'])
+          def all(options = {})
+            load(service.list_roles(options).body['roles'])
           end
+
+          alias_method :details, :all
 
           def get(id)
             service.get_role(id)

--- a/lib/fog/openstack/models/identity_v2/tenants.rb
+++ b/lib/fog/openstack/models/identity_v2/tenants.rb
@@ -8,9 +8,11 @@ module Fog
         class Tenants < Fog::Collection
           model Fog::Identity::OpenStack::V2::Tenant
 
-          def all
-            load(service.list_tenants.body['tenants'])
+          def all(options = {})
+            load(service.list_tenants(options).body['tenants'])
           end
+
+          alias_method :details, :all
 
           def find_by_id(id)
             cached_tenant = self.find { |tenant| tenant.id == id }

--- a/lib/fog/openstack/models/identity_v2/users.rb
+++ b/lib/fog/openstack/models/identity_v2/users.rb
@@ -10,9 +10,13 @@ module Fog
 
           attribute :tenant_id
 
-          def all
-            load(service.list_users(tenant_id).body['users'])
+          def all(options = {})
+            options[:tenant_id] = tenant_id
+
+            load(service.list_users(options).body['users'])
           end
+
+          alias_method :details, :all
 
           def find_by_id(id)
             self.find { |user| user.id == id } ||

--- a/lib/fog/openstack/models/identity_v3/domains.rb
+++ b/lib/fog/openstack/models/identity_v3/domains.rb
@@ -8,14 +8,15 @@ module Fog
         class Domains < Fog::Collection
           model Fog::Identity::OpenStack::V3::Domain
 
-          def all params={}
-            load(service.list_domains(params).body['domains'])
+          def all(options = {})
+            load(service.list_domains(options).body['domains'])
           end
 
-          def auth_domains params={}
-            load(service.auth_domains(params).body['domains'])
-          end
+          alias_method :details, :all
 
+          def auth_domains(options = {})
+            load(service.auth_domains(options).body['domains'])
+          end
 
           def find_by_id(id)
             cached_domain = self.find { |domain| domain.id == id }

--- a/lib/fog/openstack/models/identity_v3/endpoints.rb
+++ b/lib/fog/openstack/models/identity_v3/endpoints.rb
@@ -8,9 +8,11 @@ module Fog
         class Endpoints < Fog::Collection
           model Fog::Identity::OpenStack::V3::Endpoint
 
-          def all params = {}
-            load(service.list_endpoints(params).body['endpoints'])
+          def all(options = {})
+            load(service.list_endpoints(options).body['endpoints'])
           end
+
+          alias_method :details, :all
 
           def find_by_id(id)
             cached_endpoint = self.find { |endpoint| endpoint.id == id }
@@ -19,7 +21,6 @@ module Fog
             Fog::Identity::OpenStack::V3::Endpoint.new(
                 endpoint_hash.merge(:service => service))
           end
-
         end
       end
     end

--- a/lib/fog/openstack/models/identity_v3/groups.rb
+++ b/lib/fog/openstack/models/identity_v3/groups.rb
@@ -8,9 +8,11 @@ module Fog
         class Groups < Fog::Collection
           model Fog::Identity::OpenStack::V3::Group
 
-          def all params={}
-            load(service.list_groups(params).body['groups'])
+          def all(options = {})
+            load(service.list_groups(options).body['groups'])
           end
+
+          alias_method :details, :all
 
           def find_by_id(id)
             cached_group = self.find { |group| group.id == id }

--- a/lib/fog/openstack/models/identity_v3/os_credentials.rb
+++ b/lib/fog/openstack/models/identity_v3/os_credentials.rb
@@ -8,9 +8,11 @@ module Fog
         class OsCredentials < Fog::Collection
           model Fog::Identity::OpenStack::V3::OsCredential
 
-          def all params={}
-            load(service.list_os_credentials(params).body['credentials'])
+          def all(options = {})
+            load(service.list_os_credentials(options).body['credentials'])
           end
+
+          alias_method :details, :all
 
           def find_by_id(id)
             cached_credential = self.find { |credential| credential.id == id }

--- a/lib/fog/openstack/models/identity_v3/policies.rb
+++ b/lib/fog/openstack/models/identity_v3/policies.rb
@@ -8,9 +8,11 @@ module Fog
         class Policies < Fog::Collection
           model Fog::Identity::OpenStack::V3::Policy
 
-          def all params={}
-            load(service.list_policies(params).body['policies'])
+          def all(options = {})
+            load(service.list_policies(options).body['policies'])
           end
+
+          alias_method :details, :all
 
           def find_by_id(id)
             cached_policy = self.find { |policy| policy.id == id }

--- a/lib/fog/openstack/models/identity_v3/projects.rb
+++ b/lib/fog/openstack/models/identity_v3/projects.rb
@@ -8,12 +8,12 @@ module Fog
         class Projects < Fog::Collection
           model Fog::Identity::OpenStack::V3::Project
 
-          def all params={}
-            load(service.list_projects(params).body['projects'])
+          def all(options = {})
+            load(service.list_projects(options).body['projects'])
           end
 
-          def auth_projects params={}
-            load(service.auth_projects(params).body['projects'])
+          def auth_projects(options = {})
+            load(service.auth_projects(options).body['projects'])
           end
 
           def find_by_id(id)

--- a/lib/fog/openstack/models/identity_v3/role_assignments.rb
+++ b/lib/fog/openstack/models/identity_v3/role_assignments.rb
@@ -8,12 +8,17 @@ module Fog
         class RoleAssignments < Fog::Collection
           model Fog::Identity::OpenStack::V3::RoleAssignment
 
-          def all
-            filter_by {}
+          def all(options = {})
+            load(service.list_role_assignments(options).body['role_assignments'])
           end
 
-          def filter_by params={}
-            load(service.list_role_assignments(params).body['role_assignments'])
+          alias_method :details, :all
+
+          def filter_by(options = {})
+            Fog::Logger.deprecation("Calling OpenStack[:keystone].role_assignments.filter_by(options) method which"\
+                                    " is not part of standard interface and is deprecated, call "\
+                                    " .role_assignments.all(options) or .role_assignments.details(options) instead.")
+            all(options)
           end
         end
       end

--- a/lib/fog/openstack/models/identity_v3/roles.rb
+++ b/lib/fog/openstack/models/identity_v3/roles.rb
@@ -8,12 +8,18 @@ module Fog
         class Roles < Fog::Collection
           model Fog::Identity::OpenStack::V3::Role
 
-          def all params={}
-            load(service.list_roles(params).body['roles'])
+          def all(options = {})
+            load(service.list_roles(options).body['roles'])
           end
 
-          def assignments params={}
-            load(service.list_role_assignments(params).body['role_assignments'])
+          alias_method :details, :all
+
+          def assignments(options = {})
+            # TODO(lsmola) this method doesn't make much sense, it should be moved to role.rb and automatically add
+            # role.id filter. Otherwise it's just duplication.
+            Fog::Logger.deprecation("Calling OpenStack[:keystone].roles.assignments(options) method which"\
+                                    " deprecated, call OpenStack[:keystone].role_assignments(options) instead")
+            load(service.list_role_assignments(options).body['role_assignments'])
           end
 
           def find_by_id(id)

--- a/lib/fog/openstack/models/identity_v3/services.rb
+++ b/lib/fog/openstack/models/identity_v3/services.rb
@@ -8,9 +8,11 @@ module Fog
         class Services < Fog::Collection
           model Fog::Identity::OpenStack::V3::Service
 
-          def all params={}
-            load(service.list_services(params).body['services'])
+          def all(options = {})
+            load(service.list_services(options).body['services'])
           end
+
+          alias_method :details, :all
 
           def find_by_id(id)
             cached_service = self.find { |service| service.id == id }

--- a/lib/fog/openstack/models/identity_v3/users.rb
+++ b/lib/fog/openstack/models/identity_v3/users.rb
@@ -8,9 +8,11 @@ module Fog
         class Users < Fog::Collection
           model Fog::Identity::OpenStack::V3::User
 
-          def all params={}
-            load(service.list_users(params).body['users'])
+          def all(options = {})
+            load(service.list_users(options).body['users'])
           end
+
+          alias_method :details, :all
 
           def find_by_id(id)
             cached_user = self.find { |user| user.id == id }

--- a/lib/fog/openstack/requests/identity_v2/list_ec2_credentials.rb
+++ b/lib/fog/openstack/requests/identity_v2/list_ec2_credentials.rb
@@ -7,8 +7,8 @@ module Fog
           # List EC2 credentials for a user.  Requires administrator
           # credentials.
           #
-          # ==== Parameters
-          # * user_id<~String>: The id of the user to retrieve the credential
+          # ==== Parameters hash
+          # * :user_id<~String>: The id of the user to retrieve the credential
           #   for
           #
           # ==== Returns
@@ -20,17 +20,33 @@ module Fog
           #       * 'user_id'<~String>: The user id
           #       * 'tenant_id'<~String>: The tenant id
 
-          def list_ec2_credentials(user_id)
+          def list_ec2_credentials(options = {})
+            if options.is_a?(Hash)
+              user_id = options.delete(:user_id)
+              query = options
+            else
+              Fog::Logger.deprecation('Calling OpenStack[:identity].list_ec2_credentials(user_id) is deprecated, use .list_ec2_credentials(:user_id => value)')
+              user_id = options
+              query = {}
+            end
+
             request(
-                :expects => [200, 202],
-                :method => 'GET',
-                :path => "users/#{user_id}/credentials/OS-EC2"
+              :expects => [200, 202],
+              :method  => 'GET',
+              :path    => "users/#{user_id}/credentials/OS-EC2",
+              :query   => query
             )
           end
         end
 
         class Mock
-          def list_ec2_credentials(user_id)
+          def list_ec2_credentials(options = {})
+            if options.is_a?(Hash)
+              user_id = options.delete(:user_id)
+            else
+              user_id = options
+            end
+
             ec2_credentials = self.data[:ec2_credentials][user_id].values
 
             response = Excon::Response.new

--- a/lib/fog/openstack/requests/identity_v2/list_roles.rb
+++ b/lib/fog/openstack/requests/identity_v2/list_roles.rb
@@ -3,17 +3,18 @@ module Fog
     class OpenStack
       class V2
         class Real
-          def list_roles
+          def list_roles(options = {})
             request(
                 :expects => 200,
-                :method => 'GET',
-                :path => '/OS-KSADM/roles'
+                :method  => 'GET',
+                :path    => '/OS-KSADM/roles',
+                :query   => options
             )
           end
         end
 
         class Mock
-          def list_roles
+          def list_roles(options = {})
             if self.data[:roles].empty?
               ['admin', 'Member'].each do |name|
                 id = Fog::Mock.random_hex(32)

--- a/lib/fog/openstack/requests/identity_v2/list_tenants.rb
+++ b/lib/fog/openstack/requests/identity_v2/list_tenants.rb
@@ -3,22 +3,28 @@ module Fog
     class OpenStack
       class V2
         class Real
-          def list_tenants(limit = nil, marker = nil)
-            params = Hash.new
-            params['limit'] = limit if limit
-            params['marker'] = marker if marker
+          def list_tenants(options = nil, marker = nil)
+            if options.is_a?(Hash)
+              params = options
+            else
+              Fog::Logger.deprecation('Calling OpenStack[:identity].list_tenants(limit, marker) is deprecated, use'\
+                                      ' .list_ec2_credentials(:limit => value, :marker => value)')
+              params = {}
+              params['limit'] = options if options
+              params['marker'] = marker if marker
+            end
 
             request(
                 :expects => [200, 204],
-                :method => 'GET',
-                :path => "tenants",
-                :query => params
+                :method  => 'GET',
+                :path    => "tenants",
+                :query   => params
             )
           end
         end # class Real
 
         class Mock
-          def list_tenants
+          def list_tenants(options = nil, marker = nil)
             Excon::Response.new(
                 :body => {
                     'tenants_links' => [],

--- a/lib/fog/openstack/requests/identity_v2/list_users.rb
+++ b/lib/fog/openstack/requests/identity_v2/list_users.rb
@@ -3,18 +3,30 @@ module Fog
     class OpenStack
       class V2
         class Real
-          def list_users(tenant_id = nil)
+          def list_users(options = {})
+            if options.is_a?(Hash)
+              tenant_id = options.delete(:tenant_id)
+              query = options
+            else
+              Fog::Logger.deprecation('Calling OpenStack[:identity].list_users(tenant_id) is deprecated, use .list_users(:tenant_id => value)')
+              tenant_id = options
+              query = {}
+            end
+
             path = tenant_id ? "tenants/#{tenant_id}/users" : 'users'
             request(
                 :expects => [200, 204],
-                :method => 'GET',
-                :path => path
+                :method  => 'GET',
+                :path    => path,
+                :query   => query
             )
           end
         end # class Real
 
         class Mock
-          def list_users(tenant_id = nil)
+          def list_users(options = {})
+            tenant_id = options[:tenant_id]
+
             users = self.data[:users].values
 
             if tenant_id

--- a/lib/fog/openstack/requests/identity_v3/auth_domains.rb
+++ b/lib/fog/openstack/requests/identity_v3/auth_domains.rb
@@ -2,18 +2,13 @@ module Fog
   module Identity
     class OpenStack
       class V3
-
         class Real
           def auth_domains(options={})
-            params = Hash.new
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
             request(
                 :expects => [200],
                 :method => 'GET',
                 :path => "auth/domains",
-                :query => params
+                :query => options
             )
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/auth_projects.rb
+++ b/lib/fog/openstack/requests/identity_v3/auth_projects.rb
@@ -3,18 +3,13 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def auth_projects(options={})
-            params = Hash.new
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
+          def auth_projects(options = {})
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "auth/projects",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "auth/projects",
+              :query   => options
             )
-
           end
         end
 

--- a/lib/fog/openstack/requests/identity_v3/list_domains.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_domains.rb
@@ -3,25 +3,18 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_domains(options={})
-            params = Hash.new
-            params['name'] = options[:name] if options[:name]
-            params['enabled'] = options[:enabled] if options[:enabled]
-
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
+          def list_domains(options = {})
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "domains",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "domains",
+              :query   => options
             )
           end
         end
 
         class Mock
-          def list_domains
+          def list_domains(options = {})
 
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_endpoints.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_endpoints.rb
@@ -3,25 +3,18 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_endpoints(options={})
-            params = Hash.new
-            params['service_id'] = options[:service_id] if options[:service_id]
-            params['interface'] = options[:interface] if options[:interface]
-
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
+          def list_endpoints(options = {})
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "endpoints",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "endpoints",
+              :query   => options
             )
           end
         end
 
         class Mock
-          def list_endpoints
+          def list_endpoints(options={})
 
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_group_users.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_group_users.rb
@@ -4,19 +4,11 @@ module Fog
       class V3
         class Real
           def list_group_users(id, options={})
-            params = Hash.new
-            params['name'] = options[:name] if options[:name]
-            params['domain_id'] = options[:domain_id] if options[:domain_id]
-            params['description'] = options[:description] if options[:description]
-
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "groups/#{id}/users",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "groups/#{id}/users",
+              :query   => options
             )
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_groups.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_groups.rb
@@ -3,36 +3,26 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_groups(options={})
-            params = Hash.new
-            params['user_id'] = options[:user_id] if options[:user_id]
-            params['domain_id'] = options[:domain_id] if options[:domain_id]
-            params['name'] = options[:name] if options[:name]
-            params['enabled'] = options[:enabled] if options[:enabled]
+          def list_groups(options = {})
+            user_id = options.delete('user_id') || options.delete(:user_id)
 
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
-            if params['user_id'] then
-              request(
-                  :expects => [200],
-                  :method => 'GET',
-                  :path => "users/#{params['user_id']}groups",
-                  :query => params
-              )
+            if user_id
+              path = "users/#{user_id}groups"
             else
-              request(
-                  :expects => [200],
-                  :method => 'GET',
-                  :path => "groups",
-                  :query => params
-              )
+              path = "groups"
             end
+
+            request(
+              :expects => [200],
+              :method  => 'GET',
+              :path    => path,
+              :query   => options
+            )
           end
         end
 
         class Mock
-          def list_groups
+          def list_groups(options = {})
 
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_os_credentials.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_os_credentials.rb
@@ -3,23 +3,18 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_os_credentials(options={})
-            params = Hash.new
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-            params['name'] = options[:name] if options[:name]
-
+          def list_os_credentials(options = {})
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "credentials",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "credentials",
+              :query   => options
             )
           end
         end
 
         class Mock
-          def list_os_credentials
+          def list_os_credentials(options = {})
 
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_policies.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_policies.rb
@@ -3,22 +3,18 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_policies(options={})
-            params = Hash.new
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
+          def list_policies(options = {})
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "policies",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "policies",
+              :query   => options
             )
           end
         end
 
         class Mock
-          def list_policies
+          def list_policies(options = {})
 
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_projects.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_projects.rb
@@ -3,36 +3,25 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_projects(options={})
-            params = Hash.new
-            params['user_id'] = options[:user_id] if options[:user_id]
-            params['domain_id'] = options[:domain_id] if options[:domain_id]
-            params['name'] = options[:name] if options[:name]
-            params['enabled'] = options[:enabled] if options[:enabled]
-
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
-            if params['user_id'] then
-              request(
-                  :expects => [200],
-                  :method => 'GET',
-                  :path => "users/#{params['user_id']}/projects",
-                  :query => params
-              )
+          def list_projects(options = {})
+            user_id = options.delete('user_id') || options.delete(:user_id)
+            if user_id
+              path = "users/#{user_id}/projects"
             else
-              request(
-                  :expects => [200],
-                  :method => 'GET',
-                  :path => "projects",
-                  :query => params
-              )
+              path = "projects"
             end
+
+            request(
+              :expects => [200],
+              :method  => 'GET',
+              :path    => path,
+              :query   => options
+            )
           end
         end
 
         class Mock
-          def list_projects
+          def list_projects(options = {})
 
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_role_assignments.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_role_assignments.rb
@@ -3,29 +3,35 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_role_assignments(options={})
-            params = Hash.new
-            params['group.id'] = options[:group_id] if options[:group_id]
-            params['role.id'] = options[:role_id] if options[:role_id]
-            params['scope.domain.id'] = options[:domain_id] if options[:domain_id]
-            params['scope.project.id'] = options[:project_id] if options[:project_id]
-            params['user.id'] = options[:user_id] if options[:user_id]
-            params['effective'] = options[:effective] if options[:effective]
-
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
+          def list_role_assignments(options = {})
+            # Backwards compatibility name mapping
+            name_mapping = {
+              :group_id   => 'group.id',
+              :role_id    => 'role.id',
+              :domain_id  => 'scope.domain.id',
+              :project_id => 'scope.project.id',
+              :user_id    => 'user.id',
+            }
+            name_mapping.keys.each do |key|
+              if (opt = options.delete(key))
+                Fog::Logger.deprecation("Calling OpenStack[:keystone].list_role_assignments(options) with deprecated"\
+                                        " option '#{key}'. Use option '#{name_mapping[key]}' which is defined in"\
+                                        " keystone documentation.")
+                options[name_mapping[key]] = opt
+              end
+            end
 
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "role_assignments",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "role_assignments",
+              :query   => options
             )
           end
         end
 
         class Mock
-          def list_role_assignments
+          def list_role_assignments(options = {})
 
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_roles.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_roles.rb
@@ -3,36 +3,18 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_roles(options={})
-            params = Hash.new
-            params['name'] = options[:name] if options[:name]
-
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
-#          if params['user_id'] then
-# Returns 404 "The resource could not be found."
-# https://bugs.launchpad.net/keystone/+bug/933565 reports this - bug is set to "Won't fix"
-#   user_id = params.delete 'user_id'
-#   request(
-#       :expects => [200],
-#       :method  => 'GET',
-#       :path    => "users/#{user_id}/roles",
-#       :query   => params
-#   )
-# else
+          def list_roles(options = {})
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "roles",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "roles",
+              :query   => options
             )
-#          end
           end
         end
 
         class Mock
-          def list_roles
+          def list_roles(options = {})
 
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_services.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_services.rb
@@ -3,24 +3,18 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_services(options={})
-            params = Hash.new
-            params['type'] = options[:type] if options[:type]
-
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
+          def list_services(options = {})
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "services",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "services",
+              :query   => options
             )
           end
         end
 
         class Mock
-          def list_services
+          def list_services(options = {})
 
           end
         end

--- a/lib/fog/openstack/requests/identity_v3/list_users.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_users.rb
@@ -3,26 +3,18 @@ module Fog
     class OpenStack
       class V3
         class Real
-          def list_users(options={})
-            params = Hash.new
-            params['domain_id'] = options[:domain_id] if options[:domain_id]
-            params['name'] = options[:name] if options[:name]
-            params['enabled'] = options[:enabled] if options[:enabled]
-
-            params['page'] = options.fetch(:page, 1)
-            params['per_page'] = options.fetch(:per_page, 30)
-
+          def list_users(options = {})
             request(
-                :expects => [200],
-                :method => 'GET',
-                :path => "users",
-                :query => params
+              :expects => [200],
+              :method  => 'GET',
+              :path    => "users",
+              :query   => options
             )
           end
         end
 
         class Mock
-          def list_users
+          def list_users(options = {})
 
           end
         end

--- a/spec/fog/openstack/identity_v3/idv3.yml
+++ b/spec/fog/openstack/identity_v3/idv3.yml
@@ -104,7 +104,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:35 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=admin&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=admin
     body:
       encoding: US-ASCII
       string: ''
@@ -138,13 +138,13 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"users": [{"name": "admin", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/aa9f25defa6d4cafb48466df83106065"},
         "domain_id": "default", "enabled": true, "email": null, "id": "aa9f25defa6d4cafb48466df83106065"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=admin&page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=admin",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:35 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?name=admin&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles?name=admin
     body:
       encoding: US-ASCII
       string: ''
@@ -176,7 +176,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=admin&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=admin",
         "previous": null, "next": null}, "roles": [{"id": "6ead57f8ae124996af8b0beb72ff1007",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/6ead57f8ae124996af8b0beb72ff1007"},
         "name": "admin"}]}'

--- a/spec/fog/openstack/identity_v3/idv3_credential.yml
+++ b/spec/fog/openstack/identity_v3/idv3_credential.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -34,13 +34,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30",
+      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30",
+      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT

--- a/spec/fog/openstack/identity_v3/idv3_credential_crud.yml
+++ b/spec/fog/openstack/identity_v3/idv3_credential_crud.yml
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: US-ASCII
       string: ''
@@ -73,7 +73,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects",
         "previous": null, "next": null}, "projects": [{"description": null, "links":
         {"self": "http://devstack.openstack.stack:35357/v3/projects/123ac695d4db400a9001b91bb3b8aa46"},
         "enabled": true, "id": "123ac695d4db400a9001b91bb3b8aa46", "parent_id": null,
@@ -91,7 +91,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -123,13 +123,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30",
+      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -161,7 +161,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30",
+      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
@@ -207,7 +207,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -243,7 +243,7 @@ http_interactions:
         "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials/9e7bb4e633cc08cc863fe15351911e267f2a953b24c1a80f0f35e173303bafae"},
         "blob": "{\"access\":\"9c4e774a-f644-498f-90c4-970b3f817fc5\",\"secret\":\"7e084117-b13d-4656-9eca-85376b690897\"}",
         "project_id": "123ac695d4db400a9001b91bb3b8aa46", "type": "ec2", "id": "9e7bb4e633cc08cc863fe15351911e267f2a953b24c1a80f0f35e173303bafae"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
@@ -289,7 +289,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -325,13 +325,13 @@ http_interactions:
         "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials/9e7bb4e633cc08cc863fe15351911e267f2a953b24c1a80f0f35e173303bafae"},
         "blob": "{\"access\":\"9c4e774a-f644-498f-90c4-970b3f817fc5\",\"secret\":\"62307bcd-ca3c-47ae-a114-27a6cadb5bc9\"}",
         "project_id": "123ac695d4db400a9001b91bb3b8aa46", "type": "ec2", "id": "9e7bb4e633cc08cc863fe15351911e267f2a953b24c1a80f0f35e173303bafae"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -367,7 +367,7 @@ http_interactions:
         "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials/9e7bb4e633cc08cc863fe15351911e267f2a953b24c1a80f0f35e173303bafae"},
         "blob": "{\"access\":\"9c4e774a-f644-498f-90c4-970b3f817fc5\",\"secret\":\"62307bcd-ca3c-47ae-a114-27a6cadb5bc9\"}",
         "project_id": "123ac695d4db400a9001b91bb3b8aa46", "type": "ec2", "id": "9e7bb4e633cc08cc863fe15351911e267f2a953b24c1a80f0f35e173303bafae"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
@@ -446,7 +446,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -478,7 +478,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30",
+      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
@@ -522,7 +522,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/credentials
     body:
       encoding: US-ASCII
       string: ''
@@ -554,7 +554,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials?page=1&per_page=30",
+      string: ! '{"credentials": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/credentials",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT

--- a/spec/fog/openstack/identity_v3/idv3_domain.yml
+++ b/spec/fog/openstack/identity_v3/idv3_domain.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains
     body:
       encoding: US-ASCII
       string: ''
@@ -37,13 +37,13 @@ http_interactions:
       string: ! '{"domains": [{"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/default"},
         "enabled": true, "description": "Owns users and tenants (i.e. projects) available
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30", "previous": null,
+        "http://devstack.openstack.stack:35357/v3/domains", "previous": null,
         "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:40 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains
     body:
       encoding: US-ASCII
       string: ''
@@ -78,13 +78,13 @@ http_interactions:
       string: ! '{"domains": [{"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/default"},
         "enabled": true, "description": "Owns users and tenants (i.e. projects) available
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30", "previous": null,
+        "http://devstack.openstack.stack:35357/v3/domains", "previous": null,
         "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:40 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains
     body:
       encoding: US-ASCII
       string: ''
@@ -119,7 +119,7 @@ http_interactions:
       string: ! '{"domains": [{"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/default"},
         "enabled": true, "description": "Owns users and tenants (i.e. projects) available
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30", "previous": null,
+        "http://devstack.openstack.stack:35357/v3/domains", "previous": null,
         "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
@@ -164,7 +164,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains
     body:
       encoding: US-ASCII
       string: ''
@@ -199,7 +199,7 @@ http_interactions:
       string: ! '{"domains": [{"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/default"},
         "enabled": true, "description": "Owns users and tenants (i.e. projects) available
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30", "previous": null,
+        "http://devstack.openstack.stack:35357/v3/domains", "previous": null,
         "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT

--- a/spec/fog/openstack/identity_v3/idv3_domain_crud.yml
+++ b/spec/fog/openstack/identity_v3/idv3_domain_crud.yml
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?name=foobar&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains?name=foobar
     body:
       encoding: US-ASCII
       string: ''
@@ -75,7 +75,7 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"domains": [{"enabled": true, "id": "b4c5d89384394e0aa3e5c8daf383ee35",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/domains/b4c5d89384394e0aa3e5c8daf383ee35"},
-        "name": "foobar"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/domains?name=foobar&page=1&per_page=30",
+        "name": "foobar"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/domains?name=foobar",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
@@ -120,7 +120,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?name=baz&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains?name=baz
     body:
       encoding: US-ASCII
       string: ''
@@ -154,13 +154,13 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"domains": [{"enabled": false, "id": "b4c5d89384394e0aa3e5c8daf383ee35",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/domains/b4c5d89384394e0aa3e5c8daf383ee35"},
-        "name": "baz"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/domains?name=baz&page=1&per_page=30",
+        "name": "baz"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/domains?name=baz",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains
     body:
       encoding: US-ASCII
       string: ''
@@ -197,7 +197,7 @@ http_interactions:
         "name": "baz"}, {"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/default"},
         "enabled": true, "description": "Owns users and tenants (i.e. projects) available
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30", "previous": null,
+        "http://devstack.openstack.stack:35357/v3/domains", "previous": null,
         "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
@@ -315,7 +315,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains
     body:
       encoding: US-ASCII
       string: ''
@@ -350,7 +350,7 @@ http_interactions:
       string: ! '{"domains": [{"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/default"},
         "enabled": true, "description": "Owns users and tenants (i.e. projects) available
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30", "previous": null,
+        "http://devstack.openstack.stack:35357/v3/domains", "previous": null,
         "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
@@ -394,7 +394,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?name=foobar&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains?name=foobar
     body:
       encoding: US-ASCII
       string: ''
@@ -426,13 +426,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"domains": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/domains?name=foobar&page=1&per_page=30",
+      string: ! '{"domains": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/domains?name=foobar",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?name=baz&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains?name=baz
     body:
       encoding: US-ASCII
       string: ''
@@ -464,7 +464,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"domains": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/domains?name=baz&page=1&per_page=30",
+      string: ! '{"domains": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/domains?name=baz",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT

--- a/spec/fog/openstack/identity_v3/idv3_domain_group_roles_mutation.yml
+++ b/spec/fog/openstack/identity_v3/idv3_domain_group_roles_mutation.yml
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:42 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles
     body:
       encoding: US-ASCII
       string: ''
@@ -190,7 +190,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles",
         "previous": null, "next": null}, "roles": [{"id": "1348e84f9797426bb6ec4cae1e6289d7",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/1348e84f9797426bb6ec4cae1e6289d7"},
         "name": "anotherrole"}, {"id": "430e91ef76b74b728a2864bc8a410a60", "links":
@@ -357,7 +357,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:42 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&user.id=e51182349e024408974508cfd0e5128e
+    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&user.id=e51182349e024408974508cfd0e5128e
     body:
       encoding: US-ASCII
       string: ''
@@ -389,7 +389,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"role_assignments": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&user.id=e51182349e024408974508cfd0e5128e",
+      string: ! '{"role_assignments": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&user.id=e51182349e024408974508cfd0e5128e",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:42 GMT
@@ -467,7 +467,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&user.id=e51182349e024408974508cfd0e5128e
+    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&user.id=e51182349e024408974508cfd0e5128e
     body:
       encoding: US-ASCII
       string: ''
@@ -503,13 +503,13 @@ http_interactions:
         "role": {"id": "1391a570f2a24056961be1035aa72a61"}, "user": {"id": "e51182349e024408974508cfd0e5128e"},
         "links": {"assignment": "http://devstack.openstack.stack:35357/v3/domains/1374ea16b39b48e7bde71e737f7d964a/groups/ea21b86bd05442e59eac49626cda687e/roles/1391a570f2a24056961be1035aa72a61",
         "membership": "http://devstack.openstack.stack:35357/v3/groups/ea21b86bd05442e59eac49626cda687e/users/e51182349e024408974508cfd0e5128e"}}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&user.id=e51182349e024408974508cfd0e5128e",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&user.id=e51182349e024408974508cfd0e5128e",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/role_assignments?group.id=ea21b86bd05442e59eac49626cda687e&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/role_assignments?group.id=ea21b86bd05442e59eac49626cda687e
     body:
       encoding: US-ASCII
       string: ''
@@ -545,7 +545,7 @@ http_interactions:
         "group": {"id": "ea21b86bd05442e59eac49626cda687e"}, "links": {"assignment":
         "http://devstack.openstack.stack:35357/v3/domains/1374ea16b39b48e7bde71e737f7d964a/groups/ea21b86bd05442e59eac49626cda687e/roles/1391a570f2a24056961be1035aa72a61"},
         "scope": {"domain": {"id": "1374ea16b39b48e7bde71e737f7d964a"}}}], "links":
-        {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?group.id=ea21b86bd05442e59eac49626cda687e&page=1&per_page=30",
+        {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?group.id=ea21b86bd05442e59eac49626cda687e",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT
@@ -586,7 +586,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&user.id=e51182349e024408974508cfd0e5128e
+    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&user.id=e51182349e024408974508cfd0e5128e
     body:
       encoding: US-ASCII
       string: ''
@@ -618,7 +618,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"role_assignments": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&user.id=e51182349e024408974508cfd0e5128e",
+      string: ! '{"role_assignments": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&user.id=e51182349e024408974508cfd0e5128e",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT

--- a/spec/fog/openstack/identity_v3/idv3_domain_roles_mutation.yml
+++ b/spec/fog/openstack/identity_v3/idv3_domain_roles_mutation.yml
@@ -193,7 +193,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/role_assignments?page=1&per_page=30&user.id=05e24831bf9c45b29a6d71f2773abe45
+    uri: http://devstack.openstack.stack:35357/v3/role_assignments?user.id=05e24831bf9c45b29a6d71f2773abe45
     body:
       encoding: US-ASCII
       string: ''
@@ -228,13 +228,13 @@ http_interactions:
       string: ! '{"role_assignments": [{"scope": {"domain": {"id": "default"}}, "role":
         {"id": "30c546e4e42443368a69812a659bf675"}, "user": {"id": "05e24831bf9c45b29a6d71f2773abe45"},
         "links": {"assignment": "http://devstack.openstack.stack:35357/v3/domains/default/users/05e24831bf9c45b29a6d71f2773abe45/roles/30c546e4e42443368a69812a659bf675"}}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?page=1&per_page=30&user.id=05e24831bf9c45b29a6d71f2773abe45",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?user.id=05e24831bf9c45b29a6d71f2773abe45",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/role_assignments?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/role_assignments
     body:
       encoding: US-ASCII
       string: ''
@@ -296,7 +296,7 @@ http_interactions:
         {"scope": {"domain": {"id": "default"}}, "role": {"id": "6ead57f8ae124996af8b0beb72ff1007"},
         "user": {"id": "aa9f25defa6d4cafb48466df83106065"}, "links": {"assignment":
         "http://devstack.openstack.stack:35357/v3/domains/default/users/aa9f25defa6d4cafb48466df83106065/roles/6ead57f8ae124996af8b0beb72ff1007"}}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:41 GMT

--- a/spec/fog/openstack/identity_v3/idv3_endpoint.yml
+++ b/spec/fog/openstack/identity_v3/idv3_endpoint.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints
     body:
       encoding: US-ASCII
       string: ''
@@ -141,13 +141,13 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/f6d38c03b9c04a9e924aaa288ce014b8"},
         "url": "http://devstack.openstack.stack:8774/v2/$(tenant_id)s", "region": "RegionOne",
         "enabled": true, "interface": "public", "service_id": "5b7028751ed045d79467c7845ecb8c58",
-        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30",
+        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints
     body:
       encoding: US-ASCII
       string: ''
@@ -286,13 +286,13 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/f6d38c03b9c04a9e924aaa288ce014b8"},
         "url": "http://devstack.openstack.stack:8774/v2/$(tenant_id)s", "region": "RegionOne",
         "enabled": true, "interface": "public", "service_id": "5b7028751ed045d79467c7845ecb8c58",
-        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30",
+        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints
     body:
       encoding: US-ASCII
       string: ''
@@ -431,13 +431,13 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/f6d38c03b9c04a9e924aaa288ce014b8"},
         "url": "http://devstack.openstack.stack:8774/v2/$(tenant_id)s", "region": "RegionOne",
         "enabled": true, "interface": "public", "service_id": "5b7028751ed045d79467c7845ecb8c58",
-        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30",
+        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints
     body:
       encoding: US-ASCII
       string: ''
@@ -576,7 +576,7 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/f6d38c03b9c04a9e924aaa288ce014b8"},
         "url": "http://devstack.openstack.stack:8774/v2/$(tenant_id)s", "region": "RegionOne",
         "enabled": true, "interface": "public", "service_id": "5b7028751ed045d79467c7845ecb8c58",
-        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30",
+        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT

--- a/spec/fog/openstack/identity_v3/idv3_endpoints_crud.yml
+++ b/spec/fog/openstack/identity_v3/idv3_endpoints_crud.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -57,13 +57,13 @@ http_interactions:
         "description": "OpenStack Identity v3 x"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints
     body:
       encoding: US-ASCII
       string: ''
@@ -202,7 +202,7 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/f6d38c03b9c04a9e924aaa288ce014b8"},
         "url": "http://devstack.openstack.stack:8774/v2/$(tenant_id)s", "region": "RegionOne",
         "enabled": true, "interface": "public", "service_id": "5b7028751ed045d79467c7845ecb8c58",
-        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30",
+        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
@@ -248,7 +248,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?interface=internal&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints?interface=internal
     body:
       encoding: US-ASCII
       string: ''
@@ -318,7 +318,7 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/ece52860cf1e4eb6a8fed05c47a30147"},
         "url": "http://devstack.openstack.stack:8773/", "region": "RegionOne", "enabled": true,
         "interface": "internal", "service_id": "3364a7b95c664bf89a7a8db081576364",
-        "id": "ece52860cf1e4eb6a8fed05c47a30147"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?interface=internal&page=1&per_page=30",
+        "id": "ece52860cf1e4eb6a8fed05c47a30147"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?interface=internal",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
@@ -364,7 +364,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?interface=internal&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints?interface=internal
     body:
       encoding: US-ASCII
       string: ''
@@ -434,13 +434,13 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/ece52860cf1e4eb6a8fed05c47a30147"},
         "url": "http://devstack.openstack.stack:8773/", "region": "RegionOne", "enabled": true,
         "interface": "internal", "service_id": "3364a7b95c664bf89a7a8db081576364",
-        "id": "ece52860cf1e4eb6a8fed05c47a30147"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?interface=internal&page=1&per_page=30",
+        "id": "ece52860cf1e4eb6a8fed05c47a30147"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?interface=internal",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints
     body:
       encoding: US-ASCII
       string: ''
@@ -582,7 +582,7 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/f6d38c03b9c04a9e924aaa288ce014b8"},
         "url": "http://devstack.openstack.stack:8774/v2/$(tenant_id)s", "region": "RegionOne",
         "enabled": true, "interface": "public", "service_id": "5b7028751ed045d79467c7845ecb8c58",
-        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30",
+        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
@@ -623,7 +623,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints
     body:
       encoding: US-ASCII
       string: ''
@@ -762,7 +762,7 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/f6d38c03b9c04a9e924aaa288ce014b8"},
         "url": "http://devstack.openstack.stack:8774/v2/$(tenant_id)s", "region": "RegionOne",
         "enabled": true, "interface": "public", "service_id": "5b7028751ed045d79467c7845ecb8c58",
-        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30",
+        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
@@ -806,7 +806,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/endpoints
     body:
       encoding: US-ASCII
       string: ''
@@ -945,7 +945,7 @@ http_interactions:
         {"self": "http://devstack.openstack.stack:35357/v3/endpoints/f6d38c03b9c04a9e924aaa288ce014b8"},
         "url": "http://devstack.openstack.stack:8774/v2/$(tenant_id)s", "region": "RegionOne",
         "enabled": true, "interface": "public", "service_id": "5b7028751ed045d79467c7845ecb8c58",
-        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints?page=1&per_page=30",
+        "id": "f6d38c03b9c04a9e924aaa288ce014b8"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/endpoints",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:48 GMT

--- a/spec/fog/openstack/identity_v3/idv3_group_crud_mutation.yml
+++ b/spec/fog/openstack/identity_v3/idv3_group_crud_mutation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups
     body:
       encoding: US-ASCII
       string: ''
@@ -34,7 +34,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups",
         "previous": null, "next": null}, "groups": [{"domain_id": "default", "description":
         "non-admin group", "id": "456293145b0b48b1be46e71d97ad14e4", "links": {"self":
         "http://devstack.openstack.stack:35357/v3/groups/456293145b0b48b1be46e71d97ad14e4"},
@@ -45,7 +45,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups
     body:
       encoding: US-ASCII
       string: ''
@@ -77,7 +77,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups",
         "previous": null, "next": null}, "groups": [{"domain_id": "default", "description":
         "non-admin group", "id": "456293145b0b48b1be46e71d97ad14e4", "links": {"self":
         "http://devstack.openstack.stack:35357/v3/groups/456293145b0b48b1be46e71d97ad14e4"},
@@ -127,7 +127,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups
     body:
       encoding: US-ASCII
       string: ''
@@ -159,7 +159,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups",
         "previous": null, "next": null}, "groups": [{"domain_id": "default", "description":
         "Group of Foobar users", "id": "3e52735856774071af0c3425b8762d34", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34"},
@@ -211,7 +211,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups
     body:
       encoding: US-ASCII
       string: ''
@@ -243,7 +243,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups",
         "previous": null, "next": null}, "groups": [{"domain_id": "default", "description":
         "Group of Baz users", "id": "3e52735856774071af0c3425b8762d34", "links": {"self":
         "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34"},
@@ -256,7 +256,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups
     body:
       encoding: US-ASCII
       string: ''
@@ -288,7 +288,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups",
         "previous": null, "next": null}, "groups": [{"domain_id": "default", "description":
         "Group of Baz users", "id": "3e52735856774071af0c3425b8762d34", "links": {"self":
         "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34"},
@@ -417,7 +417,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users
     body:
       encoding: US-ASCII
       string: ''
@@ -449,7 +449,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users?page=1&per_page=30",
+      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
@@ -599,7 +599,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users
     body:
       encoding: US-ASCII
       string: ''
@@ -636,7 +636,7 @@ http_interactions:
         "7ff4aed64f0b4d7cb7a82a1a3349fc2b"}, {"name": "foobar2", "links": {"self":
         "http://devstack.openstack.stack:35357/v3/users/8e8a0629ccf84cc495c849ecfbb21d89"},
         "domain_id": "default", "enabled": true, "email": "foobar2@example.com", "id":
-        "8e8a0629ccf84cc495c849ecfbb21d89"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users?page=1&per_page=30",
+        "8e8a0629ccf84cc495c849ecfbb21d89"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
@@ -714,7 +714,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users
     body:
       encoding: US-ASCII
       string: ''
@@ -748,7 +748,7 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"users": [{"name": "foobar2", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/8e8a0629ccf84cc495c849ecfbb21d89"},
         "domain_id": "default", "enabled": true, "email": "foobar2@example.com", "id":
-        "8e8a0629ccf84cc495c849ecfbb21d89"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users?page=1&per_page=30",
+        "8e8a0629ccf84cc495c849ecfbb21d89"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
@@ -861,7 +861,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users
     body:
       encoding: US-ASCII
       string: ''
@@ -893,7 +893,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users?page=1&per_page=30",
+      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/groups/3e52735856774071af0c3425b8762d34/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
@@ -934,7 +934,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups
     body:
       encoding: US-ASCII
       string: ''
@@ -966,7 +966,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups",
         "previous": null, "next": null}, "groups": [{"domain_id": "default", "description":
         "non-admin group", "id": "456293145b0b48b1be46e71d97ad14e4", "links": {"self":
         "http://devstack.openstack.stack:35357/v3/groups/456293145b0b48b1be46e71d97ad14e4"},
@@ -1015,7 +1015,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:39 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/groups
     body:
       encoding: US-ASCII
       string: ''
@@ -1047,7 +1047,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/groups",
         "previous": null, "next": null}, "groups": [{"domain_id": "default", "description":
         "non-admin group", "id": "456293145b0b48b1be46e71d97ad14e4", "links": {"self":
         "http://devstack.openstack.stack:35357/v3/groups/456293145b0b48b1be46e71d97ad14e4"},

--- a/spec/fog/openstack/identity_v3/idv3_policy.yml
+++ b/spec/fog/openstack/identity_v3/idv3_policy.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/policies
     body:
       encoding: US-ASCII
       string: ''
@@ -34,13 +34,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies",
         "previous": null, "next": null}, "policies": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/policies
     body:
       encoding: US-ASCII
       string: ''
@@ -72,13 +72,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies",
         "previous": null, "next": null}, "policies": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/policies
     body:
       encoding: US-ASCII
       string: ''
@@ -110,7 +110,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies",
         "previous": null, "next": null}, "policies": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT

--- a/spec/fog/openstack/identity_v3/idv3_policy_crud.yml
+++ b/spec/fog/openstack/identity_v3/idv3_policy_crud.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/policies
     body:
       encoding: US-ASCII
       string: ''
@@ -34,7 +34,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies",
         "previous": null, "next": null}, "policies": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT
@@ -79,7 +79,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/policies
     body:
       encoding: US-ASCII
       string: ''
@@ -111,7 +111,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies",
         "previous": null, "next": null}, "policies": [{"type": "application/json",
         "id": "8fcf57c79e26405384b338ad44dc4043", "links": {"self": "http://devstack.openstack.stack:35357/v3/policies/8fcf57c79e26405384b338ad44dc4043"},
         "blob": "{\"foobar_user\":[\"role:compute-user\"]}"}]}'
@@ -158,7 +158,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/policies
     body:
       encoding: US-ASCII
       string: ''
@@ -190,7 +190,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies",
         "previous": null, "next": null}, "policies": [{"type": "application/json",
         "id": "8fcf57c79e26405384b338ad44dc4043", "links": {"self": "http://devstack.openstack.stack:35357/v3/policies/8fcf57c79e26405384b338ad44dc4043"},
         "blob": "{\"baz_user\":[\"role:compute-user\"]}"}]}'
@@ -198,7 +198,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/policies
     body:
       encoding: US-ASCII
       string: ''
@@ -230,7 +230,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies",
         "previous": null, "next": null}, "policies": [{"type": "application/json",
         "id": "8fcf57c79e26405384b338ad44dc4043", "links": {"self": "http://devstack.openstack.stack:35357/v3/policies/8fcf57c79e26405384b338ad44dc4043"},
         "blob": "{\"baz_user\":[\"role:compute-user\"]}"}]}'
@@ -273,7 +273,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/policies
     body:
       encoding: US-ASCII
       string: ''
@@ -305,7 +305,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies",
         "previous": null, "next": null}, "policies": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT
@@ -349,7 +349,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/policies
     body:
       encoding: US-ASCII
       string: ''
@@ -381,7 +381,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/policies",
         "previous": null, "next": null}, "policies": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:49 GMT

--- a/spec/fog/openstack/identity_v3/idv3_project.yml
+++ b/spec/fog/openstack/identity_v3/idv3_project.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: US-ASCII
       string: ''
@@ -34,7 +34,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects",
         "previous": null, "next": null}, "projects": [{"description": null, "links":
         {"self": "http://devstack.openstack.stack:35357/v3/projects/123ac695d4db400a9001b91bb3b8aa46"},
         "enabled": true, "id": "123ac695d4db400a9001b91bb3b8aa46", "parent_id": null,
@@ -52,7 +52,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: US-ASCII
       string: ''
@@ -84,7 +84,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects",
         "previous": null, "next": null}, "projects": [{"description": null, "links":
         {"self": "http://devstack.openstack.stack:35357/v3/projects/123ac695d4db400a9001b91bb3b8aa46"},
         "enabled": true, "id": "123ac695d4db400a9001b91bb3b8aa46", "parent_id": null,
@@ -102,7 +102,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: US-ASCII
       string: ''
@@ -134,7 +134,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects",
         "previous": null, "next": null}, "projects": [{"description": null, "links":
         {"self": "http://devstack.openstack.stack:35357/v3/projects/123ac695d4db400a9001b91bb3b8aa46"},
         "enabled": true, "id": "123ac695d4db400a9001b91bb3b8aa46", "parent_id": null,
@@ -152,7 +152,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: US-ASCII
       string: ''
@@ -184,7 +184,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects",
         "previous": null, "next": null}, "projects": [{"description": null, "links":
         {"self": "http://devstack.openstack.stack:35357/v3/projects/123ac695d4db400a9001b91bb3b8aa46"},
         "enabled": true, "id": "123ac695d4db400a9001b91bb3b8aa46", "parent_id": null,

--- a/spec/fog/openstack/identity_v3/idv3_project_crud.yml
+++ b/spec/fog/openstack/identity_v3/idv3_project_crud.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/domains
     body:
       encoding: US-ASCII
       string: ''
@@ -37,7 +37,7 @@ http_interactions:
       string: ! '{"domains": [{"links": {"self": "http://devstack.openstack.stack:35357/v3/domains/default"},
         "enabled": true, "description": "Owns users and tenants (i.e. projects) available
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/domains?page=1&per_page=30", "previous": null,
+        "http://devstack.openstack.stack:35357/v3/domains", "previous": null,
         "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
@@ -82,7 +82,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar46&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar46
     body:
       encoding: US-ASCII
       string: ''
@@ -114,7 +114,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar46&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar46",
         "previous": null, "next": null}, "projects": [{"description": "", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/projects/e0de6d7921d74cfaafd3cddcb2f17939"},
         "enabled": true, "id": "e0de6d7921d74cfaafd3cddcb2f17939", "parent_id": null,
@@ -162,7 +162,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz46&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz46
     body:
       encoding: US-ASCII
       string: ''
@@ -194,7 +194,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz46&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz46",
         "previous": null, "next": null}, "projects": [{"description": "", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/projects/e0de6d7921d74cfaafd3cddcb2f17939"},
         "enabled": false, "id": "e0de6d7921d74cfaafd3cddcb2f17939", "parent_id": null,
@@ -203,7 +203,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: US-ASCII
       string: ''
@@ -235,7 +235,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects",
         "previous": null, "next": null}, "projects": [{"description": null, "links":
         {"self": "http://devstack.openstack.stack:35357/v3/projects/123ac695d4db400a9001b91bb3b8aa46"},
         "enabled": true, "id": "123ac695d4db400a9001b91bb3b8aa46", "parent_id": null,
@@ -291,7 +291,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: US-ASCII
       string: ''
@@ -323,7 +323,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects",
         "previous": null, "next": null}, "projects": [{"description": null, "links":
         {"self": "http://devstack.openstack.stack:35357/v3/projects/123ac695d4db400a9001b91bb3b8aa46"},
         "enabled": true, "id": "123ac695d4db400a9001b91bb3b8aa46", "parent_id": null,
@@ -379,7 +379,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar46&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar46
     body:
       encoding: US-ASCII
       string: ''
@@ -411,13 +411,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar46&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar46",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz46&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz46
     body:
       encoding: US-ASCII
       string: ''
@@ -449,7 +449,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz46&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz46",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:45 GMT

--- a/spec/fog/openstack/identity_v3/idv3_project_group_user_roles_mutation.yml
+++ b/spec/fog/openstack/identity_v3/idv3_project_group_user_roles_mutation.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar69&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar69
     body:
       encoding: US-ASCII
       string: ''
@@ -34,13 +34,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar69&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar69",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:45 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar69&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar69
     body:
       encoding: US-ASCII
       string: ''
@@ -72,7 +72,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar69&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar69",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:45 GMT
@@ -117,7 +117,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:45 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?name=baz&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles?name=baz
     body:
       encoding: US-ASCII
       string: ''
@@ -149,7 +149,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=baz&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=baz",
         "previous": null, "next": null}, "roles": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:45 GMT
@@ -345,7 +345,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:45 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12
+    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12
     body:
       encoding: US-ASCII
       string: ''
@@ -377,7 +377,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"role_assignments": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12",
+      string: ! '{"role_assignments": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:45 GMT
@@ -718,7 +718,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:46 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12
+    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12
     body:
       encoding: US-ASCII
       string: ''
@@ -750,7 +750,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"role_assignments": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12",
+      string: ! '{"role_assignments": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:46 GMT
@@ -864,7 +864,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:46 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12
+    uri: http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12
     body:
       encoding: US-ASCII
       string: ''
@@ -900,7 +900,7 @@ http_interactions:
         "role": {"id": "814428f4dcb247e2ae6134252386bf6c"}, "user": {"id": "9a509698f17e4752b76765084b8c7f12"},
         "links": {"assignment": "http://devstack.openstack.stack:35357/v3/projects/a04b3a741e98407e815bb4526e52063d/groups/9ea29dd422af4e72be05a869cd7d51c1/roles/814428f4dcb247e2ae6134252386bf6c",
         "membership": "http://devstack.openstack.stack:35357/v3/groups/9ea29dd422af4e72be05a869cd7d51c1/users/9a509698f17e4752b76765084b8c7f12"}}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&page=1&per_page=30&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/role_assignments?effective=true&scope.project.id=a04b3a741e98407e815bb4526e52063d&user.id=9a509698f17e4752b76765084b8c7f12",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:46 GMT

--- a/spec/fog/openstack/identity_v3/idv3_role.yml
+++ b/spec/fog/openstack/identity_v3/idv3_role.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles
     body:
       encoding: US-ASCII
       string: ''
@@ -34,7 +34,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles",
         "previous": null, "next": null}, "roles": [{"id": "1348e84f9797426bb6ec4cae1e6289d7",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/1348e84f9797426bb6ec4cae1e6289d7"},
         "name": "anotherrole"}, {"id": "430e91ef76b74b728a2864bc8a410a60", "links":
@@ -50,7 +50,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles
     body:
       encoding: US-ASCII
       string: ''
@@ -82,7 +82,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles",
         "previous": null, "next": null}, "roles": [{"id": "1348e84f9797426bb6ec4cae1e6289d7",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/1348e84f9797426bb6ec4cae1e6289d7"},
         "name": "anotherrole"}, {"id": "430e91ef76b74b728a2864bc8a410a60", "links":
@@ -98,7 +98,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles
     body:
       encoding: US-ASCII
       string: ''
@@ -130,7 +130,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles",
         "previous": null, "next": null}, "roles": [{"id": "1348e84f9797426bb6ec4cae1e6289d7",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/1348e84f9797426bb6ec4cae1e6289d7"},
         "name": "anotherrole"}, {"id": "430e91ef76b74b728a2864bc8a410a60", "links":
@@ -146,7 +146,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles
     body:
       encoding: US-ASCII
       string: ''
@@ -178,7 +178,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles",
         "previous": null, "next": null}, "roles": [{"id": "1348e84f9797426bb6ec4cae1e6289d7",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/1348e84f9797426bb6ec4cae1e6289d7"},
         "name": "anotherrole"}, {"id": "430e91ef76b74b728a2864bc8a410a60", "links":

--- a/spec/fog/openstack/identity_v3/idv3_role_crud.yml
+++ b/spec/fog/openstack/identity_v3/idv3_role_crud.yml
@@ -41,7 +41,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?name=foobar23&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles?name=foobar23
     body:
       encoding: US-ASCII
       string: ''
@@ -73,7 +73,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=foobar23&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=foobar23",
         "previous": null, "next": null}, "roles": [{"id": "de6f1de9bfb04b69ab07227b43256747",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/de6f1de9bfb04b69ab07227b43256747"},
         "name": "foobar23"}]}'
@@ -120,7 +120,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:43 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?name=baz23&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles?name=baz23
     body:
       encoding: US-ASCII
       string: ''
@@ -152,7 +152,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=baz23&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=baz23",
         "previous": null, "next": null}, "roles": [{"id": "de6f1de9bfb04b69ab07227b43256747",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/de6f1de9bfb04b69ab07227b43256747"},
         "name": "baz23"}]}'
@@ -160,7 +160,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles
     body:
       encoding: US-ASCII
       string: ''
@@ -192,7 +192,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles",
         "previous": null, "next": null}, "roles": [{"id": "1348e84f9797426bb6ec4cae1e6289d7",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/1348e84f9797426bb6ec4cae1e6289d7"},
         "name": "anotherrole"}, {"id": "430e91ef76b74b728a2864bc8a410a60", "links":
@@ -245,7 +245,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles
     body:
       encoding: US-ASCII
       string: ''
@@ -277,7 +277,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles",
         "previous": null, "next": null}, "roles": [{"id": "1348e84f9797426bb6ec4cae1e6289d7",
         "links": {"self": "http://devstack.openstack.stack:35357/v3/roles/1348e84f9797426bb6ec4cae1e6289d7"},
         "name": "anotherrole"}, {"id": "430e91ef76b74b728a2864bc8a410a60", "links":
@@ -331,7 +331,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?name=foobar23&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles?name=foobar23
     body:
       encoding: US-ASCII
       string: ''
@@ -363,13 +363,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=foobar23&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=foobar23",
         "previous": null, "next": null}, "roles": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/roles?name=baz23&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/roles?name=baz23
     body:
       encoding: US-ASCII
       string: ''
@@ -401,7 +401,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=baz23&page=1&per_page=30",
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/roles?name=baz23",
         "previous": null, "next": null}, "roles": []}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:44 GMT

--- a/spec/fog/openstack/identity_v3/idv3_service.yml
+++ b/spec/fog/openstack/identity_v3/idv3_service.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -57,13 +57,13 @@ http_interactions:
         "description": "OpenStack Identity v3 x"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:46 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -118,13 +118,13 @@ http_interactions:
         "description": "OpenStack Identity v3 x"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:46 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -179,13 +179,13 @@ http_interactions:
         "description": "OpenStack Identity v3 x"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:46 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -240,7 +240,7 @@ http_interactions:
         "description": "OpenStack Identity v3 x"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:46 GMT

--- a/spec/fog/openstack/identity_v3/idv3_services_crud.yml
+++ b/spec/fog/openstack/identity_v3/idv3_services_crud.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -57,7 +57,7 @@ http_interactions:
         "description": "OpenStack Identity v3 x"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
@@ -102,7 +102,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30&type=volume
+    uri: http://devstack.openstack.stack:35357/v3/services?type=volume
     body:
       encoding: US-ASCII
       string: ''
@@ -138,7 +138,7 @@ http_interactions:
         "enabled": true, "type": "volume", "id": "511b94ce0482484ea09028091dd5e9a5",
         "description": "Cinder Volume Service"}, {"enabled": true, "type": "volume",
         "name": "foobar", "links": {"self": "http://devstack.openstack.stack:35357/v3/services/c0123d91180c46dfae5c7815d8bc271b"},
-        "id": "c0123d91180c46dfae5c7815d8bc271b"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30&type=volume",
+        "id": "c0123d91180c46dfae5c7815d8bc271b"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?type=volume",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
@@ -183,7 +183,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -240,13 +240,13 @@ http_interactions:
         "id": "c0123d91180c46dfae5c7815d8bc271b"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -303,7 +303,7 @@ http_interactions:
         "id": "c0123d91180c46dfae5c7815d8bc271b"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
@@ -344,7 +344,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -399,7 +399,7 @@ http_interactions:
         "description": "OpenStack Identity v3 x"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
@@ -443,7 +443,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/services
     body:
       encoding: US-ASCII
       string: ''
@@ -498,7 +498,7 @@ http_interactions:
         "description": "OpenStack Identity v3 x"}, {"name": "keystone_v3", "links":
         {"self": "http://devstack.openstack.stack:35357/v3/services/cd9002bbadfe495d81b5ee4c50768009"},
         "enabled": true, "type": "identity_v3", "id": "cd9002bbadfe495d81b5ee4c50768009",
-        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services?page=1&per_page=30",
+        "description": "OpenStack Identity v3"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/services",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:47 GMT

--- a/spec/fog/openstack/identity_v3/idv3_user_crud.yml
+++ b/spec/fog/openstack/identity_v3/idv3_user_crud.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=foobar&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=foobar
     body:
       encoding: US-ASCII
       string: ''
@@ -34,13 +34,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=foobar&page=1&per_page=30",
+      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=foobar",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=baz&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=baz
     body:
       encoding: US-ASCII
       string: ''
@@ -72,13 +72,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=baz&page=1&per_page=30",
+      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=baz",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=foobar&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=foobar
     body:
       encoding: US-ASCII
       string: ''
@@ -110,13 +110,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=foobar&page=1&per_page=30",
+      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=foobar",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=baz&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=baz
     body:
       encoding: US-ASCII
       string: ''
@@ -148,7 +148,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=baz&page=1&per_page=30",
+      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=baz",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
@@ -193,7 +193,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=foobar&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=foobar
     body:
       encoding: US-ASCII
       string: ''
@@ -227,7 +227,7 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"users": [{"name": "foobar", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/4e6db1d5b39e4cffbc4c04fdb79b6c5d"},
         "domain_id": "default", "enabled": true, "email": "foobar@example.com", "id":
-        "4e6db1d5b39e4cffbc4c04fdb79b6c5d"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=foobar&page=1&per_page=30",
+        "4e6db1d5b39e4cffbc4c04fdb79b6c5d"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=foobar",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
@@ -272,7 +272,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=baz&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=baz
     body:
       encoding: US-ASCII
       string: ''
@@ -306,13 +306,13 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"users": [{"name": "baz", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/4e6db1d5b39e4cffbc4c04fdb79b6c5d"},
         "domain_id": "default", "enabled": false, "email": "foobar@example.com", "id":
-        "4e6db1d5b39e4cffbc4c04fdb79b6c5d"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=baz&page=1&per_page=30",
+        "4e6db1d5b39e4cffbc4c04fdb79b6c5d"}], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=baz",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users
     body:
       encoding: US-ASCII
       string: ''
@@ -359,7 +359,7 @@ http_interactions:
         "domain_id": "default", "enabled": true, "email": "foobar@example.com", "id":
         "938bd5585fd145efaadb4a7e588078c1"}, {"name": "admin", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/aa9f25defa6d4cafb48466df83106065"},
         "domain_id": "default", "enabled": true, "email": null, "id": "aa9f25defa6d4cafb48466df83106065"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
@@ -438,7 +438,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users
     body:
       encoding: US-ASCII
       string: ''
@@ -483,7 +483,7 @@ http_interactions:
         "domain_id": "default", "enabled": true, "email": "foobar@example.com", "id":
         "938bd5585fd145efaadb4a7e588078c1"}, {"name": "admin", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/aa9f25defa6d4cafb48466df83106065"},
         "domain_id": "default", "enabled": true, "email": null, "id": "aa9f25defa6d4cafb48466df83106065"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
@@ -527,7 +527,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users
     body:
       encoding: US-ASCII
       string: ''
@@ -572,13 +572,13 @@ http_interactions:
         "domain_id": "default", "enabled": true, "email": "foobar@example.com", "id":
         "938bd5585fd145efaadb4a7e588078c1"}, {"name": "admin", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/aa9f25defa6d4cafb48466df83106065"},
         "domain_id": "default", "enabled": true, "email": null, "id": "aa9f25defa6d4cafb48466df83106065"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=foobar&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=foobar
     body:
       encoding: US-ASCII
       string: ''
@@ -610,13 +610,13 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=foobar&page=1&per_page=30",
+      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=foobar",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=baz&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=baz
     body:
       encoding: US-ASCII
       string: ''
@@ -648,7 +648,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=baz&page=1&per_page=30",
+      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=baz",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:38 GMT

--- a/spec/fog/openstack/identity_v3/idv3_users.yml
+++ b/spec/fog/openstack/identity_v3/idv3_users.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users
     body:
       encoding: US-ASCII
       string: ''
@@ -47,7 +47,7 @@ http_interactions:
         "domain_id": "default", "enabled": true, "email": "foobar@example.com", "id":
         "938bd5585fd145efaadb4a7e588078c1"}, {"name": "admin", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/aa9f25defa6d4cafb48466df83106065"},
         "domain_id": "default", "enabled": true, "email": null, "id": "aa9f25defa6d4cafb48466df83106065"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT
@@ -91,7 +91,7 @@ http_interactions:
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=admin&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=admin
     body:
       encoding: US-ASCII
       string: ''
@@ -125,13 +125,13 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"users": [{"name": "admin", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/aa9f25defa6d4cafb48466df83106065"},
         "domain_id": "default", "enabled": true, "email": null, "id": "aa9f25defa6d4cafb48466df83106065"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=admin&page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=admin",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users
     body:
       encoding: US-ASCII
       string: ''
@@ -176,13 +176,13 @@ http_interactions:
         "domain_id": "default", "enabled": true, "email": "foobar@example.com", "id":
         "938bd5585fd145efaadb4a7e588078c1"}, {"name": "admin", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/aa9f25defa6d4cafb48466df83106065"},
         "domain_id": "default", "enabled": true, "email": null, "id": "aa9f25defa6d4cafb48466df83106065"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users
     body:
       encoding: US-ASCII
       string: ''
@@ -227,13 +227,13 @@ http_interactions:
         "domain_id": "default", "enabled": true, "email": "foobar@example.com", "id":
         "938bd5585fd145efaadb4a7e588078c1"}, {"name": "admin", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/aa9f25defa6d4cafb48466df83106065"},
         "domain_id": "default", "enabled": true, "email": null, "id": "aa9f25defa6d4cafb48466df83106065"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users
     body:
       encoding: US-ASCII
       string: ''
@@ -278,13 +278,13 @@ http_interactions:
         "domain_id": "default", "enabled": true, "email": "foobar@example.com", "id":
         "938bd5585fd145efaadb4a7e588078c1"}, {"name": "admin", "links": {"self": "http://devstack.openstack.stack:35357/v3/users/aa9f25defa6d4cafb48466df83106065"},
         "domain_id": "default", "enabled": true, "email": null, "id": "aa9f25defa6d4cafb48466df83106065"}],
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/users?page=1&per_page=30",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/users",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/users?name=pimpernel&page=1&per_page=30
+    uri: http://devstack.openstack.stack:35357/v3/users?name=pimpernel
     body:
       encoding: US-ASCII
       string: ''
@@ -316,7 +316,7 @@ http_interactions:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=pimpernel&page=1&per_page=30",
+      string: ! '{"users": [], "links": {"self": "http://devstack.openstack.stack:35357/v3/users?name=pimpernel",
         "previous": null, "next": null}}'
     http_version: 
   recorded_at: Wed, 17 Jun 2015 15:06:37 GMT


### PR DESCRIPTION
We need to move all list methods to unified interface, where
only Hash is passed as a first argument. The hash can have
specific fields, that will be recognized and deleted. Rest
of the Hash goes directly to request :query.

Also filtering of options has been deleted, so Fog is now
passing everything, this way we don't have to support changes
in API. Also default values page and per_page has been deleted
because these default values are already set on keystone side.
Default values has been deleted also from recorded VCRs.

This way we can start using the list methods the same. Which
is very important for handling e.g. pagination, filtering,
etc.

All changes are made backwards compatible, with deprecation
warnings, when old interface is used.