### PR TITLE
Allow OpenStack storage adapter to take :openstack_management_url option

### DIFF
--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -8,7 +8,8 @@ module Fog
       recognizes :persistent, :openstack_service_name,
                  :openstack_service_type, :openstack_tenant,
                  :openstack_region, :openstack_temp_url_key,
-                 :openstack_endpoint_type
+                 :openstack_endpoint_type, :openstack_auth_token,
+                 :openstack_management_url
 
       model_path 'fog/openstack/models/storage'
       model       :directory
@@ -89,6 +90,7 @@ module Fog
           @connection_options     = options[:connection_options] || {}
           @openstack_temp_url_key = options[:openstack_temp_url_key]
           @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
+          @openstack_management_url = options[:openstack_management_url]
           authenticate
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)


### PR DESCRIPTION
It seems like the value used by `Fog::Storage::OpenStack::Real` for the `@openstack_management_url` is one of the few things that is not configurable on the adapter at initialization. This PR aims to make it configurable.

When paired with a valid `:openstack_auth_token` this should make it possible for the adapter to connect to Swift immediately without authenticating with Keystone.

This is useful in situations where many containers/tenants must be accessed by many processes, as it allows for caching auth information in a local file or shared memory or even something like redis. This is valuable in scenarios where keystone might not be able to handle the barrage of authentication requests for `m processes * n tenants`.

I'm open to subclassing `Fog::Storage::OpenStack::Real` if that's preferable to maintainers, but in my experimentation, the subclass I was able to create was missing some Fog magic like `adapter_instance.directories`.

One side note about this PR, presently, `:openstack_auth_token` issues a warning that it is unrecognized. I'm not sure if this is by intention or an accident, but to that end this PR makes `:openstack_auth_token` and `:openstack_management_url` recognized configuration options.

A final note, I looked around for tests that I could update, but didn't see anything that seemed relevant. Please point me to relevant tests if I have missed them!

Thanks!