### PR TITLE
[openstack] hierarchical projects: Array of Project instead of Array of Hash.

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -69,38 +69,19 @@ module Fog
       attr_reader :openstack_project_domain_id
 
       def initialize_identity options
-        @openstack_auth_token = options[:openstack_auth_token]
+        # Create @openstack_* instance variables from all :openstack_* options
+        options.select{|x|x.to_s.start_with? 'openstack'}.each do |openstack_param, value|
+          instance_variable_set "@#{openstack_param}".to_sym, value
+        end
+
         @auth_token        ||= options[:openstack_auth_token]
-        @openstack_identity_public_endpoint = options[:openstack_identity_endpoint]
-
-        @openstack_username = options[:openstack_username]
-        @openstack_userid = options[:openstack_userid]
-
-        @openstack_domain_name = options[:openstack_domain_name]
-        @openstack_user_domain = options[:openstack_user_domain]
-        @openstack_project_domain  = options[:openstack_project_domain]
-        @openstack_domain_id = options[:openstack_domain_id]
-        @openstack_user_domain_id = options[:openstack_user_domain_id]
-        @openstack_project_domain_id  = options[:openstack_project_domain_id]
-
-        @openstack_project_name = options[:openstack_project_name]
-        @openstack_tenant      = options[:openstack_tenant]
-        @openstack_tenant_id   = options[:openstack_tenant_id]
 
         @openstack_auth_uri    = URI.parse(options[:openstack_auth_url])
-
-        @openstack_management_url       = options[:openstack_management_url]
-
         @openstack_must_reauthenticate  = false
-
         @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
-        @openstack_region        = options[:openstack_region]
 
         unless @auth_token
           missing_credentials = Array.new
-          @openstack_api_key = options[:openstack_api_key]
-          @openstack_username = options[:openstack_username]
-          @openstack_userid = options[:openstack_userid]
 
           missing_credentials << :openstack_api_key unless @openstack_api_key
           unless @openstack_username || @openstack_userid
@@ -116,47 +97,34 @@ module Fog
       end
 
       def credentials
-        { :provider                 => 'openstack',
-          :openstack_domain_name    => @openstack_domain_name,
-          :openstack_user_domain    => @openstack_user_domain,
-          :openstack_project_domain => @openstack_project_domain,
-          :openstack_domain_id      => @openstack_domain_id,
-          :openstack_user_domain_id => @openstack_user_domain_id,
-          :openstack_project_domain_id => @openstack_project_domain_id,
+        options =  { :provider => 'openstack',
           :openstack_auth_url       => @openstack_auth_uri.to_s,
           :openstack_auth_token     => @auth_token,
-          :openstack_management_url => @openstack_management_url,
           :openstack_identity_endpoint => @openstack_identity_public_endpoint,
-          :openstack_region         => @openstack_region,
           :current_user             => @current_user,
           :current_user_id          => @current_user_id,
           :current_tenant           => @current_tenant }
+        openstack_options.merge options
       end
 
       private
+
+      def openstack_options
+        options={}
+        # Create a hash of (:openstack_*, value) of all the @openstack_* instance variables
+        self.instance_variables.select{|x|x.to_s.start_with? '@openstack'}.each do |openstack_param|
+          option_name = openstack_param.to_s[1..-1]
+          options[option_name.to_sym] = instance_variable_get openstack_param
+        end
+        options
+      end
+
       def authenticate
         if !@openstack_management_url || @openstack_must_reauthenticate
-          options = {
-              :openstack_tenant        => @openstack_tenant,
-              :openstack_tenant_id     => @openstack_tenant_id,
-              :openstack_api_key       => @openstack_api_key,
-              :openstack_username      => @openstack_username,
-              :openstack_userid        => @openstack_userid,
-              :openstack_user_domain   => @openstack_user_domain,
-              :openstack_project_domain => @openstack_project_domain,
-              :openstack_user_domain_id => @openstack_user_domain_id,
-              :openstack_project_domain_id => @openstack_project_domain_id,
-              :openstack_domain_name   => @openstack_domain_name,
-              :openstack_project_name  => @openstack_project_name,
-              :openstack_domain_id     => @openstack_domain_id,
-              :openstack_project_id    => @openstack_project_id,
-              :openstack_auth_uri      => @openstack_auth_uri,
-              :openstack_auth_token    => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type  => @openstack_service_type,
-              :openstack_service_name  => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type,
-              :openstack_region        => @openstack_region
-          }
+
+          options = openstack_options
+
+          options[:openstack_auth_token] = @openstack_must_reauthenticate ? nil : @openstack_auth_token
 
           credentials = Fog::OpenStack.authenticate(options, @connection_options)
 

--- a/lib/fog/openstack/models/identity_v3/project.rb
+++ b/lib/fog/openstack/models/identity_v3/project.rb
@@ -13,6 +13,8 @@ module Fog
           attribute :name
           attribute :links
           attribute :parent_id
+          attribute :subtree
+          attribute :parents
 
           def to_s
             self.name
@@ -87,13 +89,6 @@ module Fog
             service.revoke_project_group_role(self.id, group_id, role_id)
           end
 
-          def subtree
-            @attributes['subtree']
-          end
-
-          def parents
-            @attributes['parents']
-          end
         end
       end
     end

--- a/lib/fog/openstack/models/identity_v3/projects.rb
+++ b/lib/fog/openstack/models/identity_v3/projects.rb
@@ -23,10 +23,20 @@ module Fog
             cached_project = self.find { |project| project.id == id } if options.empty?
             return cached_project if cached_project
             project_hash = service.get_project(id, options).body['project']
-            Fog::Identity::OpenStack::V3::Project.new(
-                project_hash.merge(:service => service))
+            top_project = project_from_hash(project_hash, service)
+            if options.include? :subtree_as_list
+              top_project.subtree.map! {|proj_hash| project_from_hash(proj_hash['project'], service)}
+            end
+            if options.include? :parents_as_list
+              top_project.parents.map! {|proj_hash| project_from_hash(proj_hash['project'], service)}
+            end
+            return top_project
           end
 
+          private
+          def project_from_hash(project_hash, service)
+            Fog::Identity::OpenStack::V3::Project.new(project_hash.merge(:service => service))
+          end
         end
       end
     end

--- a/spec/fog/openstack/identity_v3/idv3_project_hier_crud_list.yml
+++ b/spec/fog/openstack/identity_v3/idv3_project_hier_crud_list.yml
@@ -21,13 +21,13 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:35 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-439285fe-58a6-4a85-a8bd-f8ccc84b7cb9
+      - req-6a9fcfa9-4368-4fa2-82f0-61f16dedb158
       Content-Length:
       - '317'
       Content-Type:
@@ -39,7 +39,7 @@ http_interactions:
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
         "http://devstack.openstack.stack:35357/v3/domains", "previous": null, "next": null}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:18:59 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
