### PR TITLE
OpenStack servers list options fix

### DIFF
--- a/lib/fog/openstack/models/compute/servers.rb
+++ b/lib/fog/openstack/models/compute/servers.rb
@@ -16,7 +16,13 @@ module Fog
 
         def all(filters_arg = filters)
           filters = filters_arg
-          data = service.list_servers_detail
+          data = service.list_servers_detail(filters)
+          load_response(data, 'servers')
+        end
+
+        def summary(filters_arg = filters)
+          filters = filters_arg
+          data = service.list_servers(filters)
           load_response(data, 'servers')
         end
 

--- a/lib/fog/openstack/requests/compute/list_servers.rb
+++ b/lib/fog/openstack/requests/compute/list_servers.rb
@@ -3,13 +3,16 @@ module Fog
     class OpenStack
       class Real
         def list_servers(options = {})
-          params = Hash.new
-          params['all_tenants'] = 'True' if options[:all_tenants]
+          params = options.dup
+          if params[:all_tenants]
+            params['all_tenants'] = 'True'
+            params.delete(:all_tenants)
+          end
 
           request(
-            :expects  => [200, 203],
-            :method   => 'GET',
-            :path     => 'servers.json',
+            :expects => [200, 203],
+            :method  => 'GET',
+            :path    => 'servers.json',
             :query   => params
           )
         end

--- a/lib/fog/openstack/requests/compute/list_servers_detail.rb
+++ b/lib/fog/openstack/requests/compute/list_servers_detail.rb
@@ -3,14 +3,17 @@ module Fog
     class OpenStack
       class Real
         # Available filters: name, status, image, flavor, changes_since, reservation_id
-        def list_servers_detail(filters = {})
-          params = Hash.new
-          filters[:all_tenants] ? params['all_tenants'] = 'True' : params = filters
+        def list_servers_detail(options = {})
+          params = options.dup
+          if params[:all_tenants]
+            params['all_tenants'] = 'True'
+            params.delete(:all_tenants)
+          end
 
           request(
-            :expects  => [200, 203],
-            :method   => 'GET',
-            :path     => 'servers/detail.json',
+            :expects => [200, 203],
+            :method  => 'GET',
+            :path    => 'servers/detail.json',
             :query   => params
           )
         end


### PR DESCRIPTION
Fixes that options were not passed to list_servers_detail.

Adding summary method.

Fixing how :all_tenants option behaved. It has basically
overridden all other options, so filtering and pagination
didn't work for all_tenants listing.