### PR TITLE
support neutron networks labled as public

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -135,16 +135,24 @@ module Fog
           all_floating.empty? ? manual : all_floating
         end
 
-        alias_method :public_ip_addresses, :floating_ip_addresses
+        def public_ip_addresses
+          if floating_ip_addresses.empty?
+            addresses.find_all{|s| s[0] =~ /public/i}.map{|a| a[1][0]['addr']}
+          else
+            floating_ip_addresses
+          end
+        end
 
         def floating_ip_address
           floating_ip_addresses.first
         end
 
-        alias_method :public_ip_address, :floating_ip_address
+        def public_ip_address
+          public_ip_addresses.first
+        end
 
         def private_ip_addresses
-          ip_addresses - floating_ip_addresses
+          ip_addresses - public_ip_addresses - floating_ip_addresses
         end
 
         def private_ip_address


### PR DESCRIPTION
Some folks use directly connected neutron networks that are actually public networks.
This patch supports using both floating_ip_addresses AND neutron networks with 'public' in the name.
