### PR TITLE
Adding Openstack Collection base class

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -40,6 +40,8 @@ module Fog
           new_error
         end
       end
+
+      class InterfaceNotImplemented < Fog::Errors::Error; end
     end
 
     service(:compute ,      'Compute')

--- a/lib/fog/openstack/models/collection.rb
+++ b/lib/fog/openstack/models/collection.rb
@@ -1,0 +1,45 @@
+require 'fog/core/collection'
+
+module Fog
+  module OpenStack
+    class Collection < Fog::Collection
+      # It's important to store the whole response, it contains e.g. important info about whether there is another
+      # page of data.
+      attr_accessor :response
+
+      def load_response(response, index = nil)
+        # Delete it index if it's there, so we don't store response with data twice, but we store only metadata
+        objects = index ? response.body.delete(index) : response.body
+
+        clear && objects.each { |object| self << new(object) }
+        self.response = response
+        self
+      end
+
+      ##################################################################################################################
+      # Abstract base class methods, please keep the consistent naming in all subclasses of the Collection class
+
+      # Returns detailed list of records
+      def all(options = {})
+        raise Fog::OpenStack::Errors::InterfaceNotImplemented.new('Method :all is not implemented')
+      end
+
+      # Returns non detailed list of records, usually just subset of attributes, which makes this call more effective.
+      # Not all openstack services support non detailed list, so it delegates to :all by default.
+      def summary(options = {})
+        all(options)
+      end
+
+      # Gets record given record's UUID
+      def get(uuid)
+        raise Fog::OpenStack::Errors::InterfaceNotImplemented.new('Method :get is not implemented')
+      end
+      alias_method :find_by_id, :get
+
+      # Destroys record given record's UUID
+      def destroy(uuid)
+        raise Fog::OpenStack::Errors::InterfaceNotImplemented.new('Method :destroy is not implemented')
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/network/floating_ips.rb
+++ b/lib/fog/openstack/models/network/floating_ips.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/floating_ip'
 
 module Fog
   module Network
     class OpenStack
-      class FloatingIps < Fog::Collection
+      class FloatingIps < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::FloatingIp
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_floating_ips(filters).body['floatingips'])
+          load_response(service.list_floating_ips(filters), 'floatingips')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/lb_health_monitors.rb
+++ b/lib/fog/openstack/models/network/lb_health_monitors.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/lb_health_monitor'
 
 module Fog
   module Network
     class OpenStack
-      class LbHealthMonitors < Fog::Collection
+      class LbHealthMonitors < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::LbHealthMonitor
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_lb_health_monitors(filters).body['health_monitors'])
+          load_response(service.list_lb_health_monitors(filters), 'health_monitors')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/lb_members.rb
+++ b/lib/fog/openstack/models/network/lb_members.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/lb_member'
 
 module Fog
   module Network
     class OpenStack
-      class LbMembers < Fog::Collection
+      class LbMembers < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::LbMember
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_lb_members(filters).body['members'])
+          load_response(service.list_lb_members(filters), 'members')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/lb_pools.rb
+++ b/lib/fog/openstack/models/network/lb_pools.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/lb_pool'
 
 module Fog
   module Network
     class OpenStack
-      class LbPools < Fog::Collection
+      class LbPools < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::LbPool
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_lb_pools(filters).body['pools'])
+          load_response(service.list_lb_pools(filters), 'pools')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/lb_vips.rb
+++ b/lib/fog/openstack/models/network/lb_vips.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/lb_vip'
 
 module Fog
   module Network
     class OpenStack
-      class LbVips < Fog::Collection
+      class LbVips < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::LbVip
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_lb_vips(filters).body['vips'])
+          load_response(service.list_lb_vips(filters), 'vips')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/networks.rb
+++ b/lib/fog/openstack/models/network/networks.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/network'
 
 module Fog
   module Network
     class OpenStack
-      class Networks < Fog::Collection
+      class Networks < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::Network
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_networks(filters).body['networks'])
+          load_response(service.list_networks(filters), 'networks')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/ports.rb
+++ b/lib/fog/openstack/models/network/ports.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/port'
 
 module Fog
   module Network
     class OpenStack
-      class Ports < Fog::Collection
+      class Ports < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::Port
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_ports(filters).body['ports'])
+          load_response(service.list_ports(filters), 'ports')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/routers.rb
+++ b/lib/fog/openstack/models/network/routers.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/router'
 
 module Fog
   module Network
     class OpenStack
-      class Routers < Fog::Collection
+      class Routers < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::Router
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_routers(filters).body['routers'])
+          load_response(service.list_routers(filters), 'routers')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/security_group_rules.rb
+++ b/lib/fog/openstack/models/network/security_group_rules.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/security_group_rule'
 
 module Fog
   module Network
     class OpenStack
-      class SecurityGroupRules < Fog::Collection
+      class SecurityGroupRules < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::SecurityGroupRule
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_security_group_rules(filters).body['security_group_rules'])
+          load_response(service.list_security_group_rules(filters), 'security_group_rules')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/security_groups.rb
+++ b/lib/fog/openstack/models/network/security_groups.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/security_group'
 
 module Fog
   module Network
     class OpenStack
-      class SecurityGroups < Fog::Collection
+      class SecurityGroups < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::SecurityGroup
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_security_groups(filters).body['security_groups'])
+          load_response(service.list_security_groups(filters), 'security_groups')
         end
 
         alias_method :summary, :all

--- a/lib/fog/openstack/models/network/subnets.rb
+++ b/lib/fog/openstack/models/network/subnets.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/network/subnet'
 
 module Fog
   module Network
     class OpenStack
-      class Subnets < Fog::Collection
+      class Subnets < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Network::OpenStack::Subnet
@@ -16,7 +16,7 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          load(service.list_subnets(filters).body['subnets'])
+          load_response(service.list_subnets(filters), 'subnets')
         end
 
         alias_method :summary, :all


### PR DESCRIPTION
Several parts of this patch

1. base class documents how the standard interface should look
like. This doesn't bring anything to the code, since abstract
classes are redundant in ruby, but it is nice to see what should
be the standard interface.

2. load_response method saves the whole response. Usually not
only list of records is sent. It can contain also metatada about
pagination, or other useful metadata.
