### PR TITLE
process runcmd when creating a customspec  from cloudinit in vsphere

### DIFF
--- a/lib/fog/vsphere/requests/compute/cloudinit_to_customspec.rb
+++ b/lib/fog/vsphere/requests/compute/cloudinit_to_customspec.rb
@@ -16,6 +16,7 @@ module Fog
           custom_spec['encryptionKey']    = user_data['encryptionKey'] if user_data.key?('encryptionKey')
           custom_spec['globalIPSettings'] = user_data['globalIPSettings'] if user_data.key?('globalIPSettings')
           custom_spec['identity']         = user_data['identity'] if user_data.key?('identity')
+          custom_spec['identity']         = {"Sysprep"=>{"guiRunOnce"=>{"commandList"=>user_data['runcmd']}}} if user_data.key?('runcmd') and not user_data.key?('identity')
           custom_spec['nicSettingMap']    = user_data['nicSettingMap'] if user_data.key?('nicSettingMap')
           custom_spec['options']          = user_data['options'] if user_data.key?('options')
           


### PR DESCRIPTION
this allows input to be compliant with cloudinit syntax when passing first run commands 
so the following input could be used instead of very specific   
runcmd:
 - echo superbien > /tmp/prout
 - echo 10.32.244.60 karmasat61.xxx >> /etc/hosts

(of course, for some specific items, typically windows bits, the vsphere naming can still be used)