### PR TITLE
Fog::OpenStack::Model base class for all openstack models

### DIFF
--- a/lib/fog/openstack/models/baremetal/chassis.rb
+++ b/lib/fog/openstack/models/baremetal/chassis.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Baremetal
     class OpenStack
-      class Chassis < Fog::Model
+      class Chassis < Fog::OpenStack::Model
         identity :uuid
 
         attribute :description
@@ -14,17 +14,6 @@ module Fog
         attribute :updated_at
         attribute :extra
 
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :description
-          identity ? update : create
-        end
-
         def create
           requires :description
           merge_attributes(service.create_chassis(self.attributes).body)
@@ -32,7 +21,7 @@ module Fog
         end
 
         def update(patch=nil)
-          requires :uuid
+          requires :uuid, :description
           if patch
             merge_attributes(service.patch_chassis(uuid, patch).body)
           else

--- a/lib/fog/openstack/models/baremetal/driver.rb
+++ b/lib/fog/openstack/models/baremetal/driver.rb
@@ -1,19 +1,13 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Baremetal
     class OpenStack
-      class Driver < Fog::Model
+      class Driver < Fog::OpenStack::Model
         identity :name
 
         attribute :name
         attribute :hosts
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def properties
           requires :name

--- a/lib/fog/openstack/models/baremetal/node.rb
+++ b/lib/fog/openstack/models/baremetal/node.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Baremetal
     class OpenStack
-      class Node < Fog::Model
+      class Node < Fog::OpenStack::Model
         identity :uuid
 
         attribute :instance_uuid
@@ -29,17 +29,6 @@ module Fog
         attribute :target_power_state
         attribute :target_provision_state
 
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :driver
-          identity ? update : create
-        end
-
         def create
           requires :driver
           merge_attributes(service.create_node(self.attributes).body)
@@ -47,7 +36,7 @@ module Fog
         end
 
         def update(patch=nil)
-          requires :uuid
+          requires :uuid, :driver
           if patch
             merge_attributes(service.patch_node(uuid, patch).body)
           else

--- a/lib/fog/openstack/models/baremetal/port.rb
+++ b/lib/fog/openstack/models/baremetal/port.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Baremetal
     class OpenStack
-      class Port < Fog::Model
+      class Port < Fog::OpenStack::Model
         identity :uuid
 
         attribute :address
@@ -15,17 +15,6 @@ module Fog
         attribute :extra
         attribute :node_uuid
 
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :address, :node_uuid
-          identity ? update : create
-        end
-
         def create
           requires :address, :node_uuid
           merge_attributes(service.create_port(self.attributes).body)
@@ -33,7 +22,7 @@ module Fog
         end
 
         def update(patch=nil)
-          requires :uuid
+          requires :uuid, :address, :node_uuid
           if patch
             merge_attributes(service.patch_port(uuid, patch).body)
           else

--- a/lib/fog/openstack/models/compute/address.rb
+++ b/lib/fog/openstack/models/compute/address.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Compute
     class OpenStack
-      class Address < Fog::Model
+      class Address < Fog::OpenStack::Model
         identity  :id
 
         attribute :ip

--- a/lib/fog/openstack/models/compute/aggregate.rb
+++ b/lib/fog/openstack/models/compute/aggregate.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Compute
     class OpenStack
-      class Aggregate < Fog::Model
+      class Aggregate < Fog::OpenStack::Model
         identity :id
 
         attribute :availability_zone
@@ -16,12 +16,6 @@ module Fog
 
         # Detailed
         attribute :hosts
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def save
           requires :name

--- a/lib/fog/openstack/models/compute/flavor.rb
+++ b/lib/fog/openstack/models/compute/flavor.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Compute
     class OpenStack
-      class Flavor < Fog::Model
+      class Flavor < Fog::OpenStack::Model
         identity :id
 
         attribute :name
