### PR TITLE
[openstack] move common things among services into core

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
-source "https://rubygems.org"
+source "http://moo-repo.wdf.sap.corp:8080/rubygemsorg"
+source "http://moo-repo.wdf.sap.corp:8080/geminabox/"
+#source "https://rubygems.org"
 
 group :development, :test do
   # This is here because gemspec doesn't support require: false

--- a/gemfiles/Gemfile-edge
+++ b/gemfiles/Gemfile-edge
@@ -1,4 +1,6 @@
-source "https://rubygems.org"
+source "http://moo-repo.wdf.sap.corp:8080/rubygemsorg"
+source "http://moo-repo.wdf.sap.corp:8080/geminabox/"
+#source "https://rubygems.org"
 
 # Shared components
 gem "fog-core", :github => "fog/fog-core"

--- a/gemfiles/Gemfile-ruby-1.8.7
+++ b/gemfiles/Gemfile-ruby-1.8.7
@@ -1,4 +1,6 @@
-source "https://rubygems.org"
+source "http://moo-repo.wdf.sap.corp:8080/rubygemsorg"
+source "http://moo-repo.wdf.sap.corp:8080/geminabox/"
+#source "https://rubygems.org"
 
 gem 'activesupport', '~> 3.2'
 gem 'nokogiri', '~>1.5.11'

--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -1,5 +1,6 @@
 require 'fog/openstack/compute'
 require 'fog/openstack/identity_v2'
+require 'fog/openstack/identity_v3'
 require 'fog/openstack/image'
 require 'fog/openstack/metering'
 require 'fog/openstack/network'

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -329,6 +329,8 @@ module Fog
         def initialize(options={})
           initialize_identity options
 
+          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
+
           @openstack_service_type   = options[:openstack_service_type] || ['nova', 'compute']
           @openstack_service_name   = options[:openstack_service_name]
 

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -324,28 +324,25 @@ module Fog
       end
 
       class Real
-
         include Fog::OpenStack::Core
 
         def initialize(options={})
           initialize_identity options
 
-          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
-          @openstack_service_type  = options[:openstack_service_type] || ['nova', 'compute']
-          @openstack_service_name  = options[:openstack_service_name]
+          @openstack_service_type   = options[:openstack_service_type] || ['nova', 'compute']
+          @openstack_service_name   = options[:openstack_service_name]
 
-          @connection_options = options[:connection_options] || {}
+          @connection_options       = options[:connection_options] || {}
 
-          authenticate_compute
+          authenticate
+
+          unless @path.match(/1\.1|v2/)
+            raise Fog::OpenStack::Errors::ServiceUnavailable.new(
+                    "OpenStack compute binding only supports version 2 (a.k.a. 1.1)")
+          end
 
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -362,7 +359,7 @@ module Fog
           rescue Excon::Errors::Unauthorized => error
             if error.response.body != 'Bad username or password' # token expiration
               @openstack_must_reauthenticate = true
-              authenticate_compute
+              authenticate
               retry
             else # Bad Credentials
               raise error
@@ -385,28 +382,6 @@ module Fog
 
         private
 
-        def authenticate_compute
-          authenticate
-
-          uri = URI.parse(@openstack_management_url)
-          @host   = uri.host
-          @path   = uri.path
-
-          @path.sub!(/\/$/, '')
-          unless @path.match(/1\.1|v2/)
-            raise Fog::OpenStack::Errors::ServiceUnavailable.new(
-                    "OpenStack compute binding only supports version 2 (a.k.a. 1.1)")
-          end
-
-          # Not all implementations have identity service in the catalog
-          if @openstack_identity_public_endpoint || @openstack_management_url
-            @identity_connection = Fog::Core::Connection.new(
-              @openstack_identity_public_endpoint || @openstack_management_url,
-              false, @connection_options)
-          end
-
-          true
-        end
       end
     end
   end

--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -74,8 +74,6 @@ module Fog
           instance_variable_set "@#{openstack_param}".to_sym, value
         end
 
-        @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
-
         @auth_token        ||= options[:openstack_auth_token]
 
         @openstack_auth_uri    = URI.parse(options[:openstack_auth_url])

--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -69,39 +69,21 @@ module Fog
       attr_reader :openstack_project_domain_id
 
       def initialize_identity options
+        # Create @openstack_* instance variables from all :openstack_* options
+        options.select{|x|x.to_s.start_with? 'openstack'}.each do |openstack_param, value|
+          instance_variable_set "@#{openstack_param}".to_sym, value
+        end
+
         @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
-        @openstack_auth_token = options[:openstack_auth_token]
+
         @auth_token        ||= options[:openstack_auth_token]
-        @openstack_identity_public_endpoint = options[:openstack_identity_endpoint]
-
-        @openstack_username = options[:openstack_username]
-        @openstack_userid = options[:openstack_userid]
-
-        @openstack_domain_name = options[:openstack_domain_name]
-        @openstack_user_domain = options[:openstack_user_domain]
-        @openstack_project_domain  = options[:openstack_project_domain]
-        @openstack_domain_id = options[:openstack_domain_id]
-        @openstack_user_domain_id = options[:openstack_user_domain_id]
-        @openstack_project_domain_id  = options[:openstack_project_domain_id]
-
-        @openstack_project_name = options[:openstack_project_name]
-        @openstack_tenant      = options[:openstack_tenant]
-        @openstack_tenant_id   = options[:openstack_tenant_id]
 
         @openstack_auth_uri    = URI.parse(options[:openstack_auth_url])
-
-        @openstack_management_url       = options[:openstack_management_url]
-
         @openstack_must_reauthenticate  = false
-
         @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
-        @openstack_region        = options[:openstack_region]
 
         unless @auth_token
           missing_credentials = Array.new
-          @openstack_api_key = options[:openstack_api_key]
-          @openstack_username = options[:openstack_username]
-          @openstack_userid = options[:openstack_userid]
 
           missing_credentials << :openstack_api_key unless @openstack_api_key
           unless @openstack_username || @openstack_userid
@@ -117,21 +99,14 @@ module Fog
       end
 
       def credentials
