### PR TITLE
Missing network init uri

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -161,16 +161,15 @@ module Fog
           @openstack_must_reauthenticate = false
           @auth_token = credentials[:token]
           @openstack_management_url = credentials[:server_management_url]
-          uri = URI.parse(@openstack_management_url)
         else
           @auth_token = @openstack_auth_token
-          uri = URI.parse(@openstack_management_url)
         end
+        @openstack_management_uri = URI.parse(@openstack_management_url)
 
-        @host   = uri.host
-        @path   = uri.path
-        @port   = uri.port
-        @scheme = uri.scheme
+        @host   = @openstack_management_uri.host
+        @path   = @openstack_management_uri.path
+        @port   = @openstack_management_uri.port
+        @scheme = @openstack_management_uri.scheme
         true
       end
     end

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -241,7 +241,7 @@ module Fog
           @path.sub!(/\/$/, '')
           unless @path.match(SUPPORTED_VERSIONS)
             @path = "/" + Fog::OpenStack.get_supported_version(SUPPORTED_VERSIONS,
-                                                               uri,
+                                                               @openstack_management_uri,
                                                                @auth_token,
                                                                @connection_options)
           end


### PR DESCRIPTION
Missing network init uri, got lost probably in cleanup in
https://github.com/fog/fog/commit/83b61986bd2787dd22dc8967f28d0c78d8752aff