@@ -61,30 +61,30 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:35 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-47390e98-9073-44f7-9e5a-3c2f94c76a7e
+      - req-c9af88df-0f52-4f8f-a318-492ff1bba5e5
       Content-Length:
       - '251'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e"},
-        "enabled": true, "id": "2a2a6c4f8ea746e896025f6b1ca7df7e", "parent_id": null,
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
+        "enabled": true, "id": "edd3bec6a30847349d69216ed4b3e0b4", "parent_id": null,
         "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:18:59 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-baz67","parent_id":"2a2a6c4f8ea746e896025f6b1ca7df7e"}}'
+      string: ! '{"project":{"name":"p-baz67","parent_id":"edd3bec6a30847349d69216ed4b3e0b4"}}'
     headers:
       User-Agent:
       - fog-core/1.32.0
@@ -100,24 +100,24 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:35 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-51f66661-6410-4c0a-8e81-f80aac35accb
+      - req-14ed4a49-b23f-4d5d-822e-3241a9a28b9f
       Content-Length:
       - '278'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3"},
-        "enabled": true, "id": "655c1a1d8fab40acb1e5f5be39fc47b3", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0"},
+        "enabled": true, "id": "570b1075f2a7470ea2b2f009f440b7b0", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-baz67"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:18:59 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
@@ -139,13 +139,13 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:35 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-70c7246f-65de-483c-b992-f97aacb7382b
+      - req-8517afe6-f361-4004-9a01-411d067f1a92
       Content-Length:
       - '388'
       Content-Type:
@@ -154,17 +154,17 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
         "previous": null, "next": null}, "projects": [{"description": "", "links":
-        {"self": "http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3"},
-        "enabled": true, "id": "655c1a1d8fab40acb1e5f5be39fc47b3", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
+        {"self": "http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0"},
+        "enabled": true, "id": "570b1075f2a7470ea2b2f009f440b7b0", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-baz67"}]}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-boo67","parent_id":"2a2a6c4f8ea746e896025f6b1ca7df7e"}}'
+      string: ! '{"project":{"name":"p-boo67","parent_id":"edd3bec6a30847349d69216ed4b3e0b4"}}'
     headers:
       User-Agent:
       - fog-core/1.32.0
@@ -180,30 +180,30 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:35 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-91d2c3cf-c820-40bd-834c-bc45465a741e
+      - req-2229c28f-94de-4fdd-b839-e8e23b68c2d3
       Content-Length:
       - '278'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b"},
-        "enabled": true, "id": "a06b59b9b24642bdb7a99899696a3d6b", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6"},
+        "enabled": true, "id": "8e1bc4fbfd6c47fea94d0e6ebad05be6", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-boo67"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-booboo67","parent_id":"a06b59b9b24642bdb7a99899696a3d6b"}}'
+      string: ! '{"project":{"name":"p-booboo67","parent_id":"8e1bc4fbfd6c47fea94d0e6ebad05be6"}}'
     headers:
       User-Agent:
       - fog-core/1.32.0
@@ -219,24 +219,24 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:35 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-64a8273c-a047-4228-ad4d-5872b5a35f81
+      - req-d36dac0b-3ee8-497f-90b6-ea7ee434bca5
       Content-Length:
       - '281'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855"},
-        "enabled": true, "id": "ff05b08c626e479dbba3f5da2ce0b855", "parent_id": "a06b59b9b24642bdb7a99899696a3d6b",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
         "domain_id": "default", "name": "p-booboo67"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/roles