-        { :provider                 => 'openstack',
-          :openstack_domain_name    => @openstack_domain_name,
-          :openstack_user_domain    => @openstack_user_domain,
-          :openstack_project_domain => @openstack_project_domain,
-          :openstack_domain_id      => @openstack_domain_id,
-          :openstack_user_domain_id => @openstack_user_domain_id,
-          :openstack_project_domain_id => @openstack_project_domain_id,
+        options =  { :provider => 'openstack',
           :openstack_auth_url       => @openstack_auth_uri.to_s,
           :openstack_auth_token     => @auth_token,
-          :openstack_management_url => @openstack_management_url,
           :openstack_identity_endpoint => @openstack_identity_public_endpoint,
-          :openstack_region         => @openstack_region,
           :current_user             => @current_user,
           :current_user_id          => @current_user_id,
           :current_tenant           => @current_tenant }
+        openstack_options.merge options
       end
 
       def reload
@@ -139,29 +114,23 @@ module Fog
       end
 
       private
+
+      def openstack_options
+        options={}
+        # Create a hash of (:openstack_*, value) of all the @openstack_* instance variables
+        self.instance_variables.select{|x|x.to_s.start_with? '@openstack'}.each do |openstack_param|
+          option_name = openstack_param.to_s[1..-1]
+          options[option_name.to_sym] = instance_variable_get openstack_param
+        end
+        options
+      end
+
       def authenticate
         if !@openstack_management_url || @openstack_must_reauthenticate
-          options = {
-              :openstack_tenant        => @openstack_tenant,
-              :openstack_tenant_id     => @openstack_tenant_id,
-              :openstack_api_key       => @openstack_api_key,
-              :openstack_username      => @openstack_username,
-              :openstack_userid        => @openstack_userid,
-              :openstack_user_domain   => @openstack_user_domain,
-              :openstack_project_domain => @openstack_project_domain,
-              :openstack_user_domain_id => @openstack_user_domain_id,
-              :openstack_project_domain_id => @openstack_project_domain_id,
-              :openstack_domain_name   => @openstack_domain_name,
-              :openstack_project_name  => @openstack_project_name,
-              :openstack_domain_id     => @openstack_domain_id,
-              :openstack_project_id    => @openstack_project_id,
-              :openstack_auth_uri      => @openstack_auth_uri,
-              :openstack_auth_token    => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type  => @openstack_service_type,
-              :openstack_service_name  => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type,
-              :openstack_region        => @openstack_region
-          }
+
+          options = openstack_options
+
+          options[:openstack_auth_token] = @openstack_must_reauthenticate ? nil : @openstack_auth_token
 
           credentials = Fog::OpenStack.authenticate(options, @connection_options)
 
@@ -187,7 +156,8 @@ module Fog
         if @openstack_identity_public_endpoint || @openstack_management_url
           @identity_connection = Fog::Core::Connection.new(
             @openstack_identity_public_endpoint || @openstack_management_url,
-            false, @connection_options)
+            false, @connection_options
+          )
         end
 
         true

--- a/lib/fog/openstack/identity_v2.rb
+++ b/lib/fog/openstack/identity_v2.rb
@@ -7,11 +7,15 @@ module Fog
       class V2 < Fog::Service
 
         requires :openstack_auth_url
-        recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                   :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                   :openstack_api_key, :openstack_username, :openstack_current_user_id,
-                   :current_user, :current_tenant,
-                   :openstack_endpoint_type, :openstack_region
+        recognizes :openstack_auth_token, :openstack_management_url,
+                   :persistent, :openstack_service_type, :openstack_service_name,
+                   :openstack_tenant, :openstack_tenant_id,
+                   :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                   :current_user, :current_tenant, :openstack_region,
+                   :openstack_endpoint_type,
+                   :openstack_project_name, :openstack_project_id,
+                   :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                   :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
         model_path 'fog/openstack/models/identity_v2'
         model :tenant
@@ -166,97 +170,23 @@ module Fog
         end
 
         class Real
-          attr_reader :current_user
-          attr_reader :current_tenant
-          attr_reader :unscoped_token
-
           include Fog::Identity::OpenStack::Common
 
           def initialize(options={})
-            @openstack_auth_token = options[:openstack_auth_token]
+            initialize_identity options
 
-            unless @openstack_auth_token
-              missing_credentials = Array.new
-              @openstack_api_key = options[:openstack_api_key]
-              @openstack_username = options[:openstack_username]
-              @openstack_region = options[:openstack_region]
+            @openstack_service_type   = options[:openstack_service_type] || ['identity']
+            @openstack_service_name   = options[:openstack_service_name]
 
-              missing_credentials << :openstack_api_key unless @openstack_api_key
-              missing_credentials << :openstack_username unless @openstack_username
-              raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-            end
+            @connection_options       = options[:connection_options] || {}
 
-            @openstack_tenant = options[:openstack_tenant]
-            @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
-            @openstack_management_url = options[:openstack_management_url]
-            @openstack_must_reauthenticate = false
-            @openstack_service_type = options[:openstack_service_type] || ['identity']
-            @openstack_service_name = options[:openstack_service_name]
-
-            @connection_options = options[:connection_options] || {}
-
-            @openstack_current_user_id = options[:openstack_current_user_id]
-
-            @openstack_endpoint_type = options[:openstack_endpoint_type] || 'adminURL'
-
-            @current_user = options[:current_user]
-            @current_tenant = options[:current_tenant]
+            @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
 
             authenticate
 
             @persistent = options[:persistent] || false
             @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
           end
-
-          def credentials
-            {:provider => 'openstack',
-             :openstack_auth_url => @openstack_auth_uri.to_s,
-             :openstack_auth_token => @auth_token,
-             :openstack_management_url => @openstack_management_url,
-             :openstack_current_user_id => @openstack_current_user_id,
-             :current_user => @current_user,
-             :current_tenant => @current_tenant}
-          end
-
-          def reload
-            @connection.reset
-          end
-
-          def request(params)
-            retried = false
-            begin
-              response = @connection.request(params.merge({
-                                                              :headers => {
-                                                                  'Content-Type' => 'application/json',
-                                                                  'Accept' => 'application/json',
-                                                                  'X-Auth-Token' => @auth_token
-                                                              }.merge!(params[:headers] || {}),
-                                                              :path => "#{@path}/#{params[:path]}" #,
-                                                          }))
-            rescue Excon::Errors::Unauthorized => error
-              raise if retried
-              retried = true
-
-              @openstack_must_reauthenticate = true
-              authenticate
-              retry
-            rescue Excon::Errors::HTTPStatusError => error
-              raise case error
-                      when Excon::Errors::NotFound
-                        Fog::Identity::OpenStack::NotFound.slurp(error)
-                      else
-                        error
-                    end
-            end
-            unless response.body.empty?
-              response.body = Fog::JSON.decode(response.body)
-            end
-            response
-          end
-
-          private
-
-
         end
       end
     end