@@ -17,12 +17,6 @@ module Fog
         attribute :ephemeral, :aliases => 'OS-FLV-EXT-DATA:ephemeral'
         attribute :is_public, :aliases => 'os-flavor-access:is_public'
         attribute :disabled, :aliases => 'OS-FLV-DISABLED:disabled'
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def save
           requires :name, :ram, :vcpus, :disk

--- a/lib/fog/openstack/models/compute/host.rb
+++ b/lib/fog/openstack/models/compute/host.rb
@@ -4,7 +4,7 @@ require 'fog/openstack/models/compute/metadata'
 module Fog
   module Compute
     class OpenStack
-      class Host < Fog::Model
+      class Host < Fog::OpenStack::Model
         attribute :host_name
         attribute :service_name
         attribute :details

--- a/lib/fog/openstack/models/compute/image.rb
+++ b/lib/fog/openstack/models/compute/image.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 require 'fog/openstack/models/compute/metadata'
 
 module Fog
   module Compute
     class OpenStack
-      class Image < Fog::Model
+      class Image < Fog::OpenStack::Model
         identity :id
 
         attribute :name
@@ -17,12 +17,6 @@ module Fog
         attribute :server,   :aliases => 'server'
         attribute :metadata
         attribute :links
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def metadata
           @metadata ||= begin

--- a/lib/fog/openstack/models/compute/key_pair.rb
+++ b/lib/fog/openstack/models/compute/key_pair.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Compute
     class OpenStack
-      class KeyPair < Fog::Model
+      class KeyPair < Fog::OpenStack::Model
         identity  :name
 
         attribute :fingerprint

--- a/lib/fog/openstack/models/compute/metadatum.rb
+++ b/lib/fog/openstack/models/compute/metadatum.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 require 'fog/openstack/models/meta_parent'
 
 module Fog
   module Compute
     class OpenStack
-      class Metadatum < Fog::Model
+      class Metadatum < Fog::OpenStack::Model
         include Fog::Compute::OpenStack::MetaParent
 
         identity :key

--- a/lib/fog/openstack/models/compute/network.rb
+++ b/lib/fog/openstack/models/compute/network.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Compute
     class OpenStack
-      class Network < Fog::Model
+      class Network < Fog::OpenStack::Model
         identity  :id
         attribute :name
         attribute :addresses

--- a/lib/fog/openstack/models/compute/security_group.rb
+++ b/lib/fog/openstack/models/compute/security_group.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Compute
     class OpenStack
-      class SecurityGroup < Fog::Model
+      class SecurityGroup < Fog::OpenStack::Model
         identity  :id
 
         attribute :name

--- a/lib/fog/openstack/models/compute/security_group_rule.rb
+++ b/lib/fog/openstack/models/compute/security_group_rule.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Compute
     class OpenStack
-      class SecurityGroupRule < Fog::Model
+      class SecurityGroupRule < Fog::OpenStack::Model
         identity :id
 
         attribute :from_port

--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -52,6 +52,10 @@ module Fog
         attr_writer :image_ref, :flavor_ref, :nics, :os_scheduler_hints
         attr_accessor :block_device_mapping, :block_device_mapping_v2
 
+        # In some cases it's handy to be able to store the project for the record, e.g. swift doesn't contain project info
+        # in the result, so we can track it in this attribute based on what project was used in the request
+        attr_accessor :project
+
         def initialize(attributes={})
           # Old 'connection' is renamed as service and should be used instead
           prepare_service_value(attributes)

--- a/lib/fog/openstack/models/compute/service.rb
+++ b/lib/fog/openstack/models/compute/service.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Compute
     class OpenStack
-      class Service < Fog::Model
+      class Service < Fog::OpenStack::Model
         identity :id
 
         attribute :binary
@@ -15,12 +15,6 @@ module Fog
 
         #detailed
         attribute :disabled_reason
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def enable
           requires :binary, :host

--- a/lib/fog/openstack/models/compute/snapshot.rb
+++ b/lib/fog/openstack/models/compute/snapshot.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 require 'fog/openstack/models/compute/metadata'
 
 module Fog
   module Compute
     class OpenStack
