### PR TITLE
OpenStack compute add shelve related actions

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -96,6 +96,9 @@ module Fog
       request :reset_server_state
       request :add_security_group
       request :remove_security_group
+      request :shelve_server
+      request :unshelve_server
+      request :shelve_offload_server
 
       # Server Extenstions
       request :get_console_output

--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -257,6 +257,21 @@ module Fog
           end
         end
 
+        def shelve
+          requires :id
+          service.shelve_server(id)
+        end
+
+        def unshelve
+          requires :id
+          service.unshelve_server(id)
+        end
+
+        def shelve_offload
+          requires :id
+          service.shelve_offload_server(id)
+        end
+
         def create_image(name, metadata={})
           requires :id
           service.create_image(id, name, metadata)

--- a/lib/fog/openstack/requests/compute/shelve_offload_server.rb
+++ b/lib/fog/openstack/requests/compute/shelve_offload_server.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        # Shelve Off load the server. Data and resource associations are deleted.
+        #
+        # === Parameters
+        # * server_id <~String> - The ID of the server to be shelve off loaded
+        # === Returns
+        # * success <~Boolean>
+        def shelve_offload_server(server_id)
+          body = { 'shelveOffload' => nil }
+          server_action(server_id, body).status == 202
+        end # def shelve_off_load_server
+      end # class Real
+
+      class Mock
+        def shelve_offload_server(server_id)
+          true
+        end # def shelve_off_load_server
+      end # class Mock
+    end # class OpenStack
+  end # module Compute
+end # module Fog

--- a/lib/fog/openstack/requests/compute/shelve_server.rb
+++ b/lib/fog/openstack/requests/compute/shelve_server.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        # Shelve the server.
+        #
+        # === Parameters
+        # * server_id <~String> - The ID of the server to be shelved
+        # === Returns
+        # * success <~Boolean>
+        def shelve_server(server_id)
+          body = { 'shelve' => nil }
+          server_action(server_id, body).status == 202
+        end # def shelve_server
+      end # class Real
+
+      class Mock
+        def shelve_server(server_id)
+          true
+        end # def shelve_server
+      end # class Mock
+    end # class OpenStack
+  end # module Compute
+end # module Fog

--- a/lib/fog/openstack/requests/compute/unshelve_server.rb
+++ b/lib/fog/openstack/requests/compute/unshelve_server.rb
@@ -1,0 +1,24 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        # Unshelve the server.
+        #
+        # === Parameters
+        # * server_id <~String> - The ID of the server to be unshelved
+        # === Returns
+        # * success <~Boolean>
+        def unshelve_server(server_id)
+          body = { 'unshelve' => nil }
+          server_action(server_id, body).status == 202
+        end # def unshelve_server
+      end # class Real
+
+      class Mock
+        def unshelve_server(server_id)
+          true
+        end # def unshelve_server
+      end # class Mock
+    end # class OpenStack
+  end # module Compute
+end # module Fog

--- a/tests/openstack/requests/compute/server_tests.rb
+++ b/tests/openstack/requests/compute/server_tests.rb
@@ -232,6 +232,18 @@ Shindo.tests('Fog::Compute[:openstack] | server requests', ['openstack']) do
 
     Fog::Compute[:openstack].servers.get(@server_id).wait_for { ready? } if not Fog.mocking?
 
+    tests("#shelve_server(#{@server_id})").succeeds do
+      Fog::Compute[:openstack].shelve_server(@server_id)
+    end
+
+    Fog::Compute[:openstack].servers.get(@server_id).wait_for { ready? } if not Fog.mocking?
+
+    tests("#unshelve_server(#{@server_id})").succeeds do
+      Fog::Compute[:openstack].unshelve_server(@server_id)
+    end
+
+    Fog::Compute[:openstack].servers.get(@server_id).wait_for { ready? } if not Fog.mocking?
+
     #DELETE
     tests("#delete_server(#{@server_id})").succeeds do
       Fog::Compute[:openstack].delete_server(@server_id)


### PR DESCRIPTION
Adding actions shelve, unshelve and shelve_off_load

Testing only shelve and unshelve, since shelve offload state
can be reached automaticallt dpending on settings in
shelved_offload_time in nova.conf.