### PR TITLE
Don't remove nil keys in OpenStack#create_subnet

### DIFF
--- a/lib/fog/openstack/requests/network/create_subnet.rb
+++ b/lib/fog/openstack/requests/network/create_subnet.rb
@@ -7,22 +7,22 @@ module Fog
             'subnet' => {
               'network_id' => network_id,
               'cidr'       => cidr,
-              'ip_version' => ip_version,
+              'ip_version' => ip_version
             }
           }
 
           vanilla_options = [:name, :gateway_ip, :allocation_pools,
                              :dns_nameservers, :host_routes, :enable_dhcp,
                              :tenant_id]
-          vanilla_options.reject{ |o| options[o].nil? }.each do |key|
+          vanilla_options.each do |key|
             data['subnet'][key] = options[key]
           end
 
           request(
-            :body     => Fog::JSON.encode(data),
-            :expects  => [201],
-            :method   => 'POST',
-            :path     => 'subnets'
+            :body => Fog::JSON.encode(data),
+            :expects => [201],
+            :method => 'POST',
+            :path => 'subnets'
           )
         end
       end
@@ -42,7 +42,7 @@ module Fog
             'dns_nameservers'  => options[:dns_nameservers],
             'host_routes'      => options[:host_routes],
             'enable_dhcp'      => options[:enable_dhcp],
-            'tenant_id'        => options[:tenant_id],
+            'tenant_id'        => options[:tenant_id]
           }
           self.data[:subnets][data['id']] = data
           response.body = { 'subnet' => data }


### PR DESCRIPTION
The [docs](http://developer.openstack.org/api-ref-networking-v2.html) state that a `gateway_ip` key may be passed in with nil to represent "no gateway_ip" so that a gateway IP address isn't automatically assigned.

Discovered via: http://stackoverflow.com/questions/30930343/nil-not-turning-into-null-in-request-on-fog