-      class Snapshot < Fog::Model
+      class Snapshot < Fog::OpenStack::Model
         identity :id
 
         attribute :name,                :aliases => 'displayName'
@@ -13,12 +13,6 @@ module Fog
         attribute :status
         attribute :size
         attribute :created_at,          :aliases => 'createdAt'
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def save(force=false)
           requires :volume_id, :name, :description

--- a/lib/fog/openstack/models/compute/tenant.rb
+++ b/lib/fog/openstack/models/compute/tenant.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Compute
     class OpenStack
-      class Tenant < Fog::Model
+      class Tenant < Fog::OpenStack::Model
         identity :id
 
         attribute :description

--- a/lib/fog/openstack/models/compute/volume.rb
+++ b/lib/fog/openstack/models/compute/volume.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 require 'fog/openstack/models/compute/metadata'
 
 module Fog
   module Compute
     class OpenStack
-      class Volume < Fog::Model
+      class Volume < Fog::OpenStack::Model
         identity :id
 
         attribute :name,                :aliases => 'displayName'
@@ -16,12 +16,6 @@ module Fog
         attribute :availability_zone,   :aliases => 'availabilityZone'
         attribute :created_at,          :aliases => 'createdAt'
         attribute :attachments
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def save
           requires :name, :description, :size

--- a/lib/fog/openstack/models/identity_v2/ec2_credential.rb
+++ b/lib/fog/openstack/models/identity_v2/ec2_credential.rb
@@ -1,21 +1,15 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V2
-        class Ec2Credential < Fog::Model
+        class Ec2Credential < Fog::OpenStack::Model
           identity :access, :aliases => 'access_key'
 
           attribute :secret, :aliases => 'secret_key'
           attribute :tenant_id
           attribute :user_id
-
-          def initialize(attributes)
-            # Old 'connection' is renamed as service and should be used instead
-            prepare_service_value(attributes)
-            super
-          end
 
           def destroy
             requires :access

--- a/lib/fog/openstack/models/identity_v2/role.rb
+++ b/lib/fog/openstack/models/identity_v2/role.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V2
-        class Role < Fog::Model
+        class Role < Fog::OpenStack::Model
           identity :id
           attribute :name
 

--- a/lib/fog/openstack/models/identity_v2/tenant.rb
+++ b/lib/fog/openstack/models/identity_v2/tenant.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V2
-        class Tenant < Fog::Model
+        class Tenant < Fog::OpenStack::Model
           identity :id
 
           attribute :description
@@ -33,18 +33,14 @@ module Fog
           end
 
           def update(attr = nil)
-            requires :id
+            requires :id, :name
             merge_attributes(
                 service.update_tenant(self.id, attr || attributes).body['tenant'])
             self
           end
 
-          def save
-            requires :name
-            identity ? update : create
-          end
-
           def create
+            requires :name
             merge_attributes(
                 service.create_tenant(attributes).body['tenant'])
             self

--- a/lib/fog/openstack/models/identity_v2/user.rb
+++ b/lib/fog/openstack/models/identity_v2/user.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V2
-        class User < Fog::Model
+        class User < Fog::OpenStack::Model
           identity :id
 
           attribute :email
@@ -14,12 +14,6 @@ module Fog
           attribute :password
 
           attr_accessor :email, :name, :tenant_id, :enabled, :password
-
-          def initialize(attributes)
-            # Old 'connection' is renamed as service and should be used instead
-            prepare_service_value(attributes)
-            super
-          end
 
           def ec2_credentials
             requires :id

--- a/lib/fog/openstack/models/identity_v3/domain.rb
+++ b/lib/fog/openstack/models/identity_v3/domain.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Domain < Fog::Model
+        class Domain < Fog::OpenStack::Model
           identity :id
 
           attribute :description
@@ -23,18 +23,14 @@ module Fog
           end
 
           def update(attr = nil)
-            requires :id
+            requires :id, :name
             merge_attributes(
                 service.update_domain(self.id, attr || attributes).body['domain'])
             self
           end
 
-          def save
-            requires :name
-            identity ? update : create
-          end
-
           def create
