### PR TITLE
[openstack] Add tests for subtree_as_list and parents_as_list in hierarchical projects

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -59,6 +59,7 @@ module Fog
       attr_reader :auth_token
       attr_reader :auth_token_expiration
       attr_reader :current_user
+      attr_reader :current_user_id
       attr_reader :current_tenant
       attr_reader :openstack_domain_name
       attr_reader :openstack_user_domain
@@ -109,6 +110,7 @@ module Fog
         end
 
         @current_user = options[:current_user]
+        @current_user_id = options[:current_user_id]
         @current_tenant = options[:current_tenant]
 
       end
@@ -127,6 +129,7 @@ module Fog
           :openstack_identity_endpoint => @openstack_identity_public_endpoint,
           :openstack_region         => @openstack_region,
           :current_user             => @current_user,
+          :current_user_id          => @current_user_id,
           :current_tenant           => @current_tenant }
       end
 
@@ -158,6 +161,7 @@ module Fog
           credentials = Fog::OpenStack.authenticate(options, @connection_options)
 
           @current_user = credentials[:user]
+          @current_user_id = credentials[:current_user_id]
           @current_tenant = credentials[:tenant]
 
           @openstack_must_reauthenticate = false

--- a/lib/fog/openstack/identity.rb
+++ b/lib/fog/openstack/identity.rb
@@ -44,6 +44,7 @@ module Fog
             credentials = Fog::OpenStack.authenticate(options, @connection_options)
 
             @current_user = credentials[:user]
+            @current_user_id = credentials[:current_user_id]
             @current_tenant = credentials[:tenant]
 
             @openstack_must_reauthenticate = false

--- a/lib/fog/openstack/identity_v3.rb
+++ b/lib/fog/openstack/identity_v3.rb
@@ -13,7 +13,7 @@ module Fog
                    :openstack_user_domain, :openstack_project_domain,
                    :openstack_user_domain_id, :openstack_project_domain_id,
                    :openstack_api_key, :openstack_current_user_id, :openstack_userid, :openstack_username,
-                   :current_user, :current_tenant,
+                   :current_user, :current_user_id, :current_tenant,
                    :provider
 
         model_path 'fog/openstack/models/identity_v3'
@@ -149,6 +149,7 @@ module Fog
 
         class Real
           attr_reader :current_user
+          attr_reader :current_user_id
           attr_reader :current_tenant
           attr_reader :unscoped_token
           attr_accessor :auth_token

--- a/spec/fog/openstack/identity_v3/idv3_project_hier_crud_list.yml
+++ b/spec/fog/openstack/identity_v3/idv3_project_hier_crud_list.yml
@@ -8,26 +8,26 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:00 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e0f93855-aa19-4594-9cef-a485dcd43aee
+      - req-c884f35b-9592-4e25-bd99-023d91e3980d
       Content-Length:
       - '317'
       Content-Type:
@@ -39,7 +39,7 @@ http_interactions:
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
         "http://devstack.openstack.stack:35357/v3/domains", "previous": null, "next": null}}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
@@ -48,76 +48,76 @@ http_interactions:
       string: ! '{"project":{"name":"p-foobar67"}}'
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:00 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6182a17b-0d69-4a7f-8504-3868192c76fc
+      - req-5193098e-4561-41e2-bbb0-6bfc67017797
       Content-Length:
       - '251'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/f4d4e4ec09384303b1458c7de57de87b"},
-        "enabled": true, "id": "f4d4e4ec09384303b1458c7de57de87b", "parent_id": null,
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
+        "enabled": true, "id": "27b9743d10594dd9964002f153955676", "parent_id": null,
         "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-baz67","parent_id":"f4d4e4ec09384303b1458c7de57de87b"}}'
+      string: ! '{"project":{"name":"p-baz67","parent_id":"27b9743d10594dd9964002f153955676"}}'
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:00 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-04738235-b84e-4cfa-9468-c88633ff60f4
+      - req-28665661-d06c-4e17-93b9-c25ab699b63e
       Content-Length:
       - '278'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/3e85f17ca99f46fb8d9fd4d4dbb5885b"},
