### PR TITLE
Fog::OpenStack::Collection base class for all openstack collections

### DIFF
--- a/lib/fog/openstack/models/baremetal/chassis_collection.rb
+++ b/lib/fog/openstack/models/baremetal/chassis_collection.rb
@@ -1,24 +1,24 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/baremetal/chassis'
 
 module Fog
   module Baremetal
     class OpenStack
-      class ChassisCollection < Fog::Collection
+      class ChassisCollection < Fog::OpenStack::Collection
         model Fog::Baremetal::OpenStack::Chassis
 
         def all(options = {})
-          load(service.list_chassis_detailed(options).body['chassis'])
+          load_response(service.list_chassis_detailed(options), 'chassis')
         end
 
         def summary(options = {})
-          load(service.list_chassis(options).body['chassis'])
+          load_response(service.list_chassis(options), 'chassis')
         end
 
         def details(options = {})
           Fog::Logger.deprecation("Calling OpenStack[:baremetal].chassis_collection.details will be removed, "\
                                   " call .chassis_collection.all for detailed list.")
-          load(service.list_chassis_detailed(options).body['chassis'])
+          all(options)
         end
 
         def find_by_uuid(uuid)

--- a/lib/fog/openstack/models/baremetal/drivers.rb
+++ b/lib/fog/openstack/models/baremetal/drivers.rb
@@ -1,17 +1,15 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/baremetal/driver'
 
 module Fog
   module Baremetal
     class OpenStack
-      class Drivers < Fog::Collection
+      class Drivers < Fog::OpenStack::Collection
         model Fog::Baremetal::OpenStack::Driver
 
         def all(options = {})
-          load(service.list_drivers(options).body['drivers'])
+          load_response(service.list_drivers(options), 'drivers')
         end
-
-        alias_method :summary, :all
 
         def find_by_name(name)
           new(service.get_driver(name).body)

--- a/lib/fog/openstack/models/baremetal/nodes.rb
+++ b/lib/fog/openstack/models/baremetal/nodes.rb
@@ -1,18 +1,18 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/baremetal/node'
 
 module Fog
   module Baremetal
     class OpenStack
-      class Nodes < Fog::Collection
+      class Nodes < Fog::OpenStack::Collection
         model Fog::Baremetal::OpenStack::Node
 
         def all(options = {})
-          load(service.list_nodes_detailed(options).body['nodes'])
+          load_response(service.list_nodes_detailed(options), 'nodes')
         end
 
         def summary(options = {})
-          load(service.list_nodes(options).body['nodes'])
+          load_response(service.list_nodes(options), 'nodes')
         end
 
         def details(options = {})

--- a/lib/fog/openstack/models/baremetal/ports.rb
+++ b/lib/fog/openstack/models/baremetal/ports.rb
@@ -1,18 +1,18 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/baremetal/port'
 
 module Fog
   module Baremetal
     class OpenStack
-      class Ports < Fog::Collection
+      class Ports < Fog::OpenStack::Collection
         model Fog::Baremetal::OpenStack::Port
 
         def all(options = {})
-          load(service.list_ports_detailed(options).body['ports'])
+          load_response(service.list_ports_detailed(options), 'ports')
         end
 
         def summary(options = {})
-          load(service.list_ports(options).body['ports'])
+          load_response(service.list_ports(options), 'ports')
         end
 
         def details(options = {})

--- a/lib/fog/openstack/models/compute/addresses.rb
+++ b/lib/fog/openstack/models/compute/addresses.rb
@@ -1,17 +1,15 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/address'
 
 module Fog
   module Compute
     class OpenStack
-      class Addresses < Fog::Collection
+      class Addresses < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Address
 
         def all(options = {})
-          load(service.list_all_addresses(options).body['floating_ips'])
+          load_response(service.list_all_addresses(options), 'floating_ips')
         end
-
-        alias_method :summary, :all
 
         def get(address_id)
           if address = service.get_address(address_id).body['floating_ip']

--- a/lib/fog/openstack/models/compute/aggregates.rb
+++ b/lib/fog/openstack/models/compute/aggregates.rb
@@ -1,17 +1,15 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/aggregate'
 
 module Fog
   module Compute
     class OpenStack
-      class Aggregates < Fog::Collection
+      class Aggregates < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Aggregate
 
         def all(options = {})
-          load(service.list_aggregates(options).body['aggregates'])
+          load_response(service.list_aggregates(options), 'aggregates')
         end
-
-        alias_method :summary, :all
 
         def find_by_id(id)
           new(service.get_aggregate(id).body['aggregate'])