+            requires :name
             merge_attributes(
                 service.create_domain(attributes).body['domain'])
             self

--- a/lib/fog/openstack/models/identity_v3/endpoint.rb
+++ b/lib/fog/openstack/models/identity_v3/endpoint.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Endpoint < Fog::Model
+        class Endpoint < Fog::OpenStack::Model
           identity :id
 
           attribute :description
@@ -26,18 +26,14 @@ module Fog
           end
 
           def update(attr = nil)
-            requires :id
+            requires :id, :name
             merge_attributes(
                 service.update_endpoint(self.id, attr || attributes).body['endpoint'])
             self
           end
 
-          def save
-            requires :name
-            identity ? update : create
-          end
-
           def create
+            requires :name
             merge_attributes(
                 service.create_endpoint(attributes).body['endpoint'])
             self

--- a/lib/fog/openstack/models/identity_v3/group.rb
+++ b/lib/fog/openstack/models/identity_v3/group.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Group < Fog::Model
+        class Group < Fog::OpenStack::Model
           identity :id
 
           attribute :description
@@ -23,18 +23,14 @@ module Fog
           end
 
           def update(attr = nil)
-            requires :id
+            requires :id, :name
             merge_attributes(
                 service.update_group(self.id, attr || attributes).body['group'])
             self
           end
 
-          def save
-            requires :name
-            identity ? update : create
-          end
-
           def create
+            requires :name
             merge_attributes(
                 service.create_group(attributes).body['group'])
             self

--- a/lib/fog/openstack/models/identity_v3/os_credential.rb
+++ b/lib/fog/openstack/models/identity_v3/os_credential.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class OsCredential < Fog::Model
+        class OsCredential < Fog::OpenStack::Model
           identity :id
 
           attribute :project_id

--- a/lib/fog/openstack/models/identity_v3/policy.rb
+++ b/lib/fog/openstack/models/identity_v3/policy.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Policy < Fog::Model
+        class Policy < Fog::OpenStack::Model
           identity :id
 
           attribute :type
@@ -22,18 +22,14 @@ module Fog
           end
 
           def update(attr = nil)
-            requires :id
+            requires :id, :blob, :type
             merge_attributes(
                 service.update_policy(self.id, attr || attributes).body['policy'])
             self
           end
 
-          def save
-            requires :blob, :type
-            identity ? update : create
-          end
-
           def create
+            requires :blob, :type
             merge_attributes(
                 service.create_policy(attributes).body['policy'])
             self

--- a/lib/fog/openstack/models/identity_v3/project.rb
+++ b/lib/fog/openstack/models/identity_v3/project.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Project < Fog::Model
+        class Project < Fog::OpenStack::Model
           identity :id
 
           attribute :domain_id
@@ -29,11 +29,6 @@ module Fog
             merge_attributes(
                 service.update_project(self.id, attr || attributes).body['project'])
             self
-          end
-
-          def save
-            requires :name
-            identity ? update : create
           end
 
           def create

--- a/lib/fog/openstack/models/identity_v3/role.rb
+++ b/lib/fog/openstack/models/identity_v3/role.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Role < Fog::Model
+        class Role < Fog::OpenStack::Model
           identity :id
 
           attribute :name
@@ -25,11 +25,6 @@ module Fog
             merge_attributes(
                 service.update_role(self.id, attr || attributes).body['role'])
             self
-          end
-
-          def save
-            requires :name
-            identity ? update : create
           end
 
           def create

--- a/lib/fog/openstack/models/identity_v3/role_assignment.rb
+++ b/lib/fog/openstack/models/identity_v3/role_assignment.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class RoleAssignment < Fog::Model
+        class RoleAssignment < Fog::OpenStack::Model
           attribute :scope
           attribute :role
           attribute :user

--- a/lib/fog/openstack/models/identity_v3/service.rb
+++ b/lib/fog/openstack/models/identity_v3/service.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Service < Fog::Model
+        class Service < Fog::OpenStack::Model
           identity :id
 
           attribute :description