-        "enabled": true, "id": "3e85f17ca99f46fb8d9fd4d4dbb5885b", "parent_id": "f4d4e4ec09384303b1458c7de57de87b",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25"},
+        "enabled": true, "id": "d949713f4b1845ad84b6c1e819db2c25", "parent_id": "27b9743d10594dd9964002f153955676",
         "domain_id": "default", "name": "p-baz67"}}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
@@ -126,26 +126,26 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:00 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5d039774-4986-4bbb-8d96-640a9dc08208
+      - req-bc49000f-0dae-47b1-a310-1f400179d1c0
       Content-Length:
       - '388'
       Content-Type:
@@ -154,309 +154,616 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
         "previous": null, "next": null}, "projects": [{"description": "", "links":
-        {"self": "http://devstack.openstack.stack:35357/v3/projects/3e85f17ca99f46fb8d9fd4d4dbb5885b"},
-        "enabled": true, "id": "3e85f17ca99f46fb8d9fd4d4dbb5885b", "parent_id": "f4d4e4ec09384303b1458c7de57de87b",
+        {"self": "http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25"},
+        "enabled": true, "id": "d949713f4b1845ad84b6c1e819db2c25", "parent_id": "27b9743d10594dd9964002f153955676",
         "domain_id": "default", "name": "p-baz67"}]}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-boo67","parent_id":"f4d4e4ec09384303b1458c7de57de87b"}}'
+      string: ! '{"project":{"name":"p-boo67","parent_id":"27b9743d10594dd9964002f153955676"}}'
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:00 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-28e2ad86-b1fb-4c27-941c-a71620b3867a
+      - req-a20fe500-31fa-4ef9-8100-65df6816f0a4
       Content-Length:
       - '278'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/8cf7a7f6156842c88d4ffd018e2cc7d2"},
-        "enabled": true, "id": "8cf7a7f6156842c88d4ffd018e2cc7d2", "parent_id": "f4d4e4ec09384303b1458c7de57de87b",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63"},
+        "enabled": true, "id": "974874f812174f629268f28074742b63", "parent_id": "27b9743d10594dd9964002f153955676",
         "domain_id": "default", "name": "p-boo67"}}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-booboo67","parent_id":"8cf7a7f6156842c88d4ffd018e2cc7d2"}}'
+      string: ! '{"project":{"name":"p-booboo67","parent_id":"974874f812174f629268f28074742b63"}}'
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:00 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8f89e9e0-c9e8-415f-abc1-2337506849c0
+      - req-551dd25b-e520-4781-b85c-c021e83fb0a2
       Content-Length:
       - '281'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/5d94a8ce93ce4f67b767ec1a475858a0"},
-        "enabled": true, "id": "5d94a8ce93ce4f67b767ec1a475858a0", "parent_id": "8cf7a7f6156842c88d4ffd018e2cc7d2",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
+        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
         "domain_id": "default", "name": "p-booboo67"}}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
 - request:
-    method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/f4d4e4ec09384303b1458c7de57de87b?subtree_as_ids
+    method: post
+    uri: http://devstack.openstack.stack:35357/v3/roles
     body:
-      encoding: US-ASCII
-      string: ''
+      encoding: UTF-8
+      string: ! '{"role":{"name":"r-project67"}}'
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Thu, 16 Jul 2015 16:05:00 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-e97893c6-725d-4e60-81e0-5f1144cd0728
+      Content-Length:
+      - '167'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"role": {"id": "b4a5f86a22164d4aa935d1098657d2d8", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/roles/b4a5f86a22164d4aa935d1098657d2d8"},
+        "name": "r-project67"}}'
+    http_version: 
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+- request:
+    method: put
+    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 269086a06d764f6f93d22efe162cfd36
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Date:
+      - Thu, 16 Jul 2015 16:05:01 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-e39795b5-1c84-4bf8-9987-4b7e571d9f72
+      Content-Length:
+      - '0'
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+- request:
+    method: put
+    uri: http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 269086a06d764f6f93d22efe162cfd36
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Date:
+      - Thu, 16 Jul 2015 16:05:01 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-968410c6-0f59-4a3d-a439-472cba337728
+      Content-Length:
+      - '0'
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+- request:
+    method: put
+    uri: http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 269086a06d764f6f93d22efe162cfd36
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Date:
+      - Thu, 16 Jul 2015 16:05:01 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-8f83c542-ffe3-4442-ae84-39fd3c1728fd
+      Content-Length:
+      - '0'
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+- request:
+    method: put
+    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 269086a06d764f6f93d22efe162cfd36
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Date:
+      - Thu, 16 Jul 2015 16:05:01 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-abaa07cb-b7fd-400c-871d-647a170969a4
+      Content-Length:
+      - '0'
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676?subtree_as_ids
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:01 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-989ba163-5ada-4cda-9ace-46614dd3572f
+      - req-e39ce9d1-c019-488f-8071-cee4c95d08fd
       Content-Length:
       - '386'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/f4d4e4ec09384303b1458c7de57de87b"},