@@ -258,27 +258,27 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:35 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-021aa988-3115-4fb7-a7c3-8db2e15a1060
+      - req-105f752a-0c7a-492a-9080-e8bf5767fa55
       Content-Length:
       - '167'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"role": {"id": "f4959b9baaa24305998a700023b3cf0a", "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/roles/f4959b9baaa24305998a700023b3cf0a"},
+      string: ! '{"role": {"id": "9eeae75b331946dd907f16d3dccb916a", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/roles/9eeae75b331946dd907f16d3dccb916a"},
         "name": "r-project67"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e/users/aa9f25defa6d4cafb48466df83106065/roles/f4959b9baaa24305998a700023b3cf0a
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
     body:
       encoding: US-ASCII
       string: ''
@@ -297,23 +297,23 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:35 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6ad6f670-6eb5-45ba-a4ca-636a94bff58b
+      - req-895af830-2d83-433d-ba23-8ab43a67483a
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3/users/aa9f25defa6d4cafb48466df83106065/roles/f4959b9baaa24305998a700023b3cf0a
+    uri: http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
     body:
       encoding: US-ASCII
       string: ''
@@ -332,23 +332,23 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:35 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-34c8f751-35fb-46a2-8bbb-0896965e1336
+      - req-7f126391-17af-4ca1-a348-fe4280c57450
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b/users/aa9f25defa6d4cafb48466df83106065/roles/f4959b9baaa24305998a700023b3cf0a
+    uri: http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
     body:
       encoding: US-ASCII
       string: ''
@@ -367,23 +367,23 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:36 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-66083d18-8fe8-44fe-9ecc-692ce89adab6
+      - req-91451272-cef2-467c-80aa-5de40998c2f2
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855/users/aa9f25defa6d4cafb48466df83106065/roles/f4959b9baaa24305998a700023b3cf0a
+    uri: http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
     body:
       encoding: US-ASCII
       string: ''
@@ -402,23 +402,23 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:36 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-925443e4-0490-4414-b0fe-deb9d31e4799
+      - req-1cdb03bc-58c5-4d04-b585-19e44ce2d32f
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e?subtree_as_ids
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4?subtree_as_ids
     body:
       encoding: US-ASCII
       string: ''
@@ -437,28 +437,28 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:36 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e3dcffd7-b680-4b18-a809-380cf71dff9b
+      - req-0a1a824a-364e-4afc-ba89-91c256128885
       Content-Length:
       - '386'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e"},
-        "enabled": true, "subtree": {"a06b59b9b24642bdb7a99899696a3d6b": {"ff05b08c626e479dbba3f5da2ce0b855":
-        null}, "655c1a1d8fab40acb1e5f5be39fc47b3": null}, "id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
+        "enabled": true, "subtree": {"570b1075f2a7470ea2b2f009f440b7b0": null, "8e1bc4fbfd6c47fea94d0e6ebad05be6":
+        {"15a7ecafe8c44fe18cb9b3ca009f8259": null}}, "id": "edd3bec6a30847349d69216ed4b3e0b4",
         "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e?subtree_as_list
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4?subtree_as_list
     body:
       encoding: US-ASCII
       string: ''
@@ -477,36 +477,110 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:36 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-6555d183-4918-4020-a638-6667a1e8e4c1
+      - req-b6f5c89d-e9bb-4ab9-9ea7-7ac8c2959b37
       Content-Length:
       - '1107'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e"},
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
         "enabled": true, "subtree": [{"project": {"description": "", "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3"},
-        "enabled": true, "id": "655c1a1d8fab40acb1e5f5be39fc47b3", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
+        "http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0"},
+        "enabled": true, "id": "570b1075f2a7470ea2b2f009f440b7b0", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-baz67"}}, {"project": {"description": "",
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b"},
-        "enabled": true, "id": "a06b59b9b24642bdb7a99899696a3d6b", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6"},
+        "enabled": true, "id": "8e1bc4fbfd6c47fea94d0e6ebad05be6", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855"},
-        "enabled": true, "id": "ff05b08c626e479dbba3f5da2ce0b855", "parent_id": "a06b59b9b24642bdb7a99899696a3d6b",
-        "domain_id": "default", "name": "p-booboo67"}}], "id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "domain_id": "default", "name": "p-booboo67"}}], "id": "edd3bec6a30847349d69216ed4b3e0b4",
         "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
+- request:
+    method: post
+    uri: http://devstack.openstack.stack:35357/v3/projects
+    body:
+      encoding: UTF-8
+      string: ! '{"project":{"name":"p-fooboo67","parent_id":"8e1bc4fbfd6c47fea94d0e6ebad05be6"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:54 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-7d289ea5-869d-4c95-aa82-194ac4cb805d
+      Content-Length:
+      - '281'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a288e7f1645e442da84232108c7e3ec9"},
+        "enabled": true, "id": "a288e7f1645e442da84232108c7e3ec9", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "domain_id": "default", "name": "p-fooboo67"}}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
+- request:
+    method: put
+    uri: http://devstack.openstack.stack:35357/v3/projects/a288e7f1645e442da84232108c7e3ec9/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:54 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-9a87ff8d-26a2-43fb-ad63-cf03e2324854
+      Content-Length:
+      - '0'
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855?parents_as_ids
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4?subtree_as_list
     body:
       encoding: US-ASCII
       string: ''