--- a/lib/fog/openstack/models/identity_v3/token.rb
+++ b/lib/fog/openstack/models/identity_v3/token.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Token < Fog::Model
+        class Token < Fog::OpenStack::Model
 
           attribute :value
           attribute :catalog

--- a/lib/fog/openstack/models/identity_v3/user.rb
+++ b/lib/fog/openstack/models/identity_v3/user.rb
@@ -1,10 +1,10 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class User < Fog::Model
+        class User < Fog::OpenStack::Model
           identity :id
 
           attribute :default_project_id
@@ -68,17 +68,11 @@ module Fog
             self
           end
 
-          def save
-            requires :name
-            identity ? update : create
-          end
-
           def create
             merge_attributes(
                 service.create_user(attributes).body['user'])
             self
           end
-
 
         end
       end

--- a/lib/fog/openstack/models/image/image.rb
+++ b/lib/fog/openstack/models/image/image.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Image
     class OpenStack
-      class Image < Fog::Model
+      class Image < Fog::OpenStack::Model
         identity :id
 
         attribute :name
@@ -27,17 +27,6 @@ module Fog
         attribute :properties
         attribute :location
         attribute :copy_from
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :name
-          identity ? update : create
-        end
 
         def create
           requires :name

--- a/lib/fog/openstack/models/metering/resource.rb
+++ b/lib/fog/openstack/models/metering/resource.rb
@@ -1,19 +1,14 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Metering
     class OpenStack
-      class Resource < Fog::Model
+      class Resource < Fog::OpenStack::Model
         identity :resource_id
 
         attribute :project_id
         attribute :user_id
         attribute :metadata
-
-        def initialize(attributes)
-          prepare_service_value(attributes)
-          super
-        end
       end
     end
   end

--- a/lib/fog/openstack/models/network/floating_ip.rb
+++ b/lib/fog/openstack/models/network/floating_ip.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class FloatingIp < Fog::Model
+      class FloatingIp < Fog::OpenStack::Model
         identity :id
 
         attribute :floating_network_id
@@ -15,11 +15,6 @@ module Fog
         def initialize(attributes)
           @connection = attributes[:connection]
           super
-        end
-
-        def save
-          requires :floating_network_id
-          identity ? update : create
         end
 
         def create

--- a/lib/fog/openstack/models/network/lb_health_monitor.rb
+++ b/lib/fog/openstack/models/network/lb_health_monitor.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class LbHealthMonitor < Fog::Model
+      class LbHealthMonitor < Fog::OpenStack::Model
         identity :id
 
         attribute :type
@@ -16,16 +16,6 @@ module Fog
         attribute :status
         attribute :admin_state_up
         attribute :tenant_id
-
-        def initialize(attributes)
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :type, :delay, :timeout, :max_retries
-          identity ? update : create
-        end
 
         def create
           requires :type, :delay, :timeout, :max_retries

--- a/lib/fog/openstack/models/network/lb_member.rb
+++ b/lib/fog/openstack/models/network/lb_member.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class LbMember < Fog::Model
+      class LbMember < Fog::OpenStack::Model
         identity :id
 
         attribute :pool_id
@@ -13,16 +13,6 @@ module Fog
         attribute :status
         attribute :admin_state_up
         attribute :tenant_id
-
-        def initialize(attributes)
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :pool_id, :address, :protocol_port, :weight
-          identity ? update : create
-        end
 
         def create
           requires :pool_id, :address, :protocol_port, :weight

--- a/lib/fog/openstack/models/network/lb_pool.rb
+++ b/lib/fog/openstack/models/network/lb_pool.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class LbPool < Fog::Model
+      class LbPool < Fog::OpenStack::Model
         identity :id
 
         attribute :subnet_id
@@ -21,16 +21,6 @@ module Fog
         attribute :bytes_in
         attribute :bytes_out
         attribute :total_connections
-
-        def initialize(attributes)
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :subnet_id, :protocol, :lb_method
-          identity ? update : create
-        end
 
         def create
           requires :subnet_id, :protocol, :lb_method

