### PR TITLE
[vsphere] Add support for cookie login

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -7,7 +7,7 @@ module Fog
       requires :vsphere_username, :vsphere_password, :vsphere_server
       recognizes :vsphere_port, :vsphere_path, :vsphere_ns
       recognizes :vsphere_rev, :vsphere_ssl, :vsphere_expected_pubkey_hash
-      recognizes :vsphere_debug
+      recognizes :vsphere_debug, :vsphere_cookie
 
       model_path 'fog/vsphere/models/compute'
       model :server
@@ -358,6 +358,7 @@ module Fog
           require 'rbvmomi'
           @vsphere_username = options[:vsphere_username]
           @vsphere_password = 'REDACTED'
+          @vsphere_cookie   = options[:vpshere_cookie] || nil
           @vsphere_server   = options[:vsphere_server]
           @vsphere_expected_pubkey_hash = options[:vsphere_expected_pubkey_hash]
           @vsphere_is_vcenter = true
@@ -380,6 +381,7 @@ module Fog
           require 'rbvmomi'
           @vsphere_username = options[:vsphere_username]
           @vsphere_password = options[:vsphere_password]
+          @vsphere_cookie   = options[:vsphere_cookie] || nil
           @vsphere_server   = options[:vsphere_server]
           @vsphere_port     = options[:vsphere_port] || 443
           @vsphere_path     = options[:vsphere_path] || '/sdk'
@@ -429,7 +431,8 @@ module Fog
                                              :rev  => @vsphere_rev,
                                              :ssl  => @vsphere_ssl,
                                              :insecure => bad_cert,
-                                             :debug => @vsphere_debug
+                                             :debug => @vsphere_debug,
+                                             :cookie => @vsphere_cookie
               break
             rescue OpenSSL::SSL::SSLError
               raise if bad_cert
@@ -444,8 +447,10 @@ module Fog
 
         def authenticate
           begin
-            @connection.serviceContent.sessionManager.Login :userName => @vsphere_username,
-                                                            :password => @vsphere_password
+            unless @vsphere_cookie
+              @connection.serviceContent.sessionManager.Login :userName => @vsphere_username,
+                                                              :password => @vsphere_password
+            end
           rescue RbVmomi::VIM::InvalidLogin => e
             raise Fog::Vsphere::Errors::ServiceError, e.message
           end


### PR DESCRIPTION
Hi,

this patch adds support for cookie auth to a vCenter server. To be exact i am only adding the RbVmomi option for this to the Fog::Vsphere credentials/options and changed the call to the connection constructor.

This is quite useful if you only want to login once and then work without a password, especially
the need to store a password somewhere in clear text is somewhat diminished.

Here is the link to the patch, that added this functionality to RbVmomi
https://github.com/rlane/rbvmomi/pull/22

cheers
    --lars