@@ -525,28 +599,79 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:36 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-737fadcd-dc37-4044-82fb-c54d42548c5d
+      - req-bee9ca26-a2e6-401b-95da-041161d09bde
+      Content-Length:
+      - '1390'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
+        "enabled": true, "subtree": [{"project": {"description": "", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0"},
+        "enabled": true, "id": "570b1075f2a7470ea2b2f009f440b7b0", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
+        "domain_id": "default", "name": "p-baz67"}}, {"project": {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6"},
+        "enabled": true, "id": "8e1bc4fbfd6c47fea94d0e6ebad05be6", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
+        "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "domain_id": "default", "name": "p-booboo67"}}, {"project": {"description":
+        "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a288e7f1645e442da84232108c7e3ec9"},
+        "enabled": true, "id": "a288e7f1645e442da84232108c7e3ec9", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "domain_id": "default", "name": "p-fooboo67"}}], "id": "edd3bec6a30847349d69216ed4b3e0b4",
+        "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259?parents_as_ids
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:54 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-00f313f0-b3e0-4039-b246-cb2bd06dd51f
       Content-Length:
       - '374'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855"},
-        "enabled": true, "id": "ff05b08c626e479dbba3f5da2ce0b855", "parent_id": "a06b59b9b24642bdb7a99899696a3d6b",
-        "parents": {"a06b59b9b24642bdb7a99899696a3d6b": {"2a2a6c4f8ea746e896025f6b1ca7df7e":
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "parents": {"8e1bc4fbfd6c47fea94d0e6ebad05be6": {"edd3bec6a30847349d69216ed4b3e0b4":
         null}}, "domain_id": "default", "name": "p-booboo67"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855?parents_as_list
+    uri: http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259?parents_as_list
     body:
       encoding: US-ASCII
       string: ''
@@ -565,33 +690,33 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:36 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-d9818e23-7ba4-4c33-8962-db1053d549d0
+      - req-343c722a-65c6-4427-8782-b370cca8be6c
       Content-Length:
       - '827'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855"},
-        "enabled": true, "id": "ff05b08c626e479dbba3f5da2ce0b855", "parent_id": "a06b59b9b24642bdb7a99899696a3d6b",
-        "parents": [{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b"},
-        "enabled": true, "id": "a06b59b9b24642bdb7a99899696a3d6b", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "parents": [{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6"},
+        "enabled": true, "id": "8e1bc4fbfd6c47fea94d0e6ebad05be6", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e"},
-        "enabled": true, "id": "2a2a6c4f8ea746e896025f6b1ca7df7e", "parent_id": null,
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
+        "enabled": true, "id": "edd3bec6a30847349d69216ed4b3e0b4", "parent_id": null,
         "domain_id": "default", "name": "p-foobar67"}}], "domain_id": "default", "name":
         "p-booboo67"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855
+    uri: http://devstack.openstack.stack:35357/v3/projects/a288e7f1645e442da84232108c7e3ec9
     body:
       encoding: US-ASCII
       string: ''
@@ -610,23 +735,23 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:36 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b7afb8b7-9529-4d16-b1d5-eb1393924466
+      - req-3e964bce-b106-4edf-bcdc-6da3d74f7f7c
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b
+    uri: http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259
     body:
       encoding: US-ASCII
       string: ''
@@ -645,23 +770,23 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:36 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ff353a51-f820-49b7-9af2-9d7e6f52f9a0
+      - req-e0cd202d-c96f-4b82-b9e9-29650111b15e
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3
+    uri: http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6
     body:
       encoding: US-ASCII
       string: ''
@@ -680,23 +805,23 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:36 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-f158eada-46e4-4d46-aa9f-4503eee0f729
+      - req-70eb87e6-a48c-4b76-8aa7-f2924b1aadc6
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e
+    uri: http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0
     body:
       encoding: US-ASCII
       string: ''
@@ -715,23 +840,23 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:37 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1a114402-5902-4580-a4e0-29fe6b9a0548
+      - req-997cf019-3a7a-4185-82bb-34a47e38bc21
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/roles/f4959b9baaa24305998a700023b3cf0a
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4
     body:
       encoding: US-ASCII
       string: ''
@@ -750,20 +875,55 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:37 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-20a8ae21-eb80-4ce5-9ce6-3eb98afdb2e3
+      - req-db82b42c-b459-4e5a-9bd8-cb5243f01213
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
+- request:
+    method: delete
+    uri: http://devstack.openstack.stack:35357/v3/roles/9eeae75b331946dd907f16d3dccb916a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:55 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-f3093cb8-4a6e-4510-8121-eb8829aa78e4
+      Content-Length:
+      - '0'
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects
@@ -785,13 +945,13 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:37 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-b4d84ba0-d851-45f9-8957-c291af2d0dd8
+      - req-11d93c10-819b-4af0-955c-728e195b9fdc
       Content-Length:
       - '1062'
       Content-Type:
@@ -812,10 +972,10 @@ http_interactions:
         "enabled": true, "id": "a9088d7853b843318cb026dc3373c174", "parent_id": null,
         "domain_id": "default", "name": "service"}]}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4
     body:
       encoding: US-ASCII
       string: ''