--- a/lib/fog/openstack/models/compute/flavors.rb
+++ b/lib/fog/openstack/models/compute/flavors.rb
@@ -1,20 +1,20 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/flavor'
 
 module Fog
   module Compute
     class OpenStack
-      class Flavors < Fog::Collection
+      class Flavors < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Flavor
 
         def all(options = {})
-          data = service.list_flavors_detail(options).body['flavors']
-          load(data)
+          data = service.list_flavors_detail(options)
+          load_response(data, 'flavors')
         end
 
         def summary(options = {})
-          data = service.list_flavors(options).body['flavors']
-          load(data)
+          data = service.list_flavors(options)
+          load_response(data, 'flavors')
         end
 
         def get(flavor_id)

--- a/lib/fog/openstack/models/compute/hosts.rb
+++ b/lib/fog/openstack/models/compute/hosts.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/host'
 
 module Fog
   module Compute
     class OpenStack
-      class Hosts < Fog::Collection
+      class Hosts < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Host
 
         def all(options = {})
-          data = service.list_hosts(options).body['hosts']
-          load(data)
+          data = service.list_hosts(options)
+          load_response(data, 'hosts')
         end
-
-        alias_method :summary, :all
 
         def get(host_name)
           if host = service.get_host_details(host_name).body['host']

--- a/lib/fog/openstack/models/compute/images.rb
+++ b/lib/fog/openstack/models/compute/images.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/image'
 
 module Fog
   module Compute
     class OpenStack
-      class Images < Fog::Collection
+      class Images < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Compute::OpenStack::Image
@@ -18,15 +18,13 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          data = service.list_images_detail(filters).body['images']
-          images = load(data)
+          data = service.list_images_detail(filters)
+          images = load_response(data, 'images')
           if server
             self.replace(self.select {|image| image.server_id == server.id})
           end
           images
         end
-
-        alias_method :summary, :all
 
         def get(image_id)
           data = service.get_image_details(image_id).body['image']

--- a/lib/fog/openstack/models/compute/key_pairs.rb
+++ b/lib/fog/openstack/models/compute/key_pairs.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/key_pair'
 
 module Fog
   module Compute
     class OpenStack
-      class KeyPairs < Fog::Collection
+      class KeyPairs < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::KeyPair
 
         def all(options = {})
@@ -12,10 +12,9 @@ module Fog
           service.list_key_pairs(options).body['keypairs'].each do |kp|
             items = items + kp.values
           end
+          # TODO convert to load_response?
           load(items)
         end
-
-        alias_method :summary, :all
 
         def get(key_pair_name)
           if key_pair_name

--- a/lib/fog/openstack/models/compute/metadata.rb
+++ b/lib/fog/openstack/models/compute/metadata.rb
@@ -1,4 +1,4 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/meta_parent'
 require 'fog/openstack/models/compute/metadatum'
 require 'fog/openstack/models/compute/image'
@@ -7,7 +7,7 @@ require 'fog/openstack/models/compute/server'
 module Fog
   module Compute
     class OpenStack
-      class Metadata < Fog::Collection
+      class Metadata < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Metadatum
 
         include Fog::Compute::OpenStack::MetaParent
@@ -17,6 +17,7 @@ module Fog
           metadata = service.list_metadata(collection_name, @parent.id).body['metadata']
           metas = []
           metadata.each_pair {|k,v| metas << {"key" => k, "value" => v} } unless metadata.nil?
+          # TODO convert to load_response?
           load(metas)
         end
 

--- a/lib/fog/openstack/models/compute/networks.rb
+++ b/lib/fog/openstack/models/compute/networks.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/network'
 
 module Fog
   module Compute
     class OpenStack
-      class Networks < Fog::Collection
+      class Networks < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Network
 
         attribute :server
@@ -21,6 +21,7 @@ module Fog
             }
           end
 
+          # TODO convert to load_response?
           load(networks)
         end
       end # class Networks

--- a/lib/fog/openstack/models/compute/security_group_rules.rb
+++ b/lib/fog/openstack/models/compute/security_group_rules.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/security_group_rule'
 
 module Fog
   module Compute
     class OpenStack
-      class SecurityGroupRules < Fog::Collection
+      class SecurityGroupRules < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::SecurityGroupRule
 
         def get(security_group_rule_id)

--- a/lib/fog/openstack/models/compute/security_groups.rb
+++ b/lib/fog/openstack/models/compute/security_groups.rb
@@ -1,17 +1,15 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/security_group'
 
 module Fog
   module Compute
     class OpenStack
-      class SecurityGroups < Fog::Collection
+      class SecurityGroups < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::SecurityGroup
 
         def all(options = {})
-          load(service.list_security_groups(options).body['security_groups'])
+          load_response(service.list_security_groups(options), 'security_groups')
         end