--- a/lib/fog/openstack/models/network/lb_vip.rb
+++ b/lib/fog/openstack/models/network/lb_vip.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class LbVip < Fog::Model
+      class LbVip < Fog::OpenStack::Model
         identity :id
 
         attribute :subnet_id
@@ -19,16 +19,6 @@ module Fog
         attribute :status
         attribute :admin_state_up
         attribute :tenant_id
-
-        def initialize(attributes)
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :subnet_id, :pool_id, :protocol, :protocol_port
-          identity ? update : create
-        end
 
         def create
           requires :subnet_id, :pool_id, :protocol, :protocol_port

--- a/lib/fog/openstack/models/network/network.rb
+++ b/lib/fog/openstack/models/network/network.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class Network < Fog::Model
+      class Network < Fog::OpenStack::Model
         identity :id
 
         attribute :name
@@ -16,16 +16,6 @@ module Fog
         attribute :provider_physical_network, :aliases => 'provider:physical_network'
         attribute :provider_segmentation_id,  :aliases => 'provider:segmentation_id'
         attribute :router_external,           :aliases => 'router:external'
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          identity ? update : create
-        end
 
         def subnets
           service.subnets.select {|s| s.network_id == self.id }

--- a/lib/fog/openstack/models/network/port.rb
+++ b/lib/fog/openstack/models/network/port.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class Port < Fog::Model
+      class Port < Fog::OpenStack::Model
         identity :id
 
         attribute :name
@@ -16,17 +16,6 @@ module Fog
         attribute :device_id
         attribute :tenant_id
         attribute :security_groups
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :network_id
-          identity ? update : create
-        end
 
         def create
           requires :network_id

--- a/lib/fog/openstack/models/network/router.rb
+++ b/lib/fog/openstack/models/network/router.rb
@@ -1,4 +1,4 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
@@ -10,7 +10,7 @@ module Fog
       # an appropriate external gateway.
       #
       # @see http://docs.openstack.org/api/openstack-network/2.0/content/router_ext.html
-      class Router < Fog::Model
+      class Router < Fog::OpenStack::Model
         identity :id
 
         attribute :name
@@ -18,17 +18,6 @@ module Fog
         attribute :tenant_id
         attribute :external_gateway_info
         attribute :status
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :name
-          identity ? update : create
-        end
 
         def create
           requires :name

--- a/lib/fog/openstack/models/network/security_group.rb
+++ b/lib/fog/openstack/models/network/security_group.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class SecurityGroup < Fog::Model
+      class SecurityGroup < Fog::OpenStack::Model
         identity :id
 
         attribute :name

--- a/lib/fog/openstack/models/network/security_group_rule.rb
+++ b/lib/fog/openstack/models/network/security_group_rule.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class SecurityGroupRule < Fog::Model
+      class SecurityGroupRule < Fog::OpenStack::Model
         identity :id
 
         attribute :security_group_id

--- a/lib/fog/openstack/models/network/subnet.rb
+++ b/lib/fog/openstack/models/network/subnet.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Network
     class OpenStack
-      class Subnet < Fog::Model
+      class Subnet < Fog::OpenStack::Model
         identity :id
 
         attribute :name
@@ -16,17 +16,6 @@ module Fog
         attribute :host_routes
         attribute :enable_dhcp
         attribute :tenant_id
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
-
-        def save
-          requires :network_id, :cidr, :ip_version
-          identity ? update : create
-        end
 
         def create
           requires :network_id, :cidr, :ip_version

--- a/lib/fog/openstack/models/orchestration/event.rb
+++ b/lib/fog/openstack/models/orchestration/event.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Orchestration
     class OpenStack
-      class Event < Fog::Model
+      class Event < Fog::OpenStack::Model
 
         include Reflectable
 

--- a/lib/fog/openstack/models/orchestration/resource.rb
+++ b/lib/fog/openstack/models/orchestration/resource.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Orchestration
     class OpenStack