@@ -834,137 +994,23 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:37 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4b92044b-a5d7-43cc-a041-54e4187bda43
+      - req-015abdc2-1a35-43d3-bc65-c63f5f2dc272
       Content-Length:
       - '117'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"error": {"message": "Could not find project: 2a2a6c4f8ea746e896025f6b1ca7df7e",
+      string: ! '{"error": {"message": "Could not find project: edd3bec6a30847349d69216ed4b3e0b4",
         "code": 404, "title": "Not Found"}}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
-- request:
-    method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.32.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ea1e9622dc8f4802a5f26955ccd8763f
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 24 Jul 2015 10:18:37 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-5947b235-634a-40c2-b10d-d25d30c9b5b9
-      Content-Length:
-      - '126'
-      Content-Type:
-      - application/json
-    body:
-      encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67",
-        "previous": null, "next": null}, "projects": []}'
-    http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
-- request:
-    method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.32.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ea1e9622dc8f4802a5f26955ccd8763f
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 24 Jul 2015 10:18:37 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-a251965e-599a-4169-bd52-d69729a1b772
-      Content-Length:
-      - '123'
-      Content-Type:
-      - application/json
-    body:
-      encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
-        "previous": null, "next": null}, "projects": []}'
-    http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
-- request:
-    method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-boo67
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.32.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - ea1e9622dc8f4802a5f26955ccd8763f
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Fri, 24 Jul 2015 10:18:37 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-15ae31b8-86c7-4642-8fcf-f2de0b29e798
-      Content-Length:
-      - '123'
-      Content-Type:
-      - application/json
-    body:
-      encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-boo67",
-        "previous": null, "next": null}, "projects": []}'
-    http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67
@@ -986,13 +1032,13 @@ http_interactions:
       message: ''
     headers:
       Date:
-      - Fri, 24 Jul 2015 10:18:37 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a5c269da-6321-42f7-88eb-858030657ecd
+      - req-f02cc3be-a027-491d-9e8a-bb9228e0d4e1
       Content-Length:
       - '126'
       Content-Type:
@@ -1002,5 +1048,347 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:55 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-83df3490-b901-4889-a900-a18e9a12c09f
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-fooboo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-6e0fad29-cbf5-43ca-9e78-2df6570346bc
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-fooboo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-fooboo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-28156923-6d90-46e3-876b-85096a8e4ad5
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-fooboo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-boo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-18d78997-d6be-4192-9354-329878be50ac
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-boo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-boo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-02cd3c7c-ca92-4bd3-9f97-e76d374c007f
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-boo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-8e20c713-9427-47a0-ba06-677f28a34e90
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-4e575274-0e98-4415-be62-29103606464e
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-5e735cdd-d6fb-4228-8925-524f6e8a6ba9
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-7405bdf6-3564-41ac-adc5-bec643ded99e
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fog/openstack/identity_v3/idv3_project_hier_crud_list.yml
+++ b/spec/fog/openstack/identity_v3/idv3_project_hier_crud_list.yml
@@ -14,20 +14,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 10:18:35 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c884f35b-9592-4e25-bd99-023d91e3980d
+      - req-439285fe-58a6-4a85-a8bd-f8ccc84b7cb9
       Content-Length:
       - '317'
       Content-Type:
@@ -39,7 +39,7 @@ http_interactions:
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
         "http://devstack.openstack.stack:35357/v3/domains", "previous": null, "next": null}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 10:18:59 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
@@ -54,37 +54,37 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 10:18:35 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5193098e-4561-41e2-bbb0-6bfc67017797
+      - req-47390e98-9073-44f7-9e5a-3c2f94c76a7e
       Content-Length:
       - '251'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
-        "enabled": true, "id": "27b9743d10594dd9964002f153955676", "parent_id": null,
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e"},
+        "enabled": true, "id": "2a2a6c4f8ea746e896025f6b1ca7df7e", "parent_id": null,
         "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 10:18:59 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-baz67","parent_id":"27b9743d10594dd9964002f153955676"}}'
+      string: ! '{"project":{"name":"p-baz67","parent_id":"2a2a6c4f8ea746e896025f6b1ca7df7e"}}'
     headers:
       User-Agent:
       - fog-core/1.32.0
@@ -93,31 +93,31 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 10:18:35 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-28665661-d06c-4e17-93b9-c25ab699b63e
+      - req-51f66661-6410-4c0a-8e81-f80aac35accb
       Content-Length:
       - '278'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25"},
-        "enabled": true, "id": "d949713f4b1845ad84b6c1e819db2c25", "parent_id": "27b9743d10594dd9964002f153955676",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3"},
+        "enabled": true, "id": "655c1a1d8fab40acb1e5f5be39fc47b3", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
         "domain_id": "default", "name": "p-baz67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 10:18:59 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
@@ -132,20 +132,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 10:18:35 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bc49000f-0dae-47b1-a310-1f400179d1c0
+      - req-70c7246f-65de-483c-b992-f97aacb7382b
       Content-Length:
       - '388'
       Content-Type:
@@ -154,17 +154,17 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
         "previous": null, "next": null}, "projects": [{"description": "", "links":
-        {"self": "http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25"},
-        "enabled": true, "id": "d949713f4b1845ad84b6c1e819db2c25", "parent_id": "27b9743d10594dd9964002f153955676",
+        {"self": "http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3"},
+        "enabled": true, "id": "655c1a1d8fab40acb1e5f5be39fc47b3", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
         "domain_id": "default", "name": "p-baz67"}]}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-boo67","parent_id":"27b9743d10594dd9964002f153955676"}}'