-
-        alias_method :summary, :all
 
         def get(security_group_id)
           if security_group_id

--- a/lib/fog/openstack/models/compute/servers.rb
+++ b/lib/fog/openstack/models/compute/servers.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/server'
 
 module Fog
   module Compute
     class OpenStack
-      class Servers < Fog::Collection
+      class Servers < Fog::OpenStack::Collection
         attribute :filters
 
         model Fog::Compute::OpenStack::Server
@@ -16,11 +16,9 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          data = service.list_servers_detail(filters).body['servers']
-          load(data)
+          data = service.list_servers_detail
+          load_response(data, 'servers')
         end
-
-        alias_method :summary, :all
 
         # Creates a new server and populates ssh keys
         # @return [Fog::Compute::OpenStack::Server]

--- a/lib/fog/openstack/models/compute/services.rb
+++ b/lib/fog/openstack/models/compute/services.rb
@@ -1,21 +1,21 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/service'
 
 module Fog
   module Compute
     class OpenStack
-      class Services < Fog::Collection
+      class Services < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Service
 
         def all(options = {})
-          load(service.list_services(options).body['services'])
+          load_response(service.list_services(options), 'services')
         end
 
         alias_method :summary, :all
 
         def details(options = {})
           Fog::Logger.deprecation('Calling OpenStack[:compute].services.details is deprecated, use .services.all')
-          load(service.list_services(options).body['services'])
+          all(options)
         end
       end
     end

--- a/lib/fog/openstack/models/compute/snapshots.rb
+++ b/lib/fog/openstack/models/compute/snapshots.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/snapshot'
 
 module Fog
   module Compute
     class OpenStack
-      class Snapshots < Fog::Collection
+      class Snapshots < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Snapshot
 
         def all(options = {})
@@ -14,14 +14,14 @@ module Fog
             else
               Fog::Logger.deprecation('Calling OpenStack[:compute].snapshots.all(false) is deprecated, use .snapshots.summary')
             end
-            load(service.list_snapshots(options).body['snapshots'])
+            load_response(service.list_snapshots(options), 'snapshots')
           else
-            load(service.list_snapshots_detail(options).body['snapshots'])
+            load_response(service.list_snapshots_detail(options), 'snapshots')
           end
         end
 
         def summary(options = {})
-          load(service.list_snapshots(options).body['snapshots'])
+          load_response(service.list_snapshots(options), 'snapshots')
         end
 
         def get(snapshot_id)

--- a/lib/fog/openstack/models/compute/tenants.rb
+++ b/lib/fog/openstack/models/compute/tenants.rb
@@ -1,14 +1,14 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/tenant'
 
 module Fog
   module Compute
     class OpenStack
-      class Tenants < Fog::Collection
+      class Tenants < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Tenant
 
         def all
-          load(service.list_tenants.body['tenants'])
+          load_response(service.list_tenants, 'tenants')
         end
 
         def usages(start_date = nil, end_date = nil, details = false)
@@ -18,7 +18,6 @@ module Fog
         def get(id)
           self.find {|tenant| tenant.id == id}
         end
-        alias_method :find_by_id, :get
 
       end # class Tenants
     end # class OpenStack

--- a/lib/fog/openstack/models/compute/volumes.rb
+++ b/lib/fog/openstack/models/compute/volumes.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/compute/volume'
 
 module Fog
   module Compute
     class OpenStack
-      class Volumes < Fog::Collection
+      class Volumes < Fog::OpenStack::Collection
         model Fog::Compute::OpenStack::Volume
 
         def all(options = true)
@@ -14,14 +14,14 @@ module Fog
             else
               Fog::Logger.deprecation('Calling OpenStack[:compute].volumes.all(false) is deprecated, use .volumes.summary')
             end
-            load(service.list_volumes(options).body['volumes'])
+            load_response(service.list_volumes(options), 'volumes')
           else
-            load(service.list_volumes_detail(options).body['volumes'])
+            load_response(service.list_volumes_detail(options), 'volumes')
           end
         end
 
         def summary(options = {})
-          load(service.list_volumes(options).body['volumes'])
+          load_response(service.list_volumes(options), 'volumes')
         end
 
         def get(volume_id)

--- a/lib/fog/openstack/models/identity_v2/ec2_credentials.rb
+++ b/lib/fog/openstack/models/identity_v2/ec2_credentials.rb
@@ -1,11 +1,11 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v2/ec2_credential'
 
 module Fog
   module Identity
     class OpenStack
       class V2
-        class Ec2Credentials < Fog::Collection
+        class Ec2Credentials < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V2::Ec2Credential
 
           attribute :user
