### PR TITLE
OpenStack Keystone and Ironic change all to detailed list

### DIFF
--- a/lib/fog/openstack/models/baremetal/chassis_collection.rb
+++ b/lib/fog/openstack/models/baremetal/chassis_collection.rb
@@ -8,10 +8,16 @@ module Fog
         model Fog::Baremetal::OpenStack::Chassis
 
         def all(options = {})
+          load(service.list_chassis_detailed(options).body['chassis'])
+        end
+
+        def summary(options = {})
           load(service.list_chassis(options).body['chassis'])
         end
 
         def details(options = {})
+          Fog::Logger.deprecation("Calling OpenStack[:baremetal].chassis_collection.details will be removed, "\
+                                  " call .chassis_collection.all for detailed list.")
           load(service.list_chassis_detailed(options).body['chassis'])
         end
 

--- a/lib/fog/openstack/models/baremetal/drivers.rb
+++ b/lib/fog/openstack/models/baremetal/drivers.rb
@@ -11,7 +11,7 @@ module Fog
           load(service.list_drivers(options).body['drivers'])
         end
 
-        alias_method :details, :all
+        alias_method :summary, :all
 
         def find_by_name(name)
           new(service.get_driver(name).body)

--- a/lib/fog/openstack/models/baremetal/nodes.rb
+++ b/lib/fog/openstack/models/baremetal/nodes.rb
@@ -8,10 +8,16 @@ module Fog
         model Fog::Baremetal::OpenStack::Node
 
         def all(options = {})
+          load(service.list_nodes_detailed(options).body['nodes'])
+        end
+
+        def summary(options = {})
           load(service.list_nodes(options).body['nodes'])
         end
 
         def details(options = {})
+          Fog::Logger.deprecation("Calling OpenStack[:baremetal].nodes.details will be removed, "\
+                                  " call .nodes.all for detailed list.")
           load(service.list_nodes_detailed(options).body['nodes'])
         end
 

--- a/lib/fog/openstack/models/baremetal/ports.rb
+++ b/lib/fog/openstack/models/baremetal/ports.rb
@@ -8,10 +8,16 @@ module Fog
         model Fog::Baremetal::OpenStack::Port
 
         def all(options = {})
+          load(service.list_ports_detailed(options).body['ports'])
+        end
+
+        def summary(options = {})
           load(service.list_ports(options).body['ports'])
         end
 
         def details(options = {})
+          Fog::Logger.deprecation("Calling OpenStack[:baremetal].ports.details will be removed, "\
+                                  " call .ports.all for detailed list.")
           load(service.list_ports_detailed(options).body['ports'])
         end
 

--- a/lib/fog/openstack/models/compute/aggregates.rb
+++ b/lib/fog/openstack/models/compute/aggregates.rb
@@ -10,7 +10,7 @@ module Fog
         def all(parameters=nil)
           load(service.list_aggregates(parameters).body['aggregates'])
         end
-        alias_method :details, :all
+        alias_method :summary, :all
 
         def find_by_id(id)
           new(service.get_aggregate(id).body['aggregate'])