--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -6,10 +6,15 @@ module Fog
       SUPPORTED_VERSIONS = /v1(\.(0|1))*/
 
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant, :openstack_endpoint_type, :openstack_region
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/image'
 
@@ -89,53 +94,28 @@ module Fog
       end
 
       class Real
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          initialize_identity options
 
-          unless @openstack_auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type           = options[:openstack_service_type] || ['image']
+          @openstack_service_name           = options[:openstack_service_name]
+          @openstack_endpoint_type          = options[:openstack_endpoint_type] || 'adminURL'
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['image']
-          @openstack_service_name         = options[:openstack_service_name]
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
-          @openstack_region               = options[:openstack_region]
-
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options               = options[:connection_options] || {}
 
           authenticate
 
+          unless @path.match(SUPPORTED_VERSIONS)
+            @path = "/" + Fog::OpenStack.get_supported_version(SUPPORTED_VERSIONS,
+                                                               @openstack_management_uri,
+                                                               @auth_token,
+                                                               @connection_options)
+          end
+
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -171,47 +151,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_region   => @openstack_region,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          unless @path.match(SUPPORTED_VERSIONS)
-            @path = "/" + Fog::OpenStack.get_supported_version(SUPPORTED_VERSIONS,
-                                                               uri,
-                                                               @auth_token,
-                                                               @connection_options)
-          end
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
   end

--- a/lib/fog/openstack/metering.rb
+++ b/lib/fog/openstack/metering.rb
@@ -4,11 +4,15 @@ module Fog
   module Metering
     class OpenStack < Fog::Service
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant,
-                 :openstack_endpoint_type
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/metering'
 
@@ -81,52 +85,21 @@ module Fog
       end
 
       class Real
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          initialize_identity options
 
-          unless @openstack_auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type           = options[:openstack_service_type] || ['metering']
+          @openstack_service_name           = options[:openstack_service_name]
+          @openstack_endpoint_type          = options[:openstack_endpoint_type] || 'adminURL'
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['metering']
-          @openstack_service_name         = options[:openstack_service_name]
-
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options               = options[:connection_options] || {}
 
           authenticate
 
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -165,40 +138,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
   end

--- a/lib/fog/openstack/models/identity_v3/project.rb
+++ b/lib/fog/openstack/models/identity_v3/project.rb
@@ -13,6 +13,8 @@ module Fog
           attribute :name
           attribute :links
           attribute :parent_id
+          attribute :subtree
+          attribute :parents
 
           def to_s
             self.name
@@ -87,13 +89,6 @@ module Fog
             service.revoke_project_group_role(self.id, group_id, role_id)
           end
 
-          def subtree
-            @attributes['subtree']
-          end
-
-          def parents
-            @attributes['parents']
-          end
         end
       end
     end

--- a/lib/fog/openstack/models/identity_v3/projects.rb
+++ b/lib/fog/openstack/models/identity_v3/projects.rb
@@ -23,10 +23,20 @@ module Fog
             cached_project = self.find { |project| project.id == id } if options.empty?
             return cached_project if cached_project
             project_hash = service.get_project(id, options).body['project']
-            Fog::Identity::OpenStack::V3::Project.new(
-                project_hash.merge(:service => service))
+            top_project = project_from_hash(project_hash, service)
+            if options.include? :subtree_as_list
+              top_project.subtree.map! {|proj_hash| project_from_hash(proj_hash['project'], service)}
+            end
+            if options.include? :parents_as_list
+              top_project.parents.map! {|proj_hash| project_from_hash(proj_hash['project'], service)}
+            end
+            return top_project
           end
 
+          private
+          def project_from_hash(project_hash, service)
+            Fog::Identity::OpenStack::V3::Project.new(project_hash.merge(:service => service))
+          end
         end
       end
     end

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -6,13 +6,15 @@ module Fog
       SUPPORTED_VERSIONS = /v2(\.0)*/
 
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_tenant_id,
-                 :openstack_api_key, :openstack_username, :openstack_endpoint_type,
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region,
-                 :openstack_project_name,
-                 :openstack_project_domain, :openstack_user_domain
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       ## MODELS
       #
@@ -228,13 +230,12 @@ module Fog
         include Fog::OpenStack::Core
 
         def initialize(options={})
-
           initialize_identity options
 
-          @openstack_service_type         = options[:openstack_service_type] || ['network']
-          @openstack_service_name         = options[:openstack_service_name]
+          @openstack_service_type = options[:openstack_service_type] || ['network']
+          @openstack_service_name = options[:openstack_service_name]
 
-          @connection_options = options[:connection_options] || {}
+          @connection_options     = options[:connection_options] || {}
 
           authenticate
 
@@ -250,9 +251,6 @@ module Fog
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
         end
 
-        def reload
-          @connection.reset
-        end
 
         def request(params)
           begin

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -6,10 +6,13 @@ module Fog
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url,
                  :persistent, :openstack_service_type, :openstack_service_name,
-                 :openstack_tenant,
+                 :openstack_tenant, :openstack_tenant_id,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region,
-                 :openstack_endpoint_type
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/orchestration'
       model       :stack
@@ -124,60 +127,20 @@ module Fog
       end
 
       class Real
-        attr_reader :auth_token
-        attr_reader :auth_token_expiration
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
-          @auth_token        = options[:openstack_auth_token]
-          @openstack_identity_public_endpoint = options[:openstack_identity_endpoint]
+          initialize_identity options
 