@@ -16,10 +16,8 @@ module Fog
             options[:user_id] = user_id
             ec2_credentials = service.list_ec2_credentials(options)
 
-            load(ec2_credentials.body['credentials'])
+            load_response(ec2_credentials, 'credentials')
           end
-
-          alias_method :summary, :all
 
           def create(attributes = {})
             if user then

--- a/lib/fog/openstack/models/identity_v2/roles.rb
+++ b/lib/fog/openstack/models/identity_v2/roles.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v2/role'
 
 module Fog
   module Identity
     class OpenStack
       class V2
-        class Roles < Fog::Collection
+        class Roles < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V2::Role
 
           def all(options = {})
-            load(service.list_roles(options).body['roles'])
+            load_response(service.list_roles(options), 'roles')
           end
-
-          alias_method :summary, :all
 
           def get(id)
             service.get_role(id)

--- a/lib/fog/openstack/models/identity_v2/tenants.rb
+++ b/lib/fog/openstack/models/identity_v2/tenants.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v2/tenant'
 
 module Fog
   module Identity
     class OpenStack
       class V2
-        class Tenants < Fog::Collection
+        class Tenants < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V2::Tenant
 
           def all(options = {})
-            load(service.list_tenants(options).body['tenants'])
+            load_response(service.list_tenants(options), 'tenants')
           end
-
-          alias_method :summary, :all
 
           def find_by_id(id)
             cached_tenant = self.find { |tenant| tenant.id == id }

--- a/lib/fog/openstack/models/identity_v2/users.rb
+++ b/lib/fog/openstack/models/identity_v2/users.rb
@@ -1,11 +1,11 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v2/user'
 
 module Fog
   module Identity
     class OpenStack
       class V2
-        class Users < Fog::Collection
+        class Users < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V2::User
 
           attribute :tenant_id
@@ -13,10 +13,8 @@ module Fog
           def all(options = {})
             options[:tenant_id] = tenant_id
 
-            load(service.list_users(options).body['users'])
+            load_response(service.list_users(options), 'users')
           end
-
-          alias_method :summary, :all
 
           def find_by_id(id)
             self.find { |user| user.id == id } ||

--- a/lib/fog/openstack/models/identity_v3/domains.rb
+++ b/lib/fog/openstack/models/identity_v3/domains.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/domain'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Domains < Fog::Collection
+        class Domains < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::Domain
 
           def all(options = {})
-            load(service.list_domains(options).body['domains'])
+            load_response(service.list_domains(options), 'domains')
           end
-
-          alias_method :summary, :all
 
           def auth_domains(options = {})
             load(service.auth_domains(options).body['domains'])

--- a/lib/fog/openstack/models/identity_v3/endpoints.rb
+++ b/lib/fog/openstack/models/identity_v3/endpoints.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/service'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Endpoints < Fog::Collection
+        class Endpoints < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::Endpoint
 
           def all(options = {})
-            load(service.list_endpoints(options).body['endpoints'])
+            load_response(service.list_endpoints(options), 'endpoints')
           end
-
-          alias_method :summary, :all
 
           def find_by_id(id)
             cached_endpoint = self.find { |endpoint| endpoint.id == id }

--- a/lib/fog/openstack/models/identity_v3/groups.rb
+++ b/lib/fog/openstack/models/identity_v3/groups.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/group'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Groups < Fog::Collection
+        class Groups < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::Group
 
           def all(options = {})
-            load(service.list_groups(options).body['groups'])
+            load_response(service.list_groups(options), 'groups')
           end
-
-          alias_method :summary, :all
 
           def find_by_id(id)
             cached_group = self.find { |group| group.id == id }

--- a/lib/fog/openstack/models/identity_v3/os_credentials.rb
+++ b/lib/fog/openstack/models/identity_v3/os_credentials.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/os_credential'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class OsCredentials < Fog::Collection
+        class OsCredentials < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::OsCredential
 
           def all(options = {})
-            load(service.list_os_credentials(options).body['credentials'])
+            load_response(service.list_os_credentials(options), 'credentials')
           end
-
-          alias_method :summary, :all
 
           def find_by_id(id)
             cached_credential = self.find { |credential| credential.id == id }

--- a/lib/fog/openstack/models/identity_v3/policies.rb
+++ b/lib/fog/openstack/models/identity_v3/policies.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/policy'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Policies < Fog::Collection
+        class Policies < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::Policy
 
           def all(options = {})
-            load(service.list_policies(options).body['policies'])
+            load_response(service.list_policies(options), 'policies')
           end
-
-          alias_method :summary, :all
 
           def find_by_id(id)
             cached_policy = self.find { |policy| policy.id == id }