+      string: ! '{"project":{"name":"p-boo67","parent_id":"2a2a6c4f8ea746e896025f6b1ca7df7e"}}'
     headers:
       User-Agent:
       - fog-core/1.32.0
@@ -173,37 +173,37 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 10:18:35 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a20fe500-31fa-4ef9-8100-65df6816f0a4
+      - req-91d2c3cf-c820-40bd-834c-bc45465a741e
       Content-Length:
       - '278'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63"},
-        "enabled": true, "id": "974874f812174f629268f28074742b63", "parent_id": "27b9743d10594dd9964002f153955676",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b"},
+        "enabled": true, "id": "a06b59b9b24642bdb7a99899696a3d6b", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
         "domain_id": "default", "name": "p-boo67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-booboo67","parent_id":"974874f812174f629268f28074742b63"}}'
+      string: ! '{"project":{"name":"p-booboo67","parent_id":"a06b59b9b24642bdb7a99899696a3d6b"}}'
     headers:
       User-Agent:
       - fog-core/1.32.0
@@ -212,31 +212,31 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 10:18:35 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-551dd25b-e520-4781-b85c-c021e83fb0a2
+      - req-64a8273c-a047-4228-ad4d-5872b5a35f81
       Content-Length:
       - '281'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
-        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855"},
+        "enabled": true, "id": "ff05b08c626e479dbba3f5da2ce0b855", "parent_id": "a06b59b9b24642bdb7a99899696a3d6b",
         "domain_id": "default", "name": "p-booboo67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/roles
@@ -251,34 +251,34 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 10:18:35 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e97893c6-725d-4e60-81e0-5f1144cd0728
+      - req-021aa988-3115-4fb7-a7c3-8db2e15a1060
       Content-Length:
       - '167'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"role": {"id": "b4a5f86a22164d4aa935d1098657d2d8", "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/roles/b4a5f86a22164d4aa935d1098657d2d8"},
+      string: ! '{"role": {"id": "f4959b9baaa24305998a700023b3cf0a", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/roles/f4959b9baaa24305998a700023b3cf0a"},
         "name": "r-project67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e/users/aa9f25defa6d4cafb48466df83106065/roles/f4959b9baaa24305998a700023b3cf0a
     body:
       encoding: US-ASCII
       string: ''
@@ -290,30 +290,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:35 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e39795b5-1c84-4bf8-9987-4b7e571d9f72
+      - req-6ad6f670-6eb5-45ba-a4ca-636a94bff58b
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3/users/aa9f25defa6d4cafb48466df83106065/roles/f4959b9baaa24305998a700023b3cf0a
     body:
       encoding: US-ASCII
       string: ''
@@ -325,30 +325,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:35 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-968410c6-0f59-4a3d-a439-472cba337728
+      - req-34c8f751-35fb-46a2-8bbb-0896965e1336
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b/users/aa9f25defa6d4cafb48466df83106065/roles/f4959b9baaa24305998a700023b3cf0a
     body:
       encoding: US-ASCII
       string: ''
@@ -360,30 +360,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:36 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8f83c542-ffe3-4442-ae84-39fd3c1728fd
+      - req-66083d18-8fe8-44fe-9ecc-692ce89adab6
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855/users/aa9f25defa6d4cafb48466df83106065/roles/f4959b9baaa24305998a700023b3cf0a
     body:
       encoding: US-ASCII
       string: ''
@@ -395,30 +395,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:36 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-abaa07cb-b7fd-400c-871d-647a170969a4
+      - req-925443e4-0490-4414-b0fe-deb9d31e4799
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676?subtree_as_ids
+    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e?subtree_as_ids
     body:
       encoding: US-ASCII
       string: ''
@@ -430,35 +430,35 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:36 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e39ce9d1-c019-488f-8071-cee4c95d08fd
+      - req-e3dcffd7-b680-4b18-a809-380cf71dff9b
       Content-Length:
       - '386'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
-        "enabled": true, "subtree": {"d949713f4b1845ad84b6c1e819db2c25": null, "974874f812174f629268f28074742b63":
-        {"89344733d8204c68a027ba2d596d7bce": null}}, "id": "27b9743d10594dd9964002f153955676",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e"},
+        "enabled": true, "subtree": {"a06b59b9b24642bdb7a99899696a3d6b": {"ff05b08c626e479dbba3f5da2ce0b855":
+        null}, "655c1a1d8fab40acb1e5f5be39fc47b3": null}, "id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
         "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676?subtree_as_list
+    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e?subtree_as_list
     body:
       encoding: US-ASCII
       string: ''
