### PR TITLE
Bump fog-aws dependency

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -53,7 +53,7 @@ Gem::Specification.new do |s|
 
   # Modular providers (please keep sorted)
   s.add_dependency("fog-atmos")
-  s.add_dependency("fog-aws", "~> 0.0")
+  s.add_dependency("fog-aws", ">= 0.6.0")
   s.add_dependency("fog-brightbox", "~> 0.4")
   s.add_dependency("fog-ecloud", "= 0.1.1")
   s.add_dependency("fog-google", ">= 0.0.2")


### PR DESCRIPTION
I'm trying to add <a href="http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/vpc-classiclink.html">EC2 ClassicLink</a> support to the <a href="https://github.com/chef/knife-ec2">knife ec2</a> gem.

It seems like <a href="https://github.com/fog/fog-aws/blob/916351a3532e80a0318e766ec12bb87fa2348350/lib/fog/aws/requests/compute/attach_classic_link_vpc.rb">fog-aws already supports ClassicLink</a>, so I've <a href="https://github.com/quentindemetz/knife-ec2/tree/add_support_for_ec2_classic_link">forked knife-ec2</a> to wrap around the relevant fog method.

However, it seems that the current release of fog does not require a particular version of fog-aws, which means even the latest release of fog does not include a version of fog-aws with ClassicLink support.

Please let me know if this is the way to solve this issue or if I should do it otherwise.