--- a/lib/fog/openstack/models/identity_v2/ec2_credentials.rb
+++ b/lib/fog/openstack/models/identity_v2/ec2_credentials.rb
@@ -19,7 +19,7 @@ module Fog
             load(ec2_credentials.body['credentials'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def create(attributes = {})
             if user then

--- a/lib/fog/openstack/models/identity_v2/roles.rb
+++ b/lib/fog/openstack/models/identity_v2/roles.rb
@@ -12,7 +12,7 @@ module Fog
             load(service.list_roles(options).body['roles'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def get(id)
             service.get_role(id)

--- a/lib/fog/openstack/models/identity_v2/tenants.rb
+++ b/lib/fog/openstack/models/identity_v2/tenants.rb
@@ -12,7 +12,7 @@ module Fog
             load(service.list_tenants(options).body['tenants'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def find_by_id(id)
             cached_tenant = self.find { |tenant| tenant.id == id }

--- a/lib/fog/openstack/models/identity_v2/users.rb
+++ b/lib/fog/openstack/models/identity_v2/users.rb
@@ -16,7 +16,7 @@ module Fog
             load(service.list_users(options).body['users'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def find_by_id(id)
             self.find { |user| user.id == id } ||

--- a/lib/fog/openstack/models/identity_v3/domains.rb
+++ b/lib/fog/openstack/models/identity_v3/domains.rb
@@ -12,7 +12,7 @@ module Fog
             load(service.list_domains(options).body['domains'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def auth_domains(options = {})
             load(service.auth_domains(options).body['domains'])

--- a/lib/fog/openstack/models/identity_v3/endpoints.rb
+++ b/lib/fog/openstack/models/identity_v3/endpoints.rb
@@ -12,7 +12,7 @@ module Fog
             load(service.list_endpoints(options).body['endpoints'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def find_by_id(id)
             cached_endpoint = self.find { |endpoint| endpoint.id == id }

--- a/lib/fog/openstack/models/identity_v3/groups.rb
+++ b/lib/fog/openstack/models/identity_v3/groups.rb
@@ -12,7 +12,7 @@ module Fog
             load(service.list_groups(options).body['groups'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def find_by_id(id)
             cached_group = self.find { |group| group.id == id }

--- a/lib/fog/openstack/models/identity_v3/os_credentials.rb
+++ b/lib/fog/openstack/models/identity_v3/os_credentials.rb
@@ -12,7 +12,7 @@ module Fog
             load(service.list_os_credentials(options).body['credentials'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def find_by_id(id)
             cached_credential = self.find { |credential| credential.id == id }

--- a/lib/fog/openstack/models/identity_v3/policies.rb
+++ b/lib/fog/openstack/models/identity_v3/policies.rb
@@ -12,7 +12,7 @@ module Fog
             load(service.list_policies(options).body['policies'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def find_by_id(id)
             cached_policy = self.find { |policy| policy.id == id }

--- a/lib/fog/openstack/models/identity_v3/projects.rb
+++ b/lib/fog/openstack/models/identity_v3/projects.rb
@@ -12,6 +12,8 @@ module Fog
             load(service.list_projects(options).body['projects'])
           end
 
+          alias_method :summary, :all
+
           def auth_projects(options = {})
             load(service.auth_projects(options).body['projects'])
           end

--- a/lib/fog/openstack/models/identity_v3/role_assignments.rb
+++ b/lib/fog/openstack/models/identity_v3/role_assignments.rb
@@ -12,12 +12,12 @@ module Fog
             load(service.list_role_assignments(options).body['role_assignments'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def filter_by(options = {})
             Fog::Logger.deprecation("Calling OpenStack[:keystone].role_assignments.filter_by(options) method which"\
                                     " is not part of standard interface and is deprecated, call "\
-                                    " .role_assignments.all(options) or .role_assignments.details(options) instead.")
+                                    " .role_assignments.all(options) or .role_assignments.summary(options) instead.")
             all(options)
           end
         end

--- a/lib/fog/openstack/models/identity_v3/roles.rb
+++ b/lib/fog/openstack/models/identity_v3/roles.rb
@@ -12,13 +12,13 @@ module Fog
             load(service.list_roles(options).body['roles'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def assignments(options = {})
             # TODO(lsmola) this method doesn't make much sense, it should be moved to role.rb and automatically add
             # role.id filter. Otherwise it's just duplication.
             Fog::Logger.deprecation("Calling OpenStack[:keystone].roles.assignments(options) method which"\
-                                    " deprecated, call OpenStack[:keystone].role_assignments(options) instead")
+                                    " deprecated, call OpenStack[:keystone].role_assignments.all(options) instead")
             load(service.list_role_assignments(options).body['role_assignments'])
           end
 

--- a/lib/fog/openstack/models/identity_v3/services.rb
+++ b/lib/fog/openstack/models/identity_v3/services.rb
@@ -12,7 +12,7 @@ module Fog
             load(service.list_services(options).body['services'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def find_by_id(id)
             cached_service = self.find { |service| service.id == id }

--- a/lib/fog/openstack/models/identity_v3/users.rb
+++ b/lib/fog/openstack/models/identity_v3/users.rb
@@ -12,7 +12,7 @@ module Fog
             load(service.list_users(options).body['users'])
           end
 
-          alias_method :details, :all
+          alias_method :summary, :all
 
           def find_by_id(id)
             cached_user = self.find { |user| user.id == id }

--- a/lib/fog/openstack/requests/identity_v3/list_role_assignments.rb
+++ b/lib/fog/openstack/requests/identity_v3/list_role_assignments.rb
@@ -4,7 +4,8 @@ module Fog
       class V3
         class Real
           def list_role_assignments(options = {})
-            # Backwards compatibility name mapping
+            # Backwards compatibility name mapping, also serves as single pane of glass, since keystone broke
+            # consistency in naming of options, just for this one API call
             name_mapping = {
               :group_id   => 'group.id',
               :role_id    => 'role.id',
@@ -14,9 +15,6 @@ module Fog
             }
             name_mapping.keys.each do |key|
               if (opt = options.delete(key))
-                Fog::Logger.deprecation("Calling OpenStack[:keystone].list_role_assignments(options) with deprecated"\
-                                        " option '#{key}'. Use option '#{name_mapping[key]}' which is defined in"\
-                                        " keystone documentation.")
                 options[name_mapping[key]] = opt
               end
             end


### PR DESCRIPTION
Changing 'all' to 'detailed' list and adding summary method for quick
non detailed lists.

This change is backwards compatible since all method will return
more data. And the alias details methods has not been released yet.