@@ -470,43 +470,43 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:36 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fa807474-2f6a-428f-a8c1-5b61cc740408
+      - req-6555d183-4918-4020-a638-6667a1e8e4c1
       Content-Length:
       - '1107'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e"},
         "enabled": true, "subtree": [{"project": {"description": "", "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63"},
-        "enabled": true, "id": "974874f812174f629268f28074742b63", "parent_id": "27b9743d10594dd9964002f153955676",
-        "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25"},
-        "enabled": true, "id": "d949713f4b1845ad84b6c1e819db2c25", "parent_id": "27b9743d10594dd9964002f153955676",
+        "http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3"},
+        "enabled": true, "id": "655c1a1d8fab40acb1e5f5be39fc47b3", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
         "domain_id": "default", "name": "p-baz67"}}, {"project": {"description": "",
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
-        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
-        "domain_id": "default", "name": "p-booboo67"}}], "id": "27b9743d10594dd9964002f153955676",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b"},
+        "enabled": true, "id": "a06b59b9b24642bdb7a99899696a3d6b", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
+        "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855"},
+        "enabled": true, "id": "ff05b08c626e479dbba3f5da2ce0b855", "parent_id": "a06b59b9b24642bdb7a99899696a3d6b",
+        "domain_id": "default", "name": "p-booboo67"}}], "id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
         "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce?parents_as_ids
+    uri: http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855?parents_as_ids
     body:
       encoding: US-ASCII
       string: ''
@@ -518,35 +518,35 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:36 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-23901b5a-89dc-47a4-a0cb-7b0bd6cd50e4
+      - req-737fadcd-dc37-4044-82fb-c54d42548c5d
       Content-Length:
       - '374'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
-        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
-        "parents": {"974874f812174f629268f28074742b63": {"27b9743d10594dd9964002f153955676":
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855"},
+        "enabled": true, "id": "ff05b08c626e479dbba3f5da2ce0b855", "parent_id": "a06b59b9b24642bdb7a99899696a3d6b",
+        "parents": {"a06b59b9b24642bdb7a99899696a3d6b": {"2a2a6c4f8ea746e896025f6b1ca7df7e":
         null}}, "domain_id": "default", "name": "p-booboo67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce?parents_as_list
+    uri: http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855?parents_as_list
     body:
       encoding: US-ASCII
       string: ''
@@ -558,40 +558,40 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:36 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aab4f805-bea4-4776-a58b-d77281e72228
+      - req-d9818e23-7ba4-4c33-8962-db1053d549d0
       Content-Length:
       - '827'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
-        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
-        "parents": [{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63"},
-        "enabled": true, "id": "974874f812174f629268f28074742b63", "parent_id": "27b9743d10594dd9964002f153955676",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855"},
+        "enabled": true, "id": "ff05b08c626e479dbba3f5da2ce0b855", "parent_id": "a06b59b9b24642bdb7a99899696a3d6b",
+        "parents": [{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b"},
+        "enabled": true, "id": "a06b59b9b24642bdb7a99899696a3d6b", "parent_id": "2a2a6c4f8ea746e896025f6b1ca7df7e",
         "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
-        "enabled": true, "id": "27b9743d10594dd9964002f153955676", "parent_id": null,
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e"},
+        "enabled": true, "id": "2a2a6c4f8ea746e896025f6b1ca7df7e", "parent_id": null,
         "domain_id": "default", "name": "p-foobar67"}}], "domain_id": "default", "name":
         "p-booboo67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:00 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce
+    uri: http://devstack.openstack.stack:35357/v3/projects/ff05b08c626e479dbba3f5da2ce0b855
     body:
       encoding: US-ASCII
       string: ''
@@ -603,30 +603,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:36 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-468de713-6f07-4153-963d-ad7b24202eaf
+      - req-b7afb8b7-9529-4d16-b1d5-eb1393924466
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63
+    uri: http://devstack.openstack.stack:35357/v3/projects/a06b59b9b24642bdb7a99899696a3d6b
     body:
       encoding: US-ASCII
       string: ''
@@ -638,30 +638,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:36 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a7546023-ce38-4ae0-943a-adc864ffd917
+      - req-ff353a51-f820-49b7-9af2-9d7e6f52f9a0
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25
+    uri: http://devstack.openstack.stack:35357/v3/projects/655c1a1d8fab40acb1e5f5be39fc47b3
     body:
       encoding: US-ASCII
       string: ''
@@ -673,30 +673,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 10:18:36 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-016aa0fc-eb88-4f21-8dd2-1ae7c5539afa
+      - req-f158eada-46e4-4d46-aa9f-4503eee0f729
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676
+    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e
     body:
       encoding: US-ASCII
       string: ''
@@ -708,30 +708,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 10:18:37 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c1600693-087c-432c-ae40-beb4702f0158
+      - req-1a114402-5902-4580-a4e0-29fe6b9a0548
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/roles/f4959b9baaa24305998a700023b3cf0a
     body:
       encoding: US-ASCII
       string: ''
@@ -743,27 +743,27 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 10:18:37 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-59dbcb33-e07a-4595-a175-e0a6c2c43eec
+      - req-20a8ae21-eb80-4ce5-9ce6-3eb98afdb2e3
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects
@@ -778,45 +778,44 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 10:18:37 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ffdf7c7c-f25d-45e8-a5a6-629c9d3aea17
+      - req-b4d84ba0-d851-45f9-8957-c291af2d0dd8
       Content-Length:
-      - '1070'
+      - '1062'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects", "previous":
-        null, "next": null}, "projects": [{"description": null, "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/projects/123ac695d4db400a9001b91bb3b8aa46"},
-        "enabled": true, "id": "123ac695d4db400a9001b91bb3b8aa46", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"description": null, "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/projects/3e06db1f2ff64d219d27a3f6858bf602"},
-        "enabled": true, "id": "3e06db1f2ff64d219d27a3f6858bf602", "parent_id": null,
-        "domain_id": "default", "name": "invisible_to_admin"}, {"description": null,
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/3ed7ee0512b641d3bb1fe17fc86d8bff"},
-        "enabled": true, "id": "3ed7ee0512b641d3bb1fe17fc86d8bff", "parent_id": null,
-        "domain_id": "default", "name": "demo"}, {"description": null, "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/projects/956fbf1d663b4d6fa9d26c4d78de113f"},
-        "enabled": true, "id": "956fbf1d663b4d6fa9d26c4d78de113f", "parent_id": null,
+        null, "next": null}, "projects": [{"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/287f46e0cc294b8cb0c276dd71b8710f"},
+        "enabled": true, "id": "287f46e0cc294b8cb0c276dd71b8710f", "parent_id": null,
+        "domain_id": "default", "name": "demo"}, {"description": "", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/projects/4bd6ed0a80b7465a8b25f4d7df1236ea"},
+        "enabled": true, "id": "4bd6ed0a80b7465a8b25f4d7df1236ea", "parent_id": null,
+        "domain_id": "default", "name": "invisible_to_admin"}, {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/711f0a64ef5046c084ce904b4445d119"},
+        "enabled": true, "id": "711f0a64ef5046c084ce904b4445d119", "parent_id": null,
+        "domain_id": "default", "name": "admin"}, {"description": "", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/projects/a9088d7853b843318cb026dc3373c174"},
+        "enabled": true, "id": "a9088d7853b843318cb026dc3373c174", "parent_id": null,
         "domain_id": "default", "name": "service"}]}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676
