### PR TITLE
OpenStack Cinder, Swift and Tuskar list methods unified interface

### DIFF
--- a/lib/fog/openstack/models/planning/plans.rb
+++ b/lib/fog/openstack/models/planning/plans.rb
@@ -7,9 +7,11 @@ module Fog
       class Plans < Fog::Collection
         model Fog::Openstack::Planning::Plan
 
-        def all
-          load(service.list_plans.body)
+        def all(options = {})
+          load(service.list_plans(options).body)
         end
+
+        alias_method :summary, :all
 
         def find_by_uuid(plan_uuid)
           new(service.get_plan(plan_uuid).body)

--- a/lib/fog/openstack/models/planning/roles.rb
+++ b/lib/fog/openstack/models/planning/roles.rb
@@ -7,9 +7,12 @@ module Fog
       class Roles < Fog::Collection
         model Fog::Openstack::Planning::Role
 
-        def all
-          load(service.list_roles.body)
+        def all(options = {})
+          load(service.list_roles(options).body)
         end
+
+        alias_method :summary, :all
+
       end
     end
   end

--- a/lib/fog/openstack/models/storage/directories.rb
+++ b/lib/fog/openstack/models/storage/directories.rb
@@ -7,10 +7,12 @@ module Fog
       class Directories < Fog::Collection
         model Fog::Storage::OpenStack::Directory
 
-        def all
-          data = service.get_containers.body
+        def all(options = {})
+          data = service.get_containers(options).body
           load(data)
         end
+
+        alias_method :summary, :all
 
         def get(key, options = {})
           data = service.get_container(key, options)

--- a/lib/fog/openstack/models/storage/files.rb
+++ b/lib/fog/openstack/models/storage/files.rb
@@ -33,6 +33,8 @@ module Fog
           end
         end
 
+        alias_method :summary, :all
+
         alias_method :each_file_this_page, :each
         def each
           if !block_given?

--- a/lib/fog/openstack/models/volume/volume_types.rb
+++ b/lib/fog/openstack/models/volume/volume_types.rb
@@ -12,6 +12,8 @@ module Fog
           load(response.body['volume_types'])
         end
 
+        alias_method :summary, :all
+
         def get(volume_type_id)
           if volume_type = service.get_volume_type_details(volume_type_id).body['volume_type']
             new(volume_type)

--- a/lib/fog/openstack/models/volume/volumes.rb
+++ b/lib/fog/openstack/models/volume/volumes.rb
@@ -7,11 +7,22 @@ module Fog
       class Volumes < Fog::Collection
         model Fog::Volume::OpenStack::Volume
 
-        def all(options = {:detailed => true})
+        def all(options = {})
           # the parameter has been "detailed = true" before. Make sure we are
           # backwards compatible
           detailed = options.is_a?(Hash) ? options.delete(:detailed) : options
-          load(service.list_volumes(detailed, options).body['volumes'])
+          if detailed.nil? || detailed
+            # This method gives details by default, unless false or {:detailed => false} is passed
+            load(service.list_volumes_detailed(options).body['volumes'])
+          else
+            Fog::Logger.deprecation('Calling OpenStack[:volume].volumes.all(false) or volumes.all(:detailed => false) '\
+                                    ' is deprecated, call .volumes.summary instead')
+            load(service.list_volumes(options).body['volumes'])
+          end
+        end
+
+        def summary(options = {})
+          load(service.list_volumes(options).body['volumes'])
         end
 
         def get(volume_id)

--- a/lib/fog/openstack/requests/planning/list_plans.rb
+++ b/lib/fog/openstack/requests/planning/list_plans.rb
@@ -2,17 +2,18 @@ module Fog
   module Openstack
     class Planning
       class Real
-        def list_plans
+        def list_plans(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
-            :path    => 'plans'
+            :path    => 'plans',
+            :query   => options
           )
         end
       end # class Real
 
       class Mock
-        def list_plans
+        def list_plans(options = {})
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = [

--- a/lib/fog/openstack/requests/planning/list_roles.rb
+++ b/lib/fog/openstack/requests/planning/list_roles.rb
@@ -2,24 +2,18 @@ module Fog
   module Openstack
     class Planning
       class Real
-        def list_roles(parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
+        def list_roles(options = {})
           request(
             :expects => [200, 204],
             :method  => 'GET',
             :path    => 'roles',
-            :query   => query
+            :query   => options
           )
         end
       end # class Real
 
       class Mock
-        def list_roles(parameters=nil)
+        def list_roles(options = {})
           response = Excon::Response.new
           response.status = [200, 204][rand(1)]
           response.body = [

--- a/lib/fog/openstack/requests/volume/list_volume_types.rb
+++ b/lib/fog/openstack/requests/volume/list_volume_types.rb
@@ -2,18 +2,18 @@ module Fog
   module Volume
     class OpenStack
       class Real
-        def list_volume_types(options={})
+        def list_volume_types(options = {})
           request(
-            :expects  => 200,
-            :method   => 'GET',
-            :path     => 'types',
-            :query    => options
+            :expects => 200,
+            :method  => 'GET',
+            :path    => 'types',
+            :query   => options
           )
         end
       end
 
       class Mock
-        def list_volume_types(options={})
+        def list_volume_types(options = {})
           response = Excon::Response.new
           response.status = 200
           self.data[:volume_types] ||= [

--- a/lib/fog/openstack/requests/volume/list_volumes_detailed.rb
+++ b/lib/fog/openstack/requests/volume/list_volumes_detailed.rb
@@ -2,32 +2,18 @@ module Fog
   module Volume
     class OpenStack
       class Real
-        def list_volumes(options = true, options_deprecated = {})
-          if options.is_a?(Hash)
-            path  = 'volumes'
-            query = options
-          else
-            # Backwards compatibility layer, when 'detailed' boolean was sent as first param
-            if options
-              Fog::Logger.deprecation('Calling OpenStack[:volume].list_volumes(true) is deprecated, use .list_volumes_detailed instead')
-            else
-              Fog::Logger.deprecation('Calling OpenStack[:volume].list_volumes(false) is deprecated, use .list_volumes({}) instead')
-            end
-            path  = options ? 'volumes/detail' : 'volumes'
-            query = options_deprecated
-          end
-
+        def list_volumes_detailed(options = {})
           request(
-            :expects => 200,
-            :method  => 'GET',
-            :path    => path,
-            :query   => query
+            :expects  => 200,
+            :method   => 'GET',
+            :path     => 'volumes/detail',
+            :query    => options
           )
         end
       end
 
       class Mock
-        def list_volumes(options = true, options_deprecated = {})
+        def list_volumes_detailed(options = {})
           response = Excon::Response.new
           response.status = 200
           self.data[:volumes] ||= [

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -22,6 +22,7 @@ module Fog
 
        # Volume
       request :list_volumes
+      request :list_volumes_detailed
       request :create_volume
       request :get_volume_details
       request :delete_volume


### PR DESCRIPTION
We need to move all list methods to unified interface, where
only Hash is passed as a first argument. The hash can have
specific fields, that will be recognized and deleted. Rest
of the Hash goes directly to request :query.

This way we can start using the list methods the same. Which
is very important for handling e.g. pagination, filtering,
etc.

All changes are made backwards compatible, with deprecation
warnings, when old interface is used.