### PR TITLE
[OpenStack] subnets vanilla options fix

### DIFF
--- a/lib/fog/openstack/models/network/subnet.rb
+++ b/lib/fog/openstack/models/network/subnet.rb
@@ -27,7 +27,7 @@ module Fog
         end
 
         def update
-          requires :id, :network_id, :cidr, :ip_version
+          requires :id
           merge_attributes(service.update_subnet(self.id,
                                                     self.attributes).body['subnet'])
           self

--- a/lib/fog/openstack/requests/network/create_subnet.rb
+++ b/lib/fog/openstack/requests/network/create_subnet.rb
@@ -38,9 +38,9 @@ module Fog
             'cidr'             => cidr,
             'ip_version'       => ip_version,
             'gateway_ip'       => options[:gateway_ip],
-            'allocation_pools' => options[:allocation_pools]  || [],
-            'dns_nameservers'  => options[:dns_nameservers]   || [],
-            'host_routes'      => options[:host_routes]       || [],
+            'allocation_pools' => options[:allocation_pools],
+            'dns_nameservers'  => options[:dns_nameservers],
+            'host_routes'      => options[:host_routes],
             'enable_dhcp'      => options[:enable_dhcp],
             'tenant_id'        => options[:tenant_id]
           }

--- a/lib/fog/openstack/requests/network/create_subnet.rb
+++ b/lib/fog/openstack/requests/network/create_subnet.rb
@@ -14,7 +14,7 @@ module Fog
           vanilla_options = [:name, :gateway_ip, :allocation_pools,
                              :dns_nameservers, :host_routes, :enable_dhcp,
                              :tenant_id]
-          vanilla_options.reject{ |o| options[o].nil? unless o == :gateway_ip }.each do |key|
+          vanilla_options.select{ |o| options.key?(o) }.each do |key|
             data['subnet'][key] = options[key]
           end
 

--- a/lib/fog/openstack/requests/network/create_subnet.rb
+++ b/lib/fog/openstack/requests/network/create_subnet.rb
@@ -38,9 +38,9 @@ module Fog
             'cidr'             => cidr,
             'ip_version'       => ip_version,
             'gateway_ip'       => options[:gateway_ip],
-            'allocation_pools' => options[:allocation_pools],
-            'dns_nameservers'  => options[:dns_nameservers],
-            'host_routes'      => options[:host_routes],
+            'allocation_pools' => options[:allocation_pools]  || [],
+            'dns_nameservers'  => options[:dns_nameservers]   || [],
+            'host_routes'      => options[:host_routes]       || [],
             'enable_dhcp'      => options[:enable_dhcp],
             'tenant_id'        => options[:tenant_id]
           }

--- a/lib/fog/openstack/requests/network/update_subnet.rb
+++ b/lib/fog/openstack/requests/network/update_subnet.rb
@@ -26,9 +26,9 @@ module Fog
           if subnet = list_subnets.body['subnets'].find { |_| _['id'] == subnet_id }
             subnet['name']              = options[:name]
             subnet['gateway_ip']        = options[:gateway_ip]
-            subnet['dns_nameservers']   = options[:dns_nameservers]
-            subnet['host_routes']       = options[:host_routes]
-            subnet['allocation_pools']  = options[:allocation_pools]
+            subnet['dns_nameservers']   = options[:dns_nameservers]   || []
+            subnet['host_routes']       = options[:host_routes]       || []
+            subnet['allocation_pools']  = options[:allocation_pools]  || []
             subnet['enable_dhcp']       = options[:enable_dhcp]
             response.body = { 'subnet' => subnet }
             response.status = 200

--- a/lib/fog/openstack/requests/network/update_subnet.rb
+++ b/lib/fog/openstack/requests/network/update_subnet.rb
@@ -5,8 +5,8 @@ module Fog
         def update_subnet(subnet_id, options = {})
           data = { 'subnet' => {} }
 
-          vanilla_options = [:name, :gateway_ip, :dns_nameservers,
-                             :host_routes, :enable_dhcp]
+          vanilla_options = [:name, :gateway_ip, :allocation_pools,
+                             :dns_nameservers, :host_routes, :enable_dhcp]
           vanilla_options.select{ |o| options.key?(o) }.each do |key|
             data['subnet'][key] = options[key]
           end
@@ -24,11 +24,12 @@ module Fog
         def update_subnet(subnet_id, options = {})
           response = Excon::Response.new
           if subnet = list_subnets.body['subnets'].find { |_| _['id'] == subnet_id }
-            subnet['name']            = options[:name]
-            subnet['gateway_ip']      = options[:gateway_ip]
-            subnet['dns_nameservers'] = options[:dns_nameservers]
-            subnet['host_routes']     = options[:host_routes]
-            subnet['enable_dhcp']     = options[:enable_dhcp]
+            subnet['name']              = options[:name]
+            subnet['gateway_ip']        = options[:gateway_ip]
+            subnet['dns_nameservers']   = options[:dns_nameservers]
+            subnet['host_routes']       = options[:host_routes]
+            subnet['allocation_pools']  = options[:allocation_pools]
+            subnet['enable_dhcp']       = options[:enable_dhcp]
             response.body = { 'subnet' => subnet }
             response.status = 200
             response

--- a/tests/openstack/requests/network/subnet_tests.rb
+++ b/tests/openstack/requests/network/subnet_tests.rb
@@ -38,8 +38,8 @@ Shindo.tests('Fog::Network[:openstack] | subnet requests', ['openstack']) do
     tests('#update_subnet').formats({'subnet' => @subnet_format}) do
       subnet_id = Fog::Network[:openstack].subnets.all.first.id
       attributes = {:name => 'subnet_name', :gateway_ip => '10.2.2.1',
-                    :dns_nameservers => [], :host_routes => [],
-                    :enable_dhcp => true}
+                    :allocation_pools => [], :dns_nameservers => [],
+                    :host_routes => [], :enable_dhcp => true}
       Fog::Network[:openstack].update_subnet(subnet_id, attributes).body
     end
 


### PR DESCRIPTION
The selection of vanilla options in the subnet creation needs to be the same as in update.

Especially the `gateway_ip` is tricky (hence the special treatment beforehand), because if it is not present, then OpenStack chooses a default, if you set it to nil, it will be left empty (compare [apiref](http://developer.openstack.org/api-ref-networking-v2.html#createSubnet)). So it actually makes a difference there.

Additionally I added the `:allocation_pools`vanilla option to the subnet update, which was already present in create.

And along the way I removed some requires (probable from a copy&paste error) in the subnet model method `update`.