--- a/lib/fog/openstack/models/identity_v3/projects.rb
+++ b/lib/fog/openstack/models/identity_v3/projects.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/project'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Projects < Fog::Collection
+        class Projects < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::Project
 
           def all(options = {})
-            load(service.list_projects(options).body['projects'])
+            load_response(service.list_projects(options), 'projects')
           end
-
-          alias_method :summary, :all
 
           def auth_projects(options = {})
             load(service.auth_projects(options).body['projects'])

--- a/lib/fog/openstack/models/identity_v3/role_assignments.rb
+++ b/lib/fog/openstack/models/identity_v3/role_assignments.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/role'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class RoleAssignments < Fog::Collection
+        class RoleAssignments < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::RoleAssignment
 
           def all(options = {})
-            load(service.list_role_assignments(options).body['role_assignments'])
+            load_response(service.list_role_assignments(options), 'role_assignments')
           end
-
-          alias_method :summary, :all
 
           def filter_by(options = {})
             Fog::Logger.deprecation("Calling OpenStack[:keystone].role_assignments.filter_by(options) method which"\

--- a/lib/fog/openstack/models/identity_v3/roles.rb
+++ b/lib/fog/openstack/models/identity_v3/roles.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/role'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Roles < Fog::Collection
+        class Roles < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::Role
 
           def all(options = {})
-            load(service.list_roles(options).body['roles'])
+            load_response(service.list_roles(options), 'roles')
           end
-
-          alias_method :summary, :all
 
           def assignments(options = {})
             # TODO(lsmola) this method doesn't make much sense, it should be moved to role.rb and automatically add

--- a/lib/fog/openstack/models/identity_v3/services.rb
+++ b/lib/fog/openstack/models/identity_v3/services.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/service'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Services < Fog::Collection
+        class Services < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::Service
 
           def all(options = {})
-            load(service.list_services(options).body['services'])
+            load_response(service.list_services(options), 'services')
           end
-
-          alias_method :summary, :all
 
           def find_by_id(id)
             cached_service = self.find { |service| service.id == id }

--- a/lib/fog/openstack/models/identity_v3/tokens.rb
+++ b/lib/fog/openstack/models/identity_v3/tokens.rb
@@ -1,11 +1,11 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/service'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Tokens < Fog::Collection
+        class Tokens < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::Token
 
 

--- a/lib/fog/openstack/models/identity_v3/users.rb
+++ b/lib/fog/openstack/models/identity_v3/users.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/identity_v3/domain'
 
 module Fog
   module Identity
     class OpenStack
       class V3
-        class Users < Fog::Collection
+        class Users < Fog::OpenStack::Collection
           model Fog::Identity::OpenStack::V3::User
 
           def all(options = {})
-            load(service.list_users(options).body['users'])
+            load_response(service.list_users(options), 'users')
           end
-
-          alias_method :summary, :all
 
           def find_by_id(id)
             cached_user = self.find { |user| user.id == id }

--- a/lib/fog/openstack/models/image/images.rb
+++ b/lib/fog/openstack/models/image/images.rb
@@ -1,24 +1,24 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/image/image'
 
 module Fog
   module Image
     class OpenStack
-      class Images < Fog::Collection
+      class Images < Fog::OpenStack::Collection
         model Fog::Image::OpenStack::Image
 
         def all(options = {})
-          load(service.list_public_images_detailed(options).body['images'])
+          load_response(service.list_public_images_detailed(options), 'images')
         end
 
         def summary(options = {})
-          load(service.list_public_images(options).body['images'])
+          load_response(service.list_public_images(options), 'images')
         end
 
         def details(options = {}, deprecated_query = nil)
           Fog::Logger.deprecation("Calling OpenStack[:glance].images.details will be removed, "\
                                   " call .images.all for detailed list.")
-          load(service.list_public_images_detailed(options, deprecated_query).body['images'])
+          load_response(service.list_public_images_detailed(options, deprecated_query), 'images')
         end
 
         def find_by_id(id)

--- a/lib/fog/openstack/models/metering/resources.rb
+++ b/lib/fog/openstack/models/metering/resources.rb
@@ -1,14 +1,14 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/metering/resource'
 
 module Fog
   module Metering
     class OpenStack
-      class Resources < Fog::Collection
+      class Resources < Fog::OpenStack::Collection
         model Fog::Metering::OpenStack::Resource
 
         def all(detailed=true)
-          load(service.list_resources.body)
+          load_response(service.list_resources)
         end
 
         def find_by_id(resource_id)

--- a/lib/fog/openstack/models/network/floating_ips.rb
+++ b/lib/fog/openstack/models/network/floating_ips.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_floating_ips(filters), 'floatingips')
         end
 