-      class Resource < Fog::Model
+      class Resource < Fog::OpenStack::Model
 
         include Reflectable
 

--- a/lib/fog/openstack/models/orchestration/stack.rb
+++ b/lib/fog/openstack/models/orchestration/stack.rb
@@ -1,7 +1,9 @@
+require 'fog/openstack/models/model'
+
 module Fog
   module Orchestration
     class OpenStack
-      class Stack < Fog::Model
+      class Stack < Fog::OpenStack::Model
 
         identity :id
 
@@ -9,12 +11,6 @@ module Fog
             stack_name stack_status stack_status_reason template_description timeout_mins parent
             creation_time updated_time stack_user_project_id stack_owner}.each do |a|
           attribute a.to_sym
-        end
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
         end
 
         def save(options={})

--- a/lib/fog/openstack/models/orchestration/template.rb
+++ b/lib/fog/openstack/models/orchestration/template.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Orchestration
     class OpenStack
-      class Template < Fog::Model
+      class Template < Fog::OpenStack::Model
 
         %w{format description template_version parameters resources content}.each do |a|
           attribute a.to_sym

--- a/lib/fog/openstack/models/planning/plan.rb
+++ b/lib/fog/openstack/models/planning/plan.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Openstack
     class Planning
-      class Plan < Fog::Model
+      class Plan < Fog::OpenStack::Model
 
         MASTER_TEMPLATE_NAME = 'plan.yaml'
         ENVIRONMENT_NAME = 'environment.yaml'
@@ -16,12 +16,6 @@ module Fog
         attribute :created_at
         attribute :updated_at
         attribute :parameters
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def templates
           service.get_plan_templates(uuid).body
@@ -57,11 +51,6 @@ module Fog
           requires :uuid
           service.delete_plan(uuid)
           true
-        end
-
-        def save
-          requires :name
-          identity ? update : create
         end
 
         def create

--- a/lib/fog/openstack/models/planning/role.rb
+++ b/lib/fog/openstack/models/planning/role.rb
@@ -1,20 +1,14 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Openstack
     class Planning
-      class Role < Fog::Model
+      class Role < Fog::OpenStack::Model
         identity :uuid
 
         attribute :description
         attribute :name
         attribute :uuid
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def add_to_plan(plan_uuid)
           service.add_role_to_plan(plan_uuid, uuid)

--- a/lib/fog/openstack/models/volume/transfer.rb
+++ b/lib/fog/openstack/models/volume/transfer.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Volume
     class OpenStack
-      class Transfer < Fog::Model
+      class Transfer < Fog::OpenStack::Model
         identity :id
 
         attribute :auth_key,    :aliases => 'authKey'

--- a/lib/fog/openstack/models/volume/volume.rb
+++ b/lib/fog/openstack/models/volume/volume.rb
@@ -1,9 +1,9 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Volume
     class OpenStack
-      class Volume < Fog::Model
+      class Volume < Fog::OpenStack::Model
         identity :id
 
         attribute :display_name,        :aliases => 'displayName'
@@ -19,12 +19,6 @@ module Fog
         attribute :attachments
         attribute :source_volid
         attribute :tenant_id,           :aliases => 'os-vol-tenant-attr:tenant_id'
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
 
         def save
           requires :display_name, :size

--- a/lib/fog/openstack/models/volume/volume_type.rb
+++ b/lib/fog/openstack/models/volume/volume_type.rb
@@ -1,19 +1,13 @@
-require 'fog/core/model'
+require 'fog/openstack/models/model'
 
 module Fog
   module Volume
     class OpenStack
-      class VolumeType < Fog::Model
+      class VolumeType < Fog::OpenStack::Model
         identity :id
 
         attribute :name
         attribute :volume_backend_name
-
-        def initialize(attributes)
-          # Old 'connection' is renamed as service and should be used instead
-          prepare_service_value(attributes)
-          super
-        end
       end
     end
   end


### PR DESCRIPTION
Fog::OpenStack::Model base class for all openstack models,
also deleting repeated initialize and save methods, since
they are defined in base class now.