+    uri: http://devstack.openstack.stack:35357/v3/projects/2a2a6c4f8ea746e896025f6b1ca7df7e
     body:
       encoding: US-ASCII
       string: ''
@@ -828,30 +827,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 404
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 10:18:37 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1a90473b-05bc-4f70-8591-9aa92aed3618
+      - req-4b92044b-a5d7-43cc-a041-54e4187bda43
       Content-Length:
       - '117'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"error": {"message": "Could not find project: 27b9743d10594dd9964002f153955676",
+      string: ! '{"error": {"message": "Could not find project: 2a2a6c4f8ea746e896025f6b1ca7df7e",
         "code": 404, "title": "Not Found"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67
@@ -866,20 +865,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 10:18:37 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-260b9b9e-fb36-44fa-ad7c-dcac475c20a1
+      - req-5947b235-634a-40c2-b10d-d25d30c9b5b9
       Content-Length:
       - '126'
       Content-Type:
@@ -889,7 +888,7 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
@@ -904,20 +903,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 10:18:37 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-adc5d87a-9766-4bb7-8858-25765726858d
+      - req-a251965e-599a-4169-bd52-d69729a1b772
       Content-Length:
       - '123'
       Content-Type:
@@ -927,7 +926,7 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-boo67
@@ -942,20 +941,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 10:18:37 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-4ebe3652-91bf-444c-8b61-a23898de1d5f
+      - req-15ae31b8-86c7-4642-8fcf-f2de0b29e798
       Content-Length:
       - '123'
       Content-Type:
@@ -965,7 +964,7 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-boo67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67
@@ -980,20 +979,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 10:18:37 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-03715b2e-2dd1-4716-9670-d475f4d37857
+      - req-a5c269da-6321-42f7-88eb-858030657ecd
       Content-Length:
       - '126'
       Content-Type:
@@ -1003,5 +1002,5 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 10:19:01 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fog/openstack/identity_v3_spec.rb
+++ b/spec/fog/openstack/identity_v3_spec.rb
@@ -649,7 +649,7 @@ RSpec.describe Fog::Identity::OpenStack::V3 do
         # Get the children of foobar, as a list of objects
         foobar_kids = @service.projects.find_by_id(foobar_id, :subtree_as_list).subtree
         expect(foobar_kids.length).to eq 3
-        expect([foobar_kids[0]['project']['id'],foobar_kids[1]['project']['id'],foobar_kids[2]['project']['id']].sort
+        expect([foobar_kids[0].id,foobar_kids[1].id,foobar_kids[2].id].sort
           ).to eq [baz_id, boo_id, booboo_id].sort
 
         # Get the parents of booboo, as a tree of IDs
@@ -664,8 +664,7 @@ RSpec.describe Fog::Identity::OpenStack::V3 do
         # Get the parents of booboo, as a list of objects
         booboo_parents = @service.projects.find_by_id(booboo_id, :parents_as_list).parents
         expect(booboo_parents.length).to eq 2
-        expect([booboo_parents[0]['project']['id'],booboo_parents[1]['project']['id']].sort
-          ).to eq [foobar_id, boo_id].sort
+        expect([booboo_parents[0].id,booboo_parents[1].id].sort).to eq [foobar_id, boo_id].sort
       ensure
         # Delete the projects
         booboo_project.destroy if booboo_project


### PR DESCRIPTION
For subtree_as_list and parents_as_list, set subtree and parents attributes as Array of Project instead of Array of Hash.