### PR TITLE
OpenStack Glance and Heat list methods unified interface

### DIFF
--- a/lib/fog/openstack/models/image/images.rb
+++ b/lib/fog/openstack/models/image/images.rb
@@ -7,12 +7,18 @@ module Fog
       class Images < Fog::Collection
         model Fog::Image::OpenStack::Image
 
-        def all
-          load(service.list_public_images_detailed.body['images'])
+        def all(options = {})
+          load(service.list_public_images_detailed(options).body['images'])
         end
 
-        def details(attribute=nil, query=nil)
-          load(service.list_public_images_detailed(attribute, query).body['images'])
+        def summary(options = {})
+          load(service.list_public_images(options).body['images'])
+        end
+
+        def details(options = {}, deprecated_query = nil)
+          Fog::Logger.deprecation("Calling OpenStack[:glance].images.details will be removed, "\
+                                  " call .images.all for detailed list.")
+          load(service.list_public_images_detailed(options, deprecated_query).body['images'])
         end
 
         def find_by_id(id)

--- a/lib/fog/openstack/models/orchestration/events.rb
+++ b/lib/fog/openstack/models/orchestration/events.rb
@@ -6,15 +6,19 @@ module Fog
       class Events < Fog::Collection
         model Fog::Orchestration::OpenStack::Event
 
-        def all(obj, options={})
-          data = if obj.is_a?(Stack)
-            service.list_stack_events(obj, options).body['events']
-          else
-            service.list_resource_events(obj.stack, obj, options).body['events']
-          end
+        def all(options = {}, options_deprecated = {})
+          data = if options.is_a?(Stack)
+                   service.list_stack_events(options, options_deprecated).body['events']
+                 elsif options.is_a?(Hash)
+                   service.list_events(options).body['events']
+                 else
+                   service.list_resource_events(options.stack, options, options_deprecated).body['events']
+                 end
 
           load data
         end
+
+        alias_method :summary, :all
 
         def get(stack, resource, event_id)
           data = service.show_event_details(stack, resource, event_id).body['event']

--- a/lib/fog/openstack/models/orchestration/resources.rb
+++ b/lib/fog/openstack/models/orchestration/resources.rb
@@ -10,10 +10,12 @@ module Fog
           service.list_resource_types.body['resource_types'].sort
         end
 
-        def all(stack, options={})
-          data = service.list_resources(stack, options).body['resources']
+        def all(options = {}, deprecated_options = {})
+          data = service.list_resources(options, deprecated_options).body['resources']
           load(data)
         end
+
+        alias_method :summary, :all
 
         def get(resource_name, stack=nil)
           stack = self.first.stack if stack.nil?

--- a/lib/fog/openstack/models/orchestration/stack.rb
+++ b/lib/fog/openstack/models/orchestration/stack.rb
@@ -7,7 +7,7 @@ module Fog
 
         %w{capabilities description disable_rollback links notification_topics outputs parameters
             stack_name stack_status stack_status_reason template_description timeout_mins parent
-            creation_time updated_time}.each do |a|
+            creation_time updated_time stack_user_project_id stack_owner}.each do |a|
           attribute a.to_sym
         end
 

--- a/lib/fog/openstack/models/orchestration/stacks.rb
+++ b/lib/fog/openstack/models/orchestration/stacks.rb
@@ -6,7 +6,15 @@ module Fog
       class Stacks < Fog::Collection
         model Fog::Orchestration::OpenStack::Stack
 
-        def all(options={})
+        def all(options = {})
+          # TODO(lsmola) we can uncomment this when https://bugs.launchpad.net/heat/+bug/1468318 is fixed, till then
+          # we will use non detailed list
+          # data = service.list_stack_data_detailed(options).body['stacks']
+          data = service.list_stack_data(options).body['stacks']
+          load(data)
+        end
+
+        def summary(options = {})
           data = service.list_stack_data(options).body['stacks']
           load(data)
         end

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -32,10 +32,12 @@ module Fog
       request :create_stack
       request :delete_stack
       request :get_stack_template
+      request :list_events
       request :list_resource_events
       request :list_resource_types
       request :list_resources
       request :list_stack_data