-        alias_method :summary, :all
-
         def get(floating_network_id)
           if floating_ip = service.get_floating_ip(floating_network_id).body['floatingip']
             new(floating_ip)

--- a/lib/fog/openstack/models/network/lb_health_monitors.rb
+++ b/lib/fog/openstack/models/network/lb_health_monitors.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_lb_health_monitors(filters), 'health_monitors')
         end
 
-        alias_method :summary, :all
-
         def get(health_monitor_id)
           if health_monitor = service.get_lb_health_monitor(health_monitor_id).body['health_monitor']
             new(health_monitor)

--- a/lib/fog/openstack/models/network/lb_members.rb
+++ b/lib/fog/openstack/models/network/lb_members.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_lb_members(filters), 'members')
         end
 
-        alias_method :summary, :all
-
         def get(member_id)
           if member = service.get_lb_member(member_id).body['member']
             new(member)

--- a/lib/fog/openstack/models/network/lb_pools.rb
+++ b/lib/fog/openstack/models/network/lb_pools.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_lb_pools(filters), 'pools')
         end
 
-        alias_method :summary, :all
-
         def get(pool_id)
           if pool = service.get_lb_pool(pool_id).body['pool']
             new(pool)

--- a/lib/fog/openstack/models/network/lb_vips.rb
+++ b/lib/fog/openstack/models/network/lb_vips.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_lb_vips(filters), 'vips')
         end
 
-        alias_method :summary, :all
-
         def get(vip_id)
           if vip = service.get_lb_vip(vip_id).body['vip']
             new(vip)

--- a/lib/fog/openstack/models/network/networks.rb
+++ b/lib/fog/openstack/models/network/networks.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_networks(filters), 'networks')
         end
 
-        alias_method :summary, :all
-
         def get(network_id)
           if network = service.get_network(network_id).body['network']
             new(network)

--- a/lib/fog/openstack/models/network/ports.rb
+++ b/lib/fog/openstack/models/network/ports.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_ports(filters), 'ports')
         end
 
-        alias_method :summary, :all
-
         def get(port_id)
           if port = service.get_port(port_id).body['port']
             new(port)

--- a/lib/fog/openstack/models/network/routers.rb
+++ b/lib/fog/openstack/models/network/routers.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_routers(filters), 'routers')
         end
 
-        alias_method :summary, :all
-
         def get(router_id)
           if router = service.get_router(router_id).body['router']
             new(router)

--- a/lib/fog/openstack/models/network/security_group_rules.rb
+++ b/lib/fog/openstack/models/network/security_group_rules.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_security_group_rules(filters), 'security_group_rules')
         end
 
-        alias_method :summary, :all
-
         def get(sec_group_rule_id)
           if sec_group_rule = service.get_security_group_rule(sec_group_rule_id).body['security_group_rule']
             new(sec_group_rule)

--- a/lib/fog/openstack/models/network/security_groups.rb
+++ b/lib/fog/openstack/models/network/security_groups.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_security_groups(filters), 'security_groups')
         end
 
-        alias_method :summary, :all
-
         def get(security_group_id)
           if security_group = service.get_security_group(security_group_id).body['security_group']
             new(security_group)

--- a/lib/fog/openstack/models/network/subnets.rb
+++ b/lib/fog/openstack/models/network/subnets.rb
@@ -19,8 +19,6 @@ module Fog
           load_response(service.list_subnets(filters), 'subnets')
         end
 
-        alias_method :summary, :all
-
         def get(subnet_id)
           if subnet = service.get_subnet(subnet_id).body['subnet']
             new(subnet)

--- a/lib/fog/openstack/models/orchestration/events.rb
+++ b/lib/fog/openstack/models/orchestration/events.rb
@@ -3,22 +3,20 @@ require 'fog/openstack/models/orchestration/event'
 module Fog
   module Orchestration
     class OpenStack
-      class Events < Fog::Collection
+      class Events < Fog::OpenStack::Collection
         model Fog::Orchestration::OpenStack::Event
 
         def all(options = {}, options_deprecated = {})
           data = if options.is_a?(Stack)
-                   service.list_stack_events(options, options_deprecated).body['events']
+                   service.list_stack_events(options, options_deprecated)
                  elsif options.is_a?(Hash)
-                   service.list_events(options).body['events']
+                   service.list_events(options)
                  else
-                   service.list_resource_events(options.stack, options, options_deprecated).body['events']
+                   service.list_resource_events(options.stack, options, options_deprecated)
                  end
 
-          load data
+          load_response(data, 'events')
         end
-
-        alias_method :summary, :all
 
         def get(stack, resource, event_id)
           data = service.show_event_details(stack, resource, event_id).body['event']