-          unless @auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type           = options[:openstack_service_type] || ['orchestration']
+          @openstack_service_name           = options[:openstack_service_name]
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant     = options[:openstack_tenant]
-          @openstack_auth_uri   = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type = options[:openstack_service_type] || ['orchestration']
-          @openstack_service_name = options[:openstack_service_name]
-          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
-          @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
-          @openstack_region      = options[:openstack_region]
-
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options               = options[:connection_options] || {}
 
           authenticate
 
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :openstack_identity_endpoint => @openstack_identity_public_endpoint,
-            :openstack_region         => @openstack_region,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -219,51 +182,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_api_key    => @openstack_api_key,
-              :openstack_username   => @openstack_username,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @auth_token,
-              :openstack_auth_uri   => @openstack_auth_uri,
-              :openstack_region     => @openstack_region,
-              :openstack_tenant     => @openstack_tenant,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_identity_service_type => @openstack_identity_service_type,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token               = credentials[:token]
-            @auth_token_expiration    = credentials[:expires]
-            @openstack_management_url = credentials[:server_management_url]
-            @openstack_identity_public_endpoint  = credentials[:identity_public_endpoint]
-          end
-
-          uri = URI.parse(@openstack_management_url)
-          @host   = uri.host
-          @path, @tenant_id = uri.path.scan(/(\/.*)\/(.*)/).flatten
-
-          @path.sub!(/\/$/, '')
-
-          @port   = uri.port
-          @scheme = uri.scheme
-
-          # Not all implementations have identity service in the catalog
-          if @openstack_identity_public_endpoint || @openstack_management_url
-            @identity_connection = Fog::Core::Connection.new(
-              @openstack_identity_public_endpoint || @openstack_management_url,
-              false, @connection_options)
-          end
-
-          true
-        end
       end
     end
   end

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -132,6 +132,8 @@ module Fog
         def initialize(options={})
           initialize_identity options
 
+          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
+
           @openstack_service_type           = options[:openstack_service_type] || ['orchestration']
           @openstack_service_name           = options[:openstack_service_name]
 

--- a/lib/fog/openstack/planning.rb
+++ b/lib/fog/openstack/planning.rb
@@ -6,10 +6,15 @@ module Fog
       SUPPORTED_VERSIONS = /v2/
 
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant, :openstack_endpoint_type, :openstack_region
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       ## MODELS
       #
@@ -89,53 +94,25 @@ module Fog
       end
 
       class Real
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          initialize_identity options
 
-          unless @openstack_auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type           = options[:openstack_service_type] || ['management'] # currently Tuskar is configured as 'management' service in Keystone
+          @openstack_service_name           = options[:openstack_service_name]
+          @openstack_endpoint_type          = options[:openstack_endpoint_type] || 'adminURL'
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['management'] # currently Tuskar is configured as 'management' service in Keystone
-          @openstack_service_name         = options[:openstack_service_name]
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
-          @openstack_region               = options[:openstack_region]
-
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options               = options[:connection_options] || {}
 
           authenticate
 
+          unless @path.match(SUPPORTED_VERSIONS)
+            @path = "/v2"
+          end
+
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -171,44 +148,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_region   => @openstack_region,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          unless @path.match(SUPPORTED_VERSIONS)
-            @path = "/v2"
-          end
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
 
@@ -232,4 +171,3 @@ module Fog
     end
   end
 end
-

--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -5,11 +5,15 @@ module Fog
     class OpenStack < Fog::Service
       requires   :openstack_auth_url, :openstack_username,
                  :openstack_api_key
-      recognizes :persistent, :openstack_service_name,
-                 :openstack_service_type, :openstack_tenant,
-                 :openstack_region, :openstack_temp_url_key,
-                 :openstack_endpoint_type, :openstack_auth_token,
-                 :openstack_management_url
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/storage'
       model       :directory
@@ -76,28 +80,19 @@ module Fog
       end
 
       class Real
+        include Fog::OpenStack::Core
+
         def initialize(options={})
-          @openstack_api_key = options[:openstack_api_key]
-          @openstack_username = options[:openstack_username]
-          @openstack_auth_url = options[:openstack_auth_url]
-          @openstack_auth_token = options[:openstack_auth_token]
-          @openstack_storage_url = options[:openstack_storage_url]
-          @openstack_must_reauthenticate = false
-          @openstack_service_type = options[:openstack_service_type] || ['object-store']
-          @openstack_service_name = options[:openstack_service_name]
-          @openstack_region       = options[:openstack_region]
-          @openstack_tenant       = options[:openstack_tenant]
-          @connection_options     = options[:connection_options] || {}
-          @openstack_temp_url_key = options[:openstack_temp_url_key]
-          @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
-          @openstack_management_url = options[:openstack_management_url]
+          initialize_identity options
+
+          @openstack_service_type           = options[:openstack_service_type] || ['object-store']
+          @openstack_service_name           = options[:openstack_service_name]
+
+          @connection_options               = options[:connection_options] || {}
+
           authenticate
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def reload
-          @connection.reset
         end
 
         # Change the current account while re-using the auth token.
@@ -180,40 +175,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => URI.parse(@openstack_auth_url),
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_region => @openstack_region,
-              :openstack_tenant => @openstack_tenant,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
   end

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -4,11 +4,15 @@ module Fog
   module Volume
     class OpenStack < Fog::Service
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant,
-                 :openstack_endpoint_type, :openstack_region
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/volume'
 
@@ -114,53 +118,21 @@ module Fog
       end
 
       class Real
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          initialize_identity options
 
-          unless @openstack_auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type   = options[:openstack_service_type] || ['volume']
+          @openstack_service_name   = options[:openstack_service_name]
+          @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['volume']
-          @openstack_service_name         = options[:openstack_service_name]
-          @openstack_region               = options[:openstack_region]
-
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options       = options[:connection_options] || {}
 
           authenticate
 
-          @persistent = options[:persistent] || false
+          @persistent                       = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -197,41 +169,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_region   => @openstack_region,
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
   end

--- a/spec/fog/openstack/identity_v3/idv3_project_hier_crud_list.yml
+++ b/spec/fog/openstack/identity_v3/idv3_project_hier_crud_list.yml
@@ -14,20 +14,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c884f35b-9592-4e25-bd99-023d91e3980d
+      - req-6a9fcfa9-4368-4fa2-82f0-61f16dedb158
       Content-Length:
       - '317'
       Content-Type:
@@ -39,7 +39,7 @@ http_interactions:
         on Identity API v2.", "name": "Default", "id": "default"}], "links": {"self":
         "http://devstack.openstack.stack:35357/v3/domains", "previous": null, "next": null}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
@@ -54,37 +54,37 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-5193098e-4561-41e2-bbb0-6bfc67017797
+      - req-c9af88df-0f52-4f8f-a318-492ff1bba5e5
       Content-Length:
       - '251'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
-        "enabled": true, "id": "27b9743d10594dd9964002f153955676", "parent_id": null,
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
+        "enabled": true, "id": "edd3bec6a30847349d69216ed4b3e0b4", "parent_id": null,
         "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-baz67","parent_id":"27b9743d10594dd9964002f153955676"}}'
+      string: ! '{"project":{"name":"p-baz67","parent_id":"edd3bec6a30847349d69216ed4b3e0b4"}}'
     headers:
       User-Agent:
       - fog-core/1.32.0
@@ -93,31 +93,31 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-28665661-d06c-4e17-93b9-c25ab699b63e
+      - req-14ed4a49-b23f-4d5d-822e-3241a9a28b9f
       Content-Length:
       - '278'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25"},
-        "enabled": true, "id": "d949713f4b1845ad84b6c1e819db2c25", "parent_id": "27b9743d10594dd9964002f153955676",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0"},
+        "enabled": true, "id": "570b1075f2a7470ea2b2f009f440b7b0", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-baz67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
@@ -132,20 +132,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-bc49000f-0dae-47b1-a310-1f400179d1c0
+      - req-8517afe6-f361-4004-9a01-411d067f1a92
       Content-Length:
       - '388'
       Content-Type:
@@ -154,17 +154,17 @@ http_interactions:
       encoding: US-ASCII
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
         "previous": null, "next": null}, "projects": [{"description": "", "links":
-        {"self": "http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25"},
-        "enabled": true, "id": "d949713f4b1845ad84b6c1e819db2c25", "parent_id": "27b9743d10594dd9964002f153955676",
+        {"self": "http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0"},
+        "enabled": true, "id": "570b1075f2a7470ea2b2f009f440b7b0", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-baz67"}]}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-boo67","parent_id":"27b9743d10594dd9964002f153955676"}}'
+      string: ! '{"project":{"name":"p-boo67","parent_id":"edd3bec6a30847349d69216ed4b3e0b4"}}'
     headers:
       User-Agent:
       - fog-core/1.32.0
@@ -173,37 +173,37 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a20fe500-31fa-4ef9-8100-65df6816f0a4
+      - req-2229c28f-94de-4fdd-b839-e8e23b68c2d3
       Content-Length:
       - '278'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63"},
-        "enabled": true, "id": "974874f812174f629268f28074742b63", "parent_id": "27b9743d10594dd9964002f153955676",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6"},
+        "enabled": true, "id": "8e1bc4fbfd6c47fea94d0e6ebad05be6", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-boo67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:00 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/projects
     body:
       encoding: UTF-8
-      string: ! '{"project":{"name":"p-booboo67","parent_id":"974874f812174f629268f28074742b63"}}'
+      string: ! '{"project":{"name":"p-booboo67","parent_id":"8e1bc4fbfd6c47fea94d0e6ebad05be6"}}'
     headers:
       User-Agent:
       - fog-core/1.32.0
@@ -212,31 +212,31 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 11:03:53 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-551dd25b-e520-4781-b85c-c021e83fb0a2
+      - req-d36dac0b-3ee8-497f-90b6-ea7ee434bca5
       Content-Length:
       - '281'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
-        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
         "domain_id": "default", "name": "p-booboo67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: post
     uri: http://devstack.openstack.stack:35357/v3/roles
@@ -251,34 +251,34 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 201
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:00 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e97893c6-725d-4e60-81e0-5f1144cd0728
+      - req-105f752a-0c7a-492a-9080-e8bf5767fa55
       Content-Length:
       - '167'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"role": {"id": "b4a5f86a22164d4aa935d1098657d2d8", "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/roles/b4a5f86a22164d4aa935d1098657d2d8"},
+      string: ! '{"role": {"id": "9eeae75b331946dd907f16d3dccb916a", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/roles/9eeae75b331946dd907f16d3dccb916a"},
         "name": "r-project67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:14 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
     body:
       encoding: US-ASCII
       string: ''
@@ -290,30 +290,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e39795b5-1c84-4bf8-9987-4b7e571d9f72
+      - req-895af830-2d83-433d-ba23-8ab43a67483a
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
     body:
       encoding: US-ASCII
       string: ''
@@ -325,30 +325,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-968410c6-0f59-4a3d-a439-472cba337728
+      - req-7f126391-17af-4ca1-a348-fe4280c57450
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
     body:
       encoding: US-ASCII
       string: ''
@@ -360,30 +360,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-8f83c542-ffe3-4442-ae84-39fd3c1728fd
+      - req-91451272-cef2-467c-80aa-5de40998c2f2
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: put
-    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce/users/aa9f25defa6d4cafb48466df83106065/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
     body:
       encoding: US-ASCII
       string: ''
@@ -395,30 +395,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-abaa07cb-b7fd-400c-871d-647a170969a4
+      - req-1cdb03bc-58c5-4d04-b585-19e44ce2d32f
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676?subtree_as_ids
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4?subtree_as_ids
     body:
       encoding: US-ASCII
       string: ''
@@ -430,35 +430,35 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-e39ce9d1-c019-488f-8071-cee4c95d08fd
+      - req-0a1a824a-364e-4afc-ba89-91c256128885
       Content-Length:
       - '386'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
-        "enabled": true, "subtree": {"d949713f4b1845ad84b6c1e819db2c25": null, "974874f812174f629268f28074742b63":
-        {"89344733d8204c68a027ba2d596d7bce": null}}, "id": "27b9743d10594dd9964002f153955676",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
+        "enabled": true, "subtree": {"570b1075f2a7470ea2b2f009f440b7b0": null, "8e1bc4fbfd6c47fea94d0e6ebad05be6":
+        {"15a7ecafe8c44fe18cb9b3ca009f8259": null}}, "id": "edd3bec6a30847349d69216ed4b3e0b4",
         "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676?subtree_as_list
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4?subtree_as_list
     body:
       encoding: US-ASCII
       string: ''