+      request :list_stack_data_detailed
       request :list_stack_events
       request :preview_stack
       request :show_event_details

--- a/lib/fog/openstack/requests/image/list_public_images.rb
+++ b/lib/fog/openstack/requests/image/list_public_images.rb
@@ -2,17 +2,18 @@ module Fog
   module Image
     class OpenStack
       class Real
-        def list_public_images
+        def list_public_images(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
-            :path    => 'images'
+            :path    => 'images',
+            :query   => options
           )
         end
       end # class Real
 
       class Mock
-        def list_public_images
+        def list_public_images(options = {})
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = {

--- a/lib/fog/openstack/requests/image/list_public_images_detailed.rb
+++ b/lib/fog/openstack/requests/image/list_public_images_detailed.rb
@@ -2,10 +2,13 @@ module Fog
   module Image
     class OpenStack
       class Real
-        def list_public_images_detailed(attribute=nil, query=nil)
-          path = 'images/detail'
-          if attribute
-            query = { attribute => query }
+        def list_public_images_detailed(options = {}, query_deprecated = nil)
+          if options.is_a?(Hash)
+            query = options
+          elsif options
+            Fog::Logger.deprecation("Calling OpenStack[:glance].list_public_images_detailed(attribute, query) format"\
+                                    " is deprecated, call .list_public_images_detailed(attribute => query) instead")
+            query = { options => query_deprecated }
           else
             query = {}
           end
@@ -13,14 +16,14 @@ module Fog
           request(
             :expects => [200, 204],
             :method  => 'GET',
-            :path    => path,
+            :path    => 'images/detail',
             :query   => query
           )
         end
       end # class Real
 
       class Mock
-        def list_public_images_detailed(attribute=nil, query=nil)
+        def list_public_images_detailed(options = {}, query_deprecated = nil)
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = {'images' => self.data[:images].values}

--- a/lib/fog/openstack/requests/orchestration/list_events.rb
+++ b/lib/fog/openstack/requests/orchestration/list_events.rb
@@ -1,0 +1,46 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def list_events(options = {})
+          if !options.key?(:stack) && !(options.key?(:stack_name) && options.key?(:stack_id))
+            raise(ArgumentError, "Missing required options keys: :stack or :stack_name and :stack_id, while calling "\
+                                 " .list_events(options)")
+          end
+
+          stack        = options.delete(:stack)
+          stack_name   = options.delete(:stack_name)
+          stack_name ||= stack.stack_name if stack && stack.respond_to?(:stack_name)
+          stack_id     = options.delete(:stack_id)
+          stack_id   ||= stack.id if stack && stack.respond_to?(:id)
+
+          resource        = options.delete(:resource)
+          resource_name   = options.delete(:resource_name)
+          resource_name ||= resource.resource_name if resource && resource.respond_to?(:resource_name)
+
+          if resource_name
+            path = "stacks/#{stack_name}/#{stack_id}/resources/#{resource_name}/events"
+          else
+            path = "stacks/#{stack_name}/#{stack_id}/events"
+          end
+
+          request(:method  => 'GET',
+                  :path    => path,
+                  :expects => 200,
+                  :query   => options)
+        end
+      end
+
+      class Mock
+        def list_events(options = {})
+          events = self.data[:events].values
+
+          Excon::Response.new(
+            :body => { 'events' => events },
+            :status => 200
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/list_resource_events.rb
+++ b/lib/fog/openstack/requests/orchestration/list_resource_events.rb
@@ -2,14 +2,19 @@ module Fog
   module Orchestration
     class OpenStack
       class Real
-        def list_resource_events(stack, resource, options={})
+        def list_resource_events(stack, resource, options = {})
+          Fog::Logger.deprecation('Calling OpenStack[:orchestration].list_resource_events(stack, resource, options)'\
+                                  ' is deprecated, call .list_events(:stack => stack, :resource => resource) or '\
+                                  ' .list_events(:stack_name => value, :stack_id => value, :resource_name => value)'\
+                                  ' instead')
+
           uri = "stacks/#{stack.stack_name}/#{stack.id}/resources/#{resource.resource_name}/events"
           request(:method => 'GET', :path => uri, :expects => 200, :query => options)
         end
       end
 
       class Mock
-        def list_stack_events
+        def list_resource_events(stack, resource, options={})
           events = self.data[:events].values
 
           Excon::Response.new(

--- a/lib/fog/openstack/requests/orchestration/list_resource_types.rb
+++ b/lib/fog/openstack/requests/orchestration/list_resource_types.rb
@@ -2,11 +2,12 @@ module Fog
   module Orchestration
     class OpenStack
       class Real
-        def list_resource_types
+        def list_resource_types(options = {})
           request(
             :method  => 'GET',
             :path    => "resource_types",
-            :expects => 200
+            :expects => 200,
+            :query   => {}
           )
         end
       end

--- a/lib/fog/openstack/requests/orchestration/list_resources.rb
+++ b/lib/fog/openstack/requests/orchestration/list_resources.rb
@@ -2,14 +2,37 @@ module Fog
   module Orchestration
     class OpenStack
       class Real
-        def list_resources(stack, options={})
-          uri = "stacks/#{stack.stack_name}/#{stack.id}/resources"
-          request(:method => 'GET', :path => uri, :expects => 200, :query => options)
+        def list_resources(options = {}, options_deprecated = {})
+          if options.is_a?(Hash)
+            if !options.key?(:stack) && !(options.key?(:stack_name) && options.key?(:stack_id))
+              raise(ArgumentError, "Missing required options keys: :stack or :stack_name and :stack_id, while calling "\
+                                   " .list_resources(options)")
+            end
+
+            stack        = options.delete(:stack)
+            stack_name   = options.delete(:stack_name)
+            stack_name ||=  stack.stack_name if stack && stack.respond_to?(:stack_name)
+            stack_id     = options.delete(:stack_id)
+            stack_id   ||=  stack.id if stack && stack.respond_to?(:id)
+            path         = "stacks/#{stack_name}/#{stack_id}/resources"
+            params       = options
+          else
+            Fog::Logger.deprecation('Calling OpenStack[:orchestration].list_resources(stack, options) is deprecated, '\
+                                    ' call .list_resources(:stack => stack) or '\
+                                    ' .list_resources(:stack_name => value, :stack_id => value) instead')
+            path   = "stacks/#{stack.stack_name}/#{stack.id}/resources"
+            params = options_deprecated
+          end
+
+          request(:method  => 'GET',
+                  :path    => path,
+                  :expects => 200,
+                  :query   => params)
         end
       end
 
       class Mock
-        def list_resources(stack)
+        def list_resources(options = {}, options_deprecated = {})
           resources = self.data[:resources].values
 
           Excon::Response.new(

--- a/lib/fog/openstack/requests/orchestration/list_stack_data.rb
+++ b/lib/fog/openstack/requests/orchestration/list_stack_data.rb
@@ -2,7 +2,7 @@ module Fog
   module Orchestration
     class OpenStack
       class Real
-        def list_stack_data(options={})
+        def list_stack_data(options = {})
           request(
             :method  => 'GET',
             :path    => 'stacks',
@@ -13,7 +13,7 @@ module Fog
       end
 
       class Mock
-        def list_stack_data
+        def list_stack_data(options = {})
           stacks = self.data[:stacks].values
 
           Excon::Response.new(

--- a/lib/fog/openstack/requests/orchestration/list_stack_data_detailed.rb
+++ b/lib/fog/openstack/requests/orchestration/list_stack_data_detailed.rb
@@ -1,0 +1,49 @@
+module Fog
+  module Orchestration
+    class OpenStack
+      class Real
+        def list_stack_data_detailed(options = {})
+          request(
+            :method  => 'GET',
+            :path    => 'stacks/detail',
+            :expects => 200,
+            :query   => options
+          )
+        end
+      end
+
+      class Mock
+        def list_stack_data_detailed(options = {})
+          Excon::Response.new(
+            :body => {
+              'stacks' =>
+                [{"parent"                => nil,
+                  "disable_rollback"      => true,
+                  "description"           => "No description",
+                  "links"                 => [{"href"=>"http://192.0.2.1:8004/v1/ae084f19a7974d5b95703f633e57fd64/stacks/overcloud/9ea5226f-0bb3-40bf-924b-f89ea11bb69c",
+                                               "rel"=>"self"}],
+                  "stack_status_reason"   => "Stack CREATE completed successfully",
+                  "stack_name"            => "overcloud",
+                  "stack_user_project_id" => "ae084f19a7974d5b95703f633e57fd64",
+                  "stack_owner"           => "admin",
+                  "creation_time"         => "2015-06-24T07:19:01Z",
+                  "capabilities"          => [],
+                  "notification_topics"   => [],
+                  "updated_time"          => nil,
+                  "timeout_mins"          => nil,
+                  "stack_status"          => "CREATE_COMPLETE",
+                  "parameters"            => {"Controller-1::SSLKey"=>"******",
+                                              "Compute-1::RabbitClientUseSSL"=>"False",
+                                              "Controller-1::KeystoneSSLCertificate"=>"",
+                                              "Controller-1::CinderLVMLoopDeviceSize"=>"5000"},
+                  "id"                    => "9ea5226f-0bb3-40bf-924b-f89ea11bb69c",
+                  "outputs"               => [],
+                  "template_description"  => "No description"}]
+            },
+            :status => 200
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/requests/orchestration/list_stack_events.rb
+++ b/lib/fog/openstack/requests/orchestration/list_stack_events.rb
@@ -2,14 +2,18 @@ module Fog
   module Orchestration
     class OpenStack
       class Real
-        def list_stack_events(stack, options={})
+        def list_stack_events(stack, options = {})
+          Fog::Logger.deprecation('Calling OpenStack[:orchestration].list_stack_events(stack, options)'\
+                                  ' is deprecated, call .list_events(:stack => stack) or '\
+                                  ' .list_events(:stack_name => value, :stack_id => value) instead')
+
           uri = "stacks/#{stack.stack_name}/#{stack.id}/events"
           request(:method => 'GET', :path => uri, :expects => 200, :query => options )
         end
       end
 
       class Mock
-        def list_stack_events
+        def list_stack_events(stack, options={})
           events = self.data[:events].values
 
           Excon::Response.new(

--- a/tests/openstack/requests/orchestration/stack_tests.rb
+++ b/tests/openstack/requests/orchestration/stack_tests.rb
@@ -10,6 +10,27 @@ Shindo.tests('Fog::Orchestration[:openstack] | stack requests', ['openstack']) d
     'updated_time'        => Time
   }
 
+  @stack_detailed_format = {
+    "parent"                => Fog::Nullable::String,
+    "disable_rollback"      => Fog::Boolean,
+    "description"           => String,
+    "links"                 => Array,
+    "stack_status_reason"   => String,
+    "stack_name"            => String,
+    "stack_user_project_id" => String,
+    "stack_owner"           => String,
+    "creation_time"         => Fog::Nullable::String,
+    "capabilities"          => Array,
+    "notification_topics"   => Array,
+    "updated_time"          => Fog::Nullable::String,
+    "timeout_mins"          => Fog::Nullable::String,
+    "stack_status"          => String,
+    "parameters"            => Hash,
+    "id"                    => String,
+    "outputs"               => Array,
+    "template_description"  => String
+  }
+
   @create_format = {
     'id'                  => String,
     'links'               => Array,
@@ -22,6 +43,10 @@ Shindo.tests('Fog::Orchestration[:openstack] | stack requests', ['openstack']) d
 
     tests('#list_stack_data').formats({'stacks' => [@stack_format]}) do
       Fog::Orchestration[:openstack].list_stack_data.body
+    end
+
+    tests('#list_stack_data_Detailed').formats({'stacks' => [@stack_detailed_format]}) do
+      Fog::Orchestration[:openstack].list_stack_data_detailed.body
     end
 
     tests('#update_stack("teststack")').formats({}) do


### PR DESCRIPTION
We need to move all list methods to unified interface, where
only Hash is passed as a first argument. The hash can have
specific fields, that will be recognized and deleted. Rest
of the Hash goes directly to request :query. ArgumentError
is raised when mandatory param is missing.

This way we can start using the list methods the same. Which
is very important for handling e.g. pagination, filtering,
etc.

All changes are made backwards compatible, with deprecation
warnings, when old interface is used.