-        "enabled": true, "subtree": {"3e85f17ca99f46fb8d9fd4d4dbb5885b": null, "8cf7a7f6156842c88d4ffd018e2cc7d2":
-        {"5d94a8ce93ce4f67b767ec1a475858a0": null}}, "id": "f4d4e4ec09384303b1458c7de57de87b",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
+        "enabled": true, "subtree": {"d949713f4b1845ad84b6c1e819db2c25": null, "974874f812174f629268f28074742b63":
+        {"89344733d8204c68a027ba2d596d7bce": null}}, "id": "27b9743d10594dd9964002f153955676",
         "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/5d94a8ce93ce4f67b767ec1a475858a0?parents_as_ids
+    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676?subtree_as_list
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:01 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-9c1b5caa-24ba-4b97-a502-ae4fcace959b
+      - req-fa807474-2f6a-428f-a8c1-5b61cc740408
+      Content-Length:
+      - '1107'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
+        "enabled": true, "subtree": [{"project": {"description": "", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63"},
+        "enabled": true, "id": "974874f812174f629268f28074742b63", "parent_id": "27b9743d10594dd9964002f153955676",
+        "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25"},
+        "enabled": true, "id": "d949713f4b1845ad84b6c1e819db2c25", "parent_id": "27b9743d10594dd9964002f153955676",
+        "domain_id": "default", "name": "p-baz67"}}, {"project": {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
+        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
+        "domain_id": "default", "name": "p-booboo67"}}], "id": "27b9743d10594dd9964002f153955676",
+        "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
+    http_version: 
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce?parents_as_ids
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 269086a06d764f6f93d22efe162cfd36
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Thu, 16 Jul 2015 16:05:01 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-23901b5a-89dc-47a4-a0cb-7b0bd6cd50e4
       Content-Length:
       - '374'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/5d94a8ce93ce4f67b767ec1a475858a0"},
-        "enabled": true, "id": "5d94a8ce93ce4f67b767ec1a475858a0", "parent_id": "8cf7a7f6156842c88d4ffd018e2cc7d2",
-        "parents": {"8cf7a7f6156842c88d4ffd018e2cc7d2": {"f4d4e4ec09384303b1458c7de57de87b":
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
+        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
+        "parents": {"974874f812174f629268f28074742b63": {"27b9743d10594dd9964002f153955676":
         null}}, "domain_id": "default", "name": "p-booboo67"}}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
 - request:
-    method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/5d94a8ce93ce4f67b767ec1a475858a0
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce?parents_as_list
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Thu, 16 Jul 2015 16:05:01 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-aab4f805-bea4-4776-a58b-d77281e72228
+      Content-Length:
+      - '827'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
+        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
+        "parents": [{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63"},
+        "enabled": true, "id": "974874f812174f629268f28074742b63", "parent_id": "27b9743d10594dd9964002f153955676",
+        "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
+        "enabled": true, "id": "27b9743d10594dd9964002f153955676", "parent_id": null,
+        "domain_id": "default", "name": "p-foobar67"}}], "domain_id": "default", "name":
+        "p-booboo67"}}'
+    http_version: 
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+- request:
+    method: delete
+    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:01 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-507a4623-2feb-45df-9be8-90c792626373
+      - req-468de713-6f07-4153-963d-ad7b24202eaf
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/8cf7a7f6156842c88d4ffd018e2cc7d2
+    uri: http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:01 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-cc83f907-255b-47fe-80fc-e1258f418fd3
+      - req-a7546023-ce38-4ae0-943a-adc864ffd917
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/3e85f17ca99f46fb8d9fd4d4dbb5885b
+    uri: http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:01 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-0b6e727a-2e27-4b98-ae7d-7c2bb3a77dcf
+      - req-016aa0fc-eb88-4f21-8dd2-1ae7c5539afa
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:19 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/f4d4e4ec09384303b1458c7de57de87b
+    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:02 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-61e57727-de9b-4e87-b18a-3f38323fc24c
+      - req-c1600693-087c-432c-ae40-beb4702f0158
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:20 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+- request:
+    method: delete
+    uri: http://devstack.openstack.stack:35357/v3/roles/b4a5f86a22164d4aa935d1098657d2d8
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - 269086a06d764f6f93d22efe162cfd36
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Date:
+      - Thu, 16 Jul 2015 16:05:02 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-59dbcb33-e07a-4595-a175-e0a6c2c43eec
+      Content-Length:
+      - '0'
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects
@@ -465,26 +772,26 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:02 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-01a34198-9bde-4fb4-87fb-278a8bac985b
+      - req-ffdf7c7c-f25d-45e8-a5a6-629c9d3aea17
       Content-Length:
       - '1070'
       Content-Type:
@@ -506,45 +813,45 @@ http_interactions:
         "enabled": true, "id": "956fbf1d663b4d6fa9d26c4d78de113f", "parent_id": null,
         "domain_id": "default", "name": "service"}]}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:20 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/f4d4e4ec09384303b1458c7de57de87b
+    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676
     body:
       encoding: US-ASCII
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 404
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:02 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-817fc2fe-6094-4849-b0e6-667389b4de03
+      - req-1a90473b-05bc-4f70-8591-9aa92aed3618
       Content-Length:
       - '117'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"error": {"message": "Could not find project: f4d4e4ec09384303b1458c7de57de87b",
+      string: ! '{"error": {"message": "Could not find project: 27b9743d10594dd9964002f153955676",
         "code": 404, "title": "Not Found"}}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:20 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67
@@ -553,26 +860,26 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:02 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a0fd589a-c811-47c9-9392-dbd0fa41b8d5
+      - req-260b9b9e-fb36-44fa-ad7c-dcac475c20a1
       Content-Length:
       - '126'
       Content-Type:
@@ -582,7 +889,7 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:20 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
@@ -591,26 +898,26 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:02 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-64ba076b-e396-4e83-8b10-6233901200a8
+      - req-adc5d87a-9766-4bb7-8858-25765726858d
       Content-Length:
       - '123'
       Content-Type:
@@ -620,7 +927,7 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:20 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-boo67
@@ -629,26 +936,26 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:19 GMT
+      - Thu, 16 Jul 2015 16:05:02 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-070938a9-1227-4a31-83a2-f84b8b783498
+      - req-4ebe3652-91bf-444c-8b61-a23898de1d5f
       Content-Length:
       - '123'
       Content-Type:
@@ -658,7 +965,7 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-boo67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:20 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67
@@ -667,26 +974,26 @@ http_interactions:
       string: ''
     headers:
       User-Agent:
-      - fog/1.32.0 fog-core/1.32.0
+      - fog-core/1.32.0
       Content-Type:
       - application/json
       Accept:
       - application/json
       X-Auth-Token:
-      - 0c4458de5ba5446885c65b1dedfb2404
+      - 269086a06d764f6f93d22efe162cfd36
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Wed, 15 Jul 2015 17:04:20 GMT
+      - Thu, 16 Jul 2015 16:05:02 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1a3797ce-7e67-4692-972a-a79b8070a7ab
+      - req-03715b2e-2dd1-4716-9670-d475f4d37857
       Content-Length:
       - '126'
       Content-Type:
@@ -696,5 +1003,5 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Wed, 15 Jul 2015 17:04:20 GMT
+  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fog/openstack/shared_context.rb
+++ b/spec/fog/openstack/shared_context.rb
@@ -1,6 +1,9 @@
 require 'rspec/core'
 require 'rspec/expectations'
 require 'vcr'
+require 'fog/openstack/identity'
+require 'fog/openstack/identity_v3'
+require 'fog/openstack/network'
 
 #
 # There are basically two modes of operation for these specs.


### PR DESCRIPTION
Also enhanced identity service to make the ID of the current user accessible as current_user_id.

Note that the returned lists are empty (even if *_as_ids calls return values) unless the calling user has a role in the projects - i.e. the only projects returned are those for which the user has a role.