--- a/lib/fog/openstack/models/orchestration/resource_schemas.rb
+++ b/lib/fog/openstack/models/orchestration/resource_schemas.rb
@@ -1,9 +1,9 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 
 module Fog
   module Orchestration
     class OpenStack
-      class ResourceSchemas < Fog::Collection
+      class ResourceSchemas < Fog::OpenStack::Collection
 
         def get(resource_type)
           service.show_resource_schema(resource_type).body

--- a/lib/fog/openstack/models/orchestration/resources.rb
+++ b/lib/fog/openstack/models/orchestration/resources.rb
@@ -3,7 +3,7 @@ require 'fog/openstack/models/orchestration/resource'
 module Fog
   module Orchestration
     class OpenStack
-      class Resources < Fog::Collection
+      class Resources < Fog::OpenStack::Collection
         model Fog::Orchestration::OpenStack::Resource
 
         def types
@@ -11,11 +11,9 @@ module Fog
         end
 
         def all(options = {}, deprecated_options = {})
-          data = service.list_resources(options, deprecated_options).body['resources']
-          load(data)
+          data = service.list_resources(options, deprecated_options)
+          load_response(data, 'resources')
         end
-
-        alias_method :summary, :all
 
         def get(resource_name, stack=nil)
           stack = self.first.stack if stack.nil?

--- a/lib/fog/openstack/models/orchestration/stacks.rb
+++ b/lib/fog/openstack/models/orchestration/stacks.rb
@@ -3,20 +3,20 @@ require 'fog/openstack/models/orchestration/stack'
 module Fog
   module Orchestration
     class OpenStack
-      class Stacks < Fog::Collection
+      class Stacks < Fog::OpenStack::Collection
         model Fog::Orchestration::OpenStack::Stack
 
         def all(options = {})
           # TODO(lsmola) we can uncomment this when https://bugs.launchpad.net/heat/+bug/1468318 is fixed, till then
           # we will use non detailed list
           # data = service.list_stack_data_detailed(options).body['stacks']
-          data = service.list_stack_data(options).body['stacks']
-          load(data)
+          data = service.list_stack_data(options)
+          load_response(data, 'stacks')
         end
 
         def summary(options = {})
-          data = service.list_stack_data(options).body['stacks']
-          load(data)
+          data = service.list_stack_data(options)
+          load_response(data, 'stacks')
         end
 
         # Deprecated

--- a/lib/fog/openstack/models/orchestration/templates.rb
+++ b/lib/fog/openstack/models/orchestration/templates.rb
@@ -3,7 +3,7 @@ require 'fog/openstack/models/orchestration/template'
 module Fog
   module Orchestration
     class OpenStack
-      class Templates < Fog::Collection
+      class Templates < Fog::OpenStack::Collection
         model Fog::Orchestration::OpenStack::Template
 
         def get(obj)

--- a/lib/fog/openstack/models/planning/plans.rb
+++ b/lib/fog/openstack/models/planning/plans.rb
@@ -1,17 +1,15 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/planning/plan'
 
 module Fog
   module Openstack
     class Planning
-      class Plans < Fog::Collection
+      class Plans < Fog::OpenStack::Collection
         model Fog::Openstack::Planning::Plan
 
         def all(options = {})
-          load(service.list_plans(options).body)
+          load_response(service.list_plans(options))
         end
-
-        alias_method :summary, :all
 
         def find_by_uuid(plan_uuid)
           new(service.get_plan(plan_uuid).body)

--- a/lib/fog/openstack/models/planning/roles.rb
+++ b/lib/fog/openstack/models/planning/roles.rb
@@ -1,18 +1,15 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/planning/role'
 
 module Fog
   module Openstack
     class Planning
-      class Roles < Fog::Collection
+      class Roles < Fog::OpenStack::Collection
         model Fog::Openstack::Planning::Role
 
         def all(options = {})
-          load(service.list_roles(options).body)
+          load_response(service.list_roles(options))
         end
-
-        alias_method :summary, :all
-
       end
     end
   end

--- a/lib/fog/openstack/models/storage/directories.rb
+++ b/lib/fog/openstack/models/storage/directories.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/storage/directory'
 
 module Fog
   module Storage
     class OpenStack
-      class Directories < Fog::Collection
+      class Directories < Fog::OpenStack::Collection
         model Fog::Storage::OpenStack::Directory
 
         def all(options = {})
-          data = service.get_containers(options).body
-          load(data)
+          data = service.get_containers(options)
+          load_response(data)
         end
-
-        alias_method :summary, :all
 
         def get(key, options = {})
           data = service.get_container(key, options)

--- a/lib/fog/openstack/models/storage/files.rb
+++ b/lib/fog/openstack/models/storage/files.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/storage/file'
 
 module Fog
   module Storage
     class OpenStack