@@ -470,43 +470,82 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-fa807474-2f6a-428f-a8c1-5b61cc740408
+      - req-b6f5c89d-e9bb-4ab9-9ea7-7ac8c2959b37
       Content-Length:
       - '1107'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
         "enabled": true, "subtree": [{"project": {"description": "", "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63"},
-        "enabled": true, "id": "974874f812174f629268f28074742b63", "parent_id": "27b9743d10594dd9964002f153955676",
-        "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25"},
-        "enabled": true, "id": "d949713f4b1845ad84b6c1e819db2c25", "parent_id": "27b9743d10594dd9964002f153955676",
+        "http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0"},
+        "enabled": true, "id": "570b1075f2a7470ea2b2f009f440b7b0", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-baz67"}}, {"project": {"description": "",
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
-        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
-        "domain_id": "default", "name": "p-booboo67"}}], "id": "27b9743d10594dd9964002f153955676",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6"},
+        "enabled": true, "id": "8e1bc4fbfd6c47fea94d0e6ebad05be6", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
+        "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "domain_id": "default", "name": "p-booboo67"}}], "id": "edd3bec6a30847349d69216ed4b3e0b4",
         "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
-    method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce?parents_as_ids
+    method: post
+    uri: http://devstack.openstack.stack:35357/v3/projects
+    body:
+      encoding: UTF-8
+      string: ! '{"project":{"name":"p-fooboo67","parent_id":"8e1bc4fbfd6c47fea94d0e6ebad05be6"}}'
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:54 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-7d289ea5-869d-4c95-aa82-194ac4cb805d
+      Content-Length:
+      - '281'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a288e7f1645e442da84232108c7e3ec9"},
+        "enabled": true, "id": "a288e7f1645e442da84232108c7e3ec9", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "domain_id": "default", "name": "p-fooboo67"}}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
+- request:
+    method: put
+    uri: http://devstack.openstack.stack:35357/v3/projects/a288e7f1645e442da84232108c7e3ec9/users/aa9f25defa6d4cafb48466df83106065/roles/9eeae75b331946dd907f16d3dccb916a
     body:
       encoding: US-ASCII
       string: ''
@@ -518,35 +557,121 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:54 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-9a87ff8d-26a2-43fb-ad63-cf03e2324854
+      Content-Length:
+      - '0'
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4?subtree_as_list
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-23901b5a-89dc-47a4-a0cb-7b0bd6cd50e4
+      - req-bee9ca26-a2e6-401b-95da-041161d09bde
+      Content-Length:
+      - '1390'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
+        "enabled": true, "subtree": [{"project": {"description": "", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0"},
+        "enabled": true, "id": "570b1075f2a7470ea2b2f009f440b7b0", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
+        "domain_id": "default", "name": "p-baz67"}}, {"project": {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6"},
+        "enabled": true, "id": "8e1bc4fbfd6c47fea94d0e6ebad05be6", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
+        "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "domain_id": "default", "name": "p-booboo67"}}, {"project": {"description":
+        "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/a288e7f1645e442da84232108c7e3ec9"},
+        "enabled": true, "id": "a288e7f1645e442da84232108c7e3ec9", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "domain_id": "default", "name": "p-fooboo67"}}], "id": "edd3bec6a30847349d69216ed4b3e0b4",
+        "parent_id": null, "domain_id": "default", "name": "p-foobar67"}}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259?parents_as_ids
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:54 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-00f313f0-b3e0-4039-b246-cb2bd06dd51f
       Content-Length:
       - '374'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
-        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
-        "parents": {"974874f812174f629268f28074742b63": {"27b9743d10594dd9964002f153955676":
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "parents": {"8e1bc4fbfd6c47fea94d0e6ebad05be6": {"edd3bec6a30847349d69216ed4b3e0b4":
         null}}, "domain_id": "default", "name": "p-booboo67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce?parents_as_list
+    uri: http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259?parents_as_list
     body:
       encoding: US-ASCII
       string: ''
@@ -558,40 +683,40 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:54 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-aab4f805-bea4-4776-a58b-d77281e72228
+      - req-343c722a-65c6-4427-8782-b370cca8be6c
       Content-Length:
       - '827'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce"},
-        "enabled": true, "id": "89344733d8204c68a027ba2d596d7bce", "parent_id": "974874f812174f629268f28074742b63",
-        "parents": [{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63"},
-        "enabled": true, "id": "974874f812174f629268f28074742b63", "parent_id": "27b9743d10594dd9964002f153955676",
+      string: ! '{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259"},
+        "enabled": true, "id": "15a7ecafe8c44fe18cb9b3ca009f8259", "parent_id": "8e1bc4fbfd6c47fea94d0e6ebad05be6",
+        "parents": [{"project": {"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6"},
+        "enabled": true, "id": "8e1bc4fbfd6c47fea94d0e6ebad05be6", "parent_id": "edd3bec6a30847349d69216ed4b3e0b4",
         "domain_id": "default", "name": "p-boo67"}}, {"project": {"description": "",
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676"},
-        "enabled": true, "id": "27b9743d10594dd9964002f153955676", "parent_id": null,
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4"},
+        "enabled": true, "id": "edd3bec6a30847349d69216ed4b3e0b4", "parent_id": null,
         "domain_id": "default", "name": "p-foobar67"}}], "domain_id": "default", "name":
         "p-booboo67"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:15 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/89344733d8204c68a027ba2d596d7bce
+    uri: http://devstack.openstack.stack:35357/v3/projects/a288e7f1645e442da84232108c7e3ec9
     body:
       encoding: US-ASCII
       string: ''
@@ -603,30 +728,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-468de713-6f07-4153-963d-ad7b24202eaf
+      - req-3e964bce-b106-4edf-bcdc-6da3d74f7f7c
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/974874f812174f629268f28074742b63
+    uri: http://devstack.openstack.stack:35357/v3/projects/15a7ecafe8c44fe18cb9b3ca009f8259
     body:
       encoding: US-ASCII
       string: ''
@@ -638,30 +763,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-a7546023-ce38-4ae0-943a-adc864ffd917
+      - req-e0cd202d-c96f-4b82-b9e9-29650111b15e
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:01 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/d949713f4b1845ad84b6c1e819db2c25
+    uri: http://devstack.openstack.stack:35357/v3/projects/8e1bc4fbfd6c47fea94d0e6ebad05be6
     body:
       encoding: US-ASCII
       string: ''
@@ -673,30 +798,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:01 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-016aa0fc-eb88-4f21-8dd2-1ae7c5539afa
+      - req-70eb87e6-a48c-4b76-8aa7-f2924b1aadc6
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676
+    uri: http://devstack.openstack.stack:35357/v3/projects/570b1075f2a7470ea2b2f009f440b7b0
     body:
       encoding: US-ASCII
       string: ''
@@ -708,30 +833,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-c1600693-087c-432c-ae40-beb4702f0158
+      - req-997cf019-3a7a-4185-82bb-34a47e38bc21
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: delete
-    uri: http://devstack.openstack.stack:35357/v3/roles/b4a5f86a22164d4aa935d1098657d2d8
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4
     body:
       encoding: US-ASCII
       string: ''
@@ -743,27 +868,62 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 204
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-59dbcb33-e07a-4595-a175-e0a6c2c43eec
+      - req-db82b42c-b459-4e5a-9bd8-cb5243f01213
       Content-Length:
       - '0'
     body:
       encoding: US-ASCII
       string: ''
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
+- request:
+    method: delete
+    uri: http://devstack.openstack.stack:35357/v3/roles/9eeae75b331946dd907f16d3dccb916a
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 204
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:55 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-f3093cb8-4a6e-4510-8121-eb8829aa78e4
+      Content-Length:
+      - '0'
+    body:
+      encoding: US-ASCII
+      string: ''
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects
@@ -778,45 +938,44 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-ffdf7c7c-f25d-45e8-a5a6-629c9d3aea17
+      - req-11d93c10-819b-4af0-955c-728e195b9fdc
       Content-Length:
-      - '1070'
+      - '1062'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects", "previous":
-        null, "next": null}, "projects": [{"description": null, "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/projects/123ac695d4db400a9001b91bb3b8aa46"},
-        "enabled": true, "id": "123ac695d4db400a9001b91bb3b8aa46", "parent_id": null,
-        "domain_id": "default", "name": "admin"}, {"description": null, "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/projects/3e06db1f2ff64d219d27a3f6858bf602"},
-        "enabled": true, "id": "3e06db1f2ff64d219d27a3f6858bf602", "parent_id": null,
-        "domain_id": "default", "name": "invisible_to_admin"}, {"description": null,
-        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/3ed7ee0512b641d3bb1fe17fc86d8bff"},
-        "enabled": true, "id": "3ed7ee0512b641d3bb1fe17fc86d8bff", "parent_id": null,
-        "domain_id": "default", "name": "demo"}, {"description": null, "links": {"self":
-        "http://devstack.openstack.stack:35357/v3/projects/956fbf1d663b4d6fa9d26c4d78de113f"},
-        "enabled": true, "id": "956fbf1d663b4d6fa9d26c4d78de113f", "parent_id": null,
+        null, "next": null}, "projects": [{"description": "", "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/287f46e0cc294b8cb0c276dd71b8710f"},
+        "enabled": true, "id": "287f46e0cc294b8cb0c276dd71b8710f", "parent_id": null,
+        "domain_id": "default", "name": "demo"}, {"description": "", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/projects/4bd6ed0a80b7465a8b25f4d7df1236ea"},
+        "enabled": true, "id": "4bd6ed0a80b7465a8b25f4d7df1236ea", "parent_id": null,
+        "domain_id": "default", "name": "invisible_to_admin"}, {"description": "",
+        "links": {"self": "http://devstack.openstack.stack:35357/v3/projects/711f0a64ef5046c084ce904b4445d119"},
+        "enabled": true, "id": "711f0a64ef5046c084ce904b4445d119", "parent_id": null,
+        "domain_id": "default", "name": "admin"}, {"description": "", "links": {"self":
+        "http://devstack.openstack.stack:35357/v3/projects/a9088d7853b843318cb026dc3373c174"},
+        "enabled": true, "id": "a9088d7853b843318cb026dc3373c174", "parent_id": null,
         "domain_id": "default", "name": "service"}]}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects/27b9743d10594dd9964002f153955676
+    uri: http://devstack.openstack.stack:35357/v3/projects/edd3bec6a30847349d69216ed4b3e0b4
     body:
       encoding: US-ASCII
       string: ''
@@ -828,144 +987,30 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 404
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-1a90473b-05bc-4f70-8591-9aa92aed3618
+      - req-015abdc2-1a35-43d3-bc65-c63f5f2dc272
       Content-Length:
       - '117'
       Content-Type:
       - application/json
     body:
       encoding: US-ASCII
-      string: ! '{"error": {"message": "Could not find project: 27b9743d10594dd9964002f153955676",
+      string: ! '{"error": {"message": "Could not find project: edd3bec6a30847349d69216ed4b3e0b4",
         "code": 404, "title": "Not Found"}}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
-- request:
-    method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.32.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-260b9b9e-fb36-44fa-ad7c-dcac475c20a1
-      Content-Length:
-      - '126'
-      Content-Type:
-      - application/json
-    body:
-      encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67",
-        "previous": null, "next": null}, "projects": []}'
-    http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
-- request:
-    method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.32.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-adc5d87a-9766-4bb7-8858-25765726858d
-      Content-Length:
-      - '123'
-      Content-Type:
-      - application/json
-    body:
-      encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
-        "previous": null, "next": null}, "projects": []}'
-    http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
-- request:
-    method: get
-    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-boo67
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - fog-core/1.32.0
-      Content-Type:
-      - application/json
-      Accept:
-      - application/json
-      X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
-  response:
-    status:
-      code: 200
-      message: ''
-    headers:
-      Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
-      Server:
-      - Apache/2.4.7 (Ubuntu)
-      Vary:
-      - X-Auth-Token
-      X-Openstack-Request-Id:
-      - req-4ebe3652-91bf-444c-8b61-a23898de1d5f
-      Content-Length:
-      - '123'
-      Content-Type:
-      - application/json
-    body:
-      encoding: US-ASCII
-      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-boo67",
-        "previous": null, "next": null}, "projects": []}'
-    http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
 - request:
     method: get
     uri: http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67
@@ -980,20 +1025,20 @@ http_interactions:
       Accept:
       - application/json
       X-Auth-Token:
-      - 269086a06d764f6f93d22efe162cfd36
+      - ea1e9622dc8f4802a5f26955ccd8763f
   response:
     status:
       code: 200
       message: ''
     headers:
       Date:
-      - Thu, 16 Jul 2015 16:05:02 GMT
+      - Fri, 24 Jul 2015 11:03:55 GMT
       Server:
       - Apache/2.4.7 (Ubuntu)
       Vary:
       - X-Auth-Token
       X-Openstack-Request-Id:
-      - req-03715b2e-2dd1-4716-9670-d475f4d37857
+      - req-f02cc3be-a027-491d-9e8a-bb9228e0d4e1
       Content-Length:
       - '126'
       Content-Type:
@@ -1003,5 +1048,347 @@ http_interactions:
       string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67",
         "previous": null, "next": null}, "projects": []}'
     http_version: 
-  recorded_at: Thu, 16 Jul 2015 16:05:02 GMT
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:55 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-83df3490-b901-4889-a900-a18e9a12c09f
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-booboo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-fooboo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-6e0fad29-cbf5-43ca-9e78-2df6570346bc
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-fooboo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:16 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-fooboo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-28156923-6d90-46e3-876b-85096a8e4ad5
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-fooboo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-boo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-18d78997-d6be-4192-9354-329878be50ac
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-boo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-boo67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-02cd3c7c-ca92-4bd3-9f97-e76d374c007f
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-boo67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-8e20c713-9427-47a0-ba06-677f28a34e90
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-baz67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-4e575274-0e98-4415-be62-29103606464e
+      Content-Length:
+      - '123'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-baz67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-5e735cdd-d6fb-4228-8925-524f6e8a6ba9
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
+- request:
+    method: get
+    uri: http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - fog-core/1.32.0
+      Content-Type:
+      - application/json
+      Accept:
+      - application/json
+      X-Auth-Token:
+      - ea1e9622dc8f4802a5f26955ccd8763f
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Fri, 24 Jul 2015 11:03:56 GMT
+      Server:
+      - Apache/2.4.7 (Ubuntu)
+      Vary:
+      - X-Auth-Token
+      X-Openstack-Request-Id:
+      - req-7405bdf6-3564-41ac-adc5-bec643ded99e
+      Content-Length:
+      - '126'
+      Content-Type:
+      - application/json
+    body:
+      encoding: US-ASCII
+      string: ! '{"links": {"self": "http://devstack.openstack.stack:35357/v3/projects?name=p-foobar67",
+        "previous": null, "next": null}, "projects": []}'
+    http_version: 
+  recorded_at: Fri, 24 Jul 2015 11:04:17 GMT
 recorded_with: VCR 2.9.3

--- a/spec/fog/openstack/identity_v3_spec.rb
+++ b/spec/fog/openstack/identity_v3_spec.rb
@@ -649,8 +649,15 @@ RSpec.describe Fog::Identity::OpenStack::V3 do
         # Get the children of foobar, as a list of objects
         foobar_kids = @service.projects.find_by_id(foobar_id, :subtree_as_list).subtree
         expect(foobar_kids.length).to eq 3
-        expect([foobar_kids[0]['project']['id'],foobar_kids[1]['project']['id'],foobar_kids[2]['project']['id']].sort
+        expect([foobar_kids[0].id,foobar_kids[1].id,foobar_kids[2].id].sort
           ).to eq [baz_id, boo_id, booboo_id].sort
+
+        # Create a another sub-project of boo called fooboo and check that it appears in the parent's subtree
+        fooboo_project = @service.projects.create(:name => 'p-fooboo67', :parent_id => boo_id)
+        fooboo_id = fooboo_project.id
+        fooboo_project.grant_role_to_user(prj_role.id, @service.current_user_id)
+        foobar_new_kids = @service.projects.find_by_id(foobar_id, :subtree_as_list).subtree
+        expect(foobar_new_kids.length).to eq 4
 
         # Get the parents of booboo, as a tree of IDs
         booboo_parents = @service.projects.find_by_id(booboo_id, :parents_as_ids).parents
@@ -664,10 +671,10 @@ RSpec.describe Fog::Identity::OpenStack::V3 do
         # Get the parents of booboo, as a list of objects
         booboo_parents = @service.projects.find_by_id(booboo_id, :parents_as_list).parents
         expect(booboo_parents.length).to eq 2
-        expect([booboo_parents[0]['project']['id'],booboo_parents[1]['project']['id']].sort
-          ).to eq [foobar_id, boo_id].sort
+        expect([booboo_parents[0].id,booboo_parents[1].id].sort).to eq [foobar_id, boo_id].sort
       ensure
         # Delete the projects
+        fooboo_project.destroy if fooboo_project
         booboo_project.destroy if booboo_project
         boo_project.destroy if boo_project
         baz_project.destroy if baz_project
@@ -675,8 +682,10 @@ RSpec.describe Fog::Identity::OpenStack::V3 do
         prj_role = @service.roles.all(:name => 'r-project67').first unless prj_role
         prj_role.destroy if prj_role
         # Check that the deletion worked
-        expect { @service.projects.find_by_id foobar_id }.to raise_error(Fog::Identity::OpenStack::NotFound)
-        ['p-foobar67', 'p-baz67', 'p-boo67', 'p-booboo67'].each do |project_name|
+        expect { @service.projects.find_by_id foobar_id }.to raise_error(Fog::Identity::OpenStack::NotFound) if foobar_id
+        ['p-booboo67', 'p-fooboo67', 'p-boo67', 'p-baz67', 'p-foobar67'].each do |project_name|
+          prj = @service.projects.all(:name => project_name).first
+          prj.destroy if prj
           expect(@service.projects.all(:name => project_name).length).to be 0
         end
       end


### PR DESCRIPTION
I noticed, that only compute and network use the core method `initialize_identity`, which enabled this services to be used with a v3 keystone - the other did not work.

Additionally I added the v3 parameters to the recognized parameters for all services and
instead of duplicating a lot of code, I took the chance to reuse the common stuff from core.