### PR TITLE
Openstack Model base class

### DIFF
--- a/lib/fog/openstack/models/model.rb
+++ b/lib/fog/openstack/models/model.rb
@@ -1,0 +1,44 @@
+require 'fog/core/model'
+
+module Fog
+  module OpenStack
+    class Model < Fog::Model
+      # In some cases it's handy to be able to store the project for the record, e.g. swift doesn't contain project info
+      # in the result, so we can track it in this attribute based on what project was used in the request
+      attr_accessor :project
+
+      ##################################################################################################################
+      # Abstract base class methods, please keep the consistent naming in all subclasses of the Model class
+
+      # Initialize a record
+      def initialize(attributes)
+        # Old 'connection' is renamed as service and should be used instead
+        prepare_service_value(attributes)
+        super
+      end
+
+      # Saves a record, call create or update based on identity, which marks if object was already created
+      def save
+        identity ? update : create
+      end
+
+      # Updates a record
+      def update
+        # uncomment when exception is defined in another PR
+        # raise Fog::OpenStack::Errors::InterfaceNotImplemented.new('Method :get is not implemented')
+      end
+
+      # Creates a record
+      def create
+        # uncomment when exception is defined in another PR
+        # raise Fog::OpenStack::Errors::InterfaceNotImplemented.new('Method :get is not implemented')
+      end
+
+      # Destroys a record
+      def destroy
+        # uncomment when exception is defined in another PR
+        # raise Fog::OpenStack::Errors::InterfaceNotImplemented.new('Method :get is not implemented')
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/storage/directory.rb
+++ b/lib/fog/openstack/models/storage/directory.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 require 'fog/openstack/models/storage/files'
 
 module Fog
   module Storage
     class OpenStack
-      class Directory < Fog::Model
+      class Directory < Fog::OpenStack::Model
         identity  :key, :aliases => 'name'
 
         attribute :bytes, :aliases => 'X-Container-Bytes-Used'

--- a/lib/fog/openstack/models/storage/file.rb
+++ b/lib/fog/openstack/models/storage/file.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Storage
     class OpenStack
-      class File < Fog::Model
+      class File < Fog::OpenStack::Model
         identity  :key,             :aliases => 'name'
 
         attribute :access_control_allow_origin, :aliases => ['Access-Control-Allow-Origin']


### PR DESCRIPTION
base class documents how the standard interface should look
like. This doesn't bring anything to the code, since abstract
classes are redundant in ruby, but it is nice to see what should
be the standard interface.

Base class also define the repeated methods initialize and save,
so we don't need to define them in subclasess.

project is storable to attribute, since not all results contain
project associated, it's good to to be able to store the project
used when processing the collection.