-      class Files < Fog::Collection
+      class Files < Fog::OpenStack::Collection
         attribute :directory
         attribute :limit
         attribute :marker
@@ -16,10 +16,10 @@ module Fog
         def all(options = {})
           requires :directory
           options = {
-            'limit'   => limit,
-            'marker'  => marker,
-            'path'    => path,
-            'prefix'  => prefix
+            'limit'  => limit,
+            'marker' => marker,
+            'path'   => path,
+            'prefix' => prefix
           }.merge!(options)
           merge_attributes(options)
           parent = directory.collection.get(
@@ -27,13 +27,12 @@ module Fog
             options
           )
           if parent
+            # TODO change to load_response?
             load(parent.files.map {|file| file.attributes})
           else
             nil
           end
         end
-
-        alias_method :summary, :all
 
         alias_method :each_file_this_page, :each
         def each

--- a/lib/fog/openstack/models/volume/transfers.rb
+++ b/lib/fog/openstack/models/volume/transfers.rb
@@ -1,18 +1,18 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/volume/transfer'
 
 module Fog
   module Volume
     class OpenStack
-      class Transfers < Fog::Collection
+      class Transfers < Fog::OpenStack::Collection
         model Fog::Volume::OpenStack::Transfer
 
         def all(options = {})
-          load(service.list_transfers_detailed(options).body['transfers'])
+          load_response(service.list_transfers_detailed(options), 'transfers')
         end
 
         def summary(options = {})
-          load(service.list_transfers(options).body['transfers'])
+          load_response(service.list_transfers(options), 'transfers')
         end
 
         def get(transfer_id)
@@ -22,7 +22,6 @@ module Fog
         rescue Fog::Volume::OpenStack::NotFound
           nil
         end
-        alias_method :find_by_id, :get
 
         def accept(transfer_id, auth_key)
           # NOTE: This is NOT a method on the Transfer object, since the

--- a/lib/fog/openstack/models/volume/volume_types.rb
+++ b/lib/fog/openstack/models/volume/volume_types.rb
@@ -1,18 +1,16 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/volume/volume_type'
 
 module Fog
   module Volume
     class OpenStack
-      class VolumeTypes < Fog::Collection
+      class VolumeTypes < Fog::OpenStack::Collection
         model Fog::Volume::OpenStack::VolumeType
 
         def all(options = {})
           response = service.list_volume_types(options)
-          load(response.body['volume_types'])
+          load_response(response, 'volume_types')
         end
-
-        alias_method :summary, :all
 
         def get(volume_type_id)
           if volume_type = service.get_volume_type_details(volume_type_id).body['volume_type']
@@ -21,7 +19,6 @@ module Fog
         rescue Fog::Volume::OpenStack::NotFound
           nil
         end
-        alias_method :find_by_id, :get
       end
     end
   end

--- a/lib/fog/openstack/models/volume/volumes.rb
+++ b/lib/fog/openstack/models/volume/volumes.rb
@@ -1,10 +1,10 @@
-require 'fog/core/collection'
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/volume/volume'
 
 module Fog
   module Volume
     class OpenStack
-      class Volumes < Fog::Collection
+      class Volumes < Fog::OpenStack::Collection
         model Fog::Volume::OpenStack::Volume
 
         def all(options = {})
@@ -13,16 +13,16 @@ module Fog
           detailed = options.is_a?(Hash) ? options.delete(:detailed) : options
           if detailed.nil? || detailed
             # This method gives details by default, unless false or {:detailed => false} is passed
-            load(service.list_volumes_detailed(options).body['volumes'])
+            load_response(service.list_volumes_detailed(options), 'volumes')
           else
             Fog::Logger.deprecation('Calling OpenStack[:volume].volumes.all(false) or volumes.all(:detailed => false) '\
                                     ' is deprecated, call .volumes.summary instead')
-            load(service.list_volumes(options).body['volumes'])
+            load_response(service.list_volumes(options), 'volumes')
           end
         end
 
         def summary(options = {})
-          load(service.list_volumes(options).body['volumes'])
+          load_response(service.list_volumes(options), 'volumes')
         end
 
         def get(volume_id)
@@ -32,7 +32,6 @@ module Fog
         rescue Fog::Volume::OpenStack::NotFound
           nil
         end
-        alias_method :find_by_id, :get
       end
     end
   end


### PR DESCRIPTION
Fog::OpenStack::Collection base class for all openstack collections,
also replacing load method with load_response method, which stores
the whole response on Collection object, in the case that we need
other metadata e.g. for pagination.

Also removing :summary and :find_by_id aliases, since they are
defined in the base method.