### PR TITLE
[cloudstack] Use `isdefault` in `listNetworks` response

### DIFF
--- a/lib/fog/cloudstack/models/compute/network.rb
+++ b/lib/fog/cloudstack/models/compute/network.rb
@@ -38,6 +38,7 @@ module Fog
         attribute :canuse_for_deploy,       :aliases => 'canusefordeploy'
         attribute :is_persistent,           :aliases => 'ispersistent', :type => :boolean
         attribute :display_network,         :aliases => 'displaynetwork'
+        attribute :is_default,              :aliases => 'isdefault', :type => :boolean
 
         # restart network - will return a job
         def restart(options={})


### PR DESCRIPTION
Add support for `isdefault` field in the response from CloudStacks `listNetworks` request.

https://cloudstack.apache.org/api/apidocs-4.4/user/listNetworks.html