### PR TITLE
[openstack] move common things among services into core

### DIFF
--- a/lib/fog/openstack.rb
+++ b/lib/fog/openstack.rb
@@ -1,5 +1,6 @@
 require 'fog/openstack/compute'
 require 'fog/openstack/identity_v2'
+require 'fog/openstack/identity_v3'
 require 'fog/openstack/image'
 require 'fog/openstack/metering'
 require 'fog/openstack/network'

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -332,6 +332,8 @@ module Fog
         def initialize(options={})
           initialize_identity options
 
+          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
+
           @openstack_service_type   = options[:openstack_service_type] || ['nova', 'compute']
           @openstack_service_name   = options[:openstack_service_name]
 

--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -69,8 +69,8 @@ module Fog
       attr_reader :openstack_project_domain_id
 
       def initialize_identity options
-        @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
         @openstack_auth_token = options[:openstack_auth_token]
+
         @auth_token        ||= options[:openstack_auth_token]
         @openstack_identity_public_endpoint = options[:openstack_identity_endpoint]
 

--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -69,20 +69,10 @@ module Fog
       attr_reader :openstack_project_domain_id
 
       def initialize_identity options
-        @openstack_auth_token = options[:openstack_auth_token]
-
-        @auth_token        ||= options[:openstack_auth_token]
-        @openstack_identity_public_endpoint = options[:openstack_identity_endpoint]
-
-        @openstack_username = options[:openstack_username]
-        @openstack_userid = options[:openstack_userid]
-
-        @openstack_domain_name = options[:openstack_domain_name]
-        @openstack_user_domain = options[:openstack_user_domain]
-        @openstack_project_domain  = options[:openstack_project_domain]
-        @openstack_domain_id = options[:openstack_domain_id]
-        @openstack_user_domain_id = options[:openstack_user_domain_id]
-        @openstack_project_domain_id  = options[:openstack_project_domain_id]
+        # Create @openstack_* instance variables from all :openstack_* options
+        options.select{|x|x.to_s.start_with? 'openstack'}.each do |openstack_param, value|
+          instance_variable_set "@#{openstack_param}".to_sym, value
+        end
 
         @auth_token        ||= options[:openstack_auth_token]
 

--- a/lib/fog/openstack/identity_v2.rb
+++ b/lib/fog/openstack/identity_v2.rb
@@ -7,11 +7,15 @@ module Fog
       class V2 < Fog::Service
 
         requires :openstack_auth_url
-        recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                   :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                   :openstack_api_key, :openstack_username, :openstack_current_user_id,
-                   :current_user, :current_tenant,
-                   :openstack_endpoint_type, :openstack_region
+        recognizes :openstack_auth_token, :openstack_management_url,
+                   :persistent, :openstack_service_type, :openstack_service_name,
+                   :openstack_tenant, :openstack_tenant_id,
+                   :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                   :current_user, :current_tenant, :openstack_region,
+                   :openstack_endpoint_type,
+                   :openstack_project_name, :openstack_project_id,
+                   :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                   :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
         model_path 'fog/openstack/models/identity_v2'
         model :tenant
@@ -166,97 +170,23 @@ module Fog
         end
 
         class Real
-          attr_reader :current_user
-          attr_reader :current_tenant
-          attr_reader :unscoped_token
-
           include Fog::Identity::OpenStack::Common
 
           def initialize(options={})
-            @openstack_auth_token = options[:openstack_auth_token]
+            initialize_identity options
 
-            unless @openstack_auth_token
-              missing_credentials = Array.new
-              @openstack_api_key = options[:openstack_api_key]
-              @openstack_username = options[:openstack_username]
-              @openstack_region = options[:openstack_region]
+            @openstack_service_type   = options[:openstack_service_type] || ['identity']
+            @openstack_service_name   = options[:openstack_service_name]
 
-              missing_credentials << :openstack_api_key unless @openstack_api_key
-              missing_credentials << :openstack_username unless @openstack_username
-              raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-            end
+            @connection_options       = options[:connection_options] || {}
 
-            @openstack_tenant = options[:openstack_tenant]
-            @openstack_auth_uri = URI.parse(options[:openstack_auth_url])
-            @openstack_management_url = options[:openstack_management_url]
-            @openstack_must_reauthenticate = false
-            @openstack_service_type = options[:openstack_service_type] || ['identity']
-            @openstack_service_name = options[:openstack_service_name]
-
-            @connection_options = options[:connection_options] || {}
-
-            @openstack_current_user_id = options[:openstack_current_user_id]
-
-            @openstack_endpoint_type = options[:openstack_endpoint_type] || 'adminURL'
-
-            @current_user = options[:current_user]
-            @current_tenant = options[:current_tenant]
+            @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
 
             authenticate
 
             @persistent = options[:persistent] || false
             @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
           end
-
-          def credentials
-            {:provider => 'openstack',
-             :openstack_auth_url => @openstack_auth_uri.to_s,
-             :openstack_auth_token => @auth_token,
-             :openstack_management_url => @openstack_management_url,
-             :openstack_current_user_id => @openstack_current_user_id,
-             :current_user => @current_user,
-             :current_tenant => @current_tenant}
-          end
-
-          def reload
-            @connection.reset
-          end
-
-          def request(params)
-            retried = false
-            begin
-              response = @connection.request(params.merge({
-                                                              :headers => {
-                                                                  'Content-Type' => 'application/json',
-                                                                  'Accept' => 'application/json',
-                                                                  'X-Auth-Token' => @auth_token
-                                                              }.merge!(params[:headers] || {}),
-                                                              :path => "#{@path}/#{params[:path]}" #,
-                                                          }))
-            rescue Excon::Errors::Unauthorized => error
-              raise if retried
-              retried = true
-
-              @openstack_must_reauthenticate = true
-              authenticate
-              retry
-            rescue Excon::Errors::HTTPStatusError => error
-              raise case error
-                      when Excon::Errors::NotFound
-                        Fog::Identity::OpenStack::NotFound.slurp(error)
-                      else
-                        error
-                    end
-            end
-            unless response.body.empty?
-              response.body = Fog::JSON.decode(response.body)
-            end
-            response
-          end
-
-          private
-
-
         end
       end
     end

--- a/lib/fog/openstack/image.rb
+++ b/lib/fog/openstack/image.rb
@@ -6,10 +6,15 @@ module Fog
       SUPPORTED_VERSIONS = /v1(\.(0|1))*/
 
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant, :openstack_endpoint_type, :openstack_region
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/image'
 
@@ -89,53 +94,28 @@ module Fog
       end
 
       class Real
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          initialize_identity options
 
-          unless @openstack_auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type           = options[:openstack_service_type] || ['image']
+          @openstack_service_name           = options[:openstack_service_name]
+          @openstack_endpoint_type          = options[:openstack_endpoint_type] || 'adminURL'
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['image']
-          @openstack_service_name         = options[:openstack_service_name]
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
-          @openstack_region               = options[:openstack_region]
-
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options               = options[:connection_options] || {}
 
           authenticate
 
+          unless @path.match(SUPPORTED_VERSIONS)
+            @path = "/" + Fog::OpenStack.get_supported_version(SUPPORTED_VERSIONS,
+                                                               @openstack_management_uri,
+                                                               @auth_token,
+                                                               @connection_options)
+          end
+
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -171,47 +151,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_region   => @openstack_region,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          unless @path.match(SUPPORTED_VERSIONS)
-            @path = "/" + Fog::OpenStack.get_supported_version(SUPPORTED_VERSIONS,
-                                                               uri,
-                                                               @auth_token,
-                                                               @connection_options)
-          end
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
   end

--- a/lib/fog/openstack/metering.rb
+++ b/lib/fog/openstack/metering.rb
@@ -4,11 +4,15 @@ module Fog
   module Metering
     class OpenStack < Fog::Service
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant,
-                 :openstack_endpoint_type
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/metering'
 
@@ -81,52 +85,21 @@ module Fog
       end
 
       class Real
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          initialize_identity options
 
-          unless @openstack_auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type           = options[:openstack_service_type] || ['metering']
+          @openstack_service_name           = options[:openstack_service_name]
+          @openstack_endpoint_type          = options[:openstack_endpoint_type] || 'adminURL'
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['metering']
-          @openstack_service_name         = options[:openstack_service_name]
-
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options               = options[:connection_options] || {}
 
           authenticate
 
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -165,40 +138,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
   end

--- a/lib/fog/openstack/models/orchestration/events.rb
+++ b/lib/fog/openstack/models/orchestration/events.rb
@@ -1,3 +1,4 @@
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/orchestration/event'
 
 module Fog

--- a/lib/fog/openstack/models/orchestration/resources.rb
+++ b/lib/fog/openstack/models/orchestration/resources.rb
@@ -1,3 +1,4 @@
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/orchestration/resource'
 
 module Fog

--- a/lib/fog/openstack/models/orchestration/stacks.rb
+++ b/lib/fog/openstack/models/orchestration/stacks.rb
@@ -1,3 +1,4 @@
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/orchestration/stack'
 
 module Fog

--- a/lib/fog/openstack/models/orchestration/templates.rb
+++ b/lib/fog/openstack/models/orchestration/templates.rb
@@ -1,3 +1,4 @@
+require 'fog/openstack/models/collection'
 require 'fog/openstack/models/orchestration/template'
 
 module Fog

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -6,13 +6,15 @@ module Fog
       SUPPORTED_VERSIONS = /v2(\.0)*/
 
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_tenant_id,
-                 :openstack_api_key, :openstack_username, :openstack_endpoint_type,
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region,
-                 :openstack_project_name,
-                 :openstack_project_domain, :openstack_user_domain
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       ## MODELS
       #
@@ -228,13 +230,12 @@ module Fog
         include Fog::OpenStack::Core
 
         def initialize(options={})
-
           initialize_identity options
 
-          @openstack_service_type         = options[:openstack_service_type] || ['network']
-          @openstack_service_name         = options[:openstack_service_name]
+          @openstack_service_type = options[:openstack_service_type] || ['network']
+          @openstack_service_name = options[:openstack_service_name]
 
-          @connection_options = options[:connection_options] || {}
+          @connection_options     = options[:connection_options] || {}
 
           authenticate
 
@@ -250,9 +251,6 @@ module Fog
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
         end
 
-        def reload
-          @connection.reset
-        end
 
         def request(params)
           begin

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -155,7 +155,7 @@ module Fog
                 'X-Auth-User'  => @openstack_username,
                 'X-Auth-Key'   => @openstack_api_key
               }.merge!(params[:headers] || {}),
-              :path     => "#{@path}/#{@tenant_id}/#{params[:path]}",
+              :path     => "#{@path}/#{params[:path]}",
               :query    => params[:query]
             }))
           rescue Excon::Errors::Unauthorized => error

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -6,10 +6,13 @@ module Fog
       requires :openstack_auth_url
       recognizes :openstack_auth_token, :openstack_management_url,
                  :persistent, :openstack_service_type, :openstack_service_name,
-                 :openstack_tenant,
+                 :openstack_tenant, :openstack_tenant_id,
                  :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
                  :current_user, :current_tenant, :openstack_region,
-                 :openstack_endpoint_type
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/orchestration'
       model       :stack
@@ -124,60 +127,20 @@ module Fog
       end
 
       class Real
-        attr_reader :auth_token
-        attr_reader :auth_token_expiration
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
-          @auth_token        = options[:openstack_auth_token]
-          @openstack_identity_public_endpoint = options[:openstack_identity_endpoint]
+          initialize_identity options
 
-          unless @auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type           = options[:openstack_service_type] || ['orchestration']
+          @openstack_service_name           = options[:openstack_service_name]
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant     = options[:openstack_tenant]
-          @openstack_auth_uri   = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type = options[:openstack_service_type] || ['orchestration']
-          @openstack_service_name = options[:openstack_service_name]
-          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
-          @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
-          @openstack_region      = options[:openstack_region]
-
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options               = options[:connection_options] || {}
 
           authenticate
 
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :openstack_identity_endpoint => @openstack_identity_public_endpoint,
-            :openstack_region         => @openstack_region,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -219,51 +182,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_api_key    => @openstack_api_key,
-              :openstack_username   => @openstack_username,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @auth_token,
-              :openstack_auth_uri   => @openstack_auth_uri,
-              :openstack_region     => @openstack_region,
-              :openstack_tenant     => @openstack_tenant,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_identity_service_type => @openstack_identity_service_type,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token               = credentials[:token]
-            @auth_token_expiration    = credentials[:expires]
-            @openstack_management_url = credentials[:server_management_url]
-            @openstack_identity_public_endpoint  = credentials[:identity_public_endpoint]
-          end
-
-          uri = URI.parse(@openstack_management_url)
-          @host   = uri.host
-          @path, @tenant_id = uri.path.scan(/(\/.*)\/(.*)/).flatten
-
-          @path.sub!(/\/$/, '')
-
-          @port   = uri.port
-          @scheme = uri.scheme
-
-          # Not all implementations have identity service in the catalog
-          if @openstack_identity_public_endpoint || @openstack_management_url
-            @identity_connection = Fog::Core::Connection.new(
-              @openstack_identity_public_endpoint || @openstack_management_url,
-              false, @connection_options)
-          end
-
-          true
-        end
       end
     end
   end

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -132,6 +132,8 @@ module Fog
         def initialize(options={})
           initialize_identity options
 
+          @openstack_identity_service_type = options[:openstack_identity_service_type] || 'identity'
+
           @openstack_service_type           = options[:openstack_service_type] || ['orchestration']
           @openstack_service_name           = options[:openstack_service_name]
 

--- a/lib/fog/openstack/planning.rb
+++ b/lib/fog/openstack/planning.rb
@@ -6,10 +6,15 @@ module Fog
       SUPPORTED_VERSIONS = /v2/
 
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant, :openstack_endpoint_type, :openstack_region
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       ## MODELS
       #
@@ -89,53 +94,25 @@ module Fog
       end
 
       class Real
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          initialize_identity options
 
-          unless @openstack_auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type           = options[:openstack_service_type] || ['management'] # currently Tuskar is configured as 'management' service in Keystone
+          @openstack_service_name           = options[:openstack_service_name]
+          @openstack_endpoint_type          = options[:openstack_endpoint_type] || 'adminURL'
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['management'] # currently Tuskar is configured as 'management' service in Keystone
-          @openstack_service_name         = options[:openstack_service_name]
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
-          @openstack_region               = options[:openstack_region]
-
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options               = options[:connection_options] || {}
 
           authenticate
 
+          unless @path.match(SUPPORTED_VERSIONS)
+            @path = "/v2"
+          end
+
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -171,44 +148,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_region   => @openstack_region,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          unless @path.match(SUPPORTED_VERSIONS)
-            @path = "/v2"
-          end
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
 
@@ -232,4 +171,3 @@ module Fog
     end
   end
 end
-

--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -5,11 +5,15 @@ module Fog
     class OpenStack < Fog::Service
       requires   :openstack_auth_url, :openstack_username,
                  :openstack_api_key
-      recognizes :persistent, :openstack_service_name,
-                 :openstack_service_type, :openstack_tenant,
-                 :openstack_region, :openstack_temp_url_key,
-                 :openstack_endpoint_type, :openstack_auth_token,
-                 :openstack_management_url
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/storage'
       model       :directory
@@ -76,28 +80,19 @@ module Fog
       end
 
       class Real
+        include Fog::OpenStack::Core
+
         def initialize(options={})
-          @openstack_api_key = options[:openstack_api_key]
-          @openstack_username = options[:openstack_username]
-          @openstack_auth_url = options[:openstack_auth_url]
-          @openstack_auth_token = options[:openstack_auth_token]
-          @openstack_storage_url = options[:openstack_storage_url]
-          @openstack_must_reauthenticate = false
-          @openstack_service_type = options[:openstack_service_type] || ['object-store']
-          @openstack_service_name = options[:openstack_service_name]
-          @openstack_region       = options[:openstack_region]
-          @openstack_tenant       = options[:openstack_tenant]
-          @connection_options     = options[:connection_options] || {}
-          @openstack_temp_url_key = options[:openstack_temp_url_key]
-          @openstack_endpoint_type = options[:openstack_endpoint_type] || 'publicURL'
-          @openstack_management_url = options[:openstack_management_url]
+          initialize_identity options
+
+          @openstack_service_type           = options[:openstack_service_type] || ['object-store']
+          @openstack_service_name           = options[:openstack_service_name]
+
+          @connection_options               = options[:connection_options] || {}
+
           authenticate
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def reload
-          @connection.reset
         end
 
         # Change the current account while re-using the auth token.
@@ -180,40 +175,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => URI.parse(@openstack_auth_url),
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_region => @openstack_region,
-              :openstack_tenant => @openstack_tenant,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
   end

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -4,11 +4,15 @@ module Fog
   module Volume
     class OpenStack < Fog::Service
       requires :openstack_auth_url
-      recognizes :openstack_auth_token, :openstack_management_url, :persistent,
-                 :openstack_service_type, :openstack_service_name, :openstack_tenant,
-                 :openstack_api_key, :openstack_username,
-                 :current_user, :current_tenant,
-                 :openstack_endpoint_type, :openstack_region
+      recognizes :openstack_auth_token, :openstack_management_url,
+                 :persistent, :openstack_service_type, :openstack_service_name,
+                 :openstack_tenant, :openstack_tenant_id,
+                 :openstack_api_key, :openstack_username, :openstack_identity_endpoint,
+                 :current_user, :current_tenant, :openstack_region,
+                 :openstack_endpoint_type,
+                 :openstack_project_name, :openstack_project_id,
+                 :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
 
       model_path 'fog/openstack/models/volume'
 
@@ -119,53 +123,21 @@ module Fog
       end
 
       class Real
-        attr_reader :current_user
-        attr_reader :current_tenant
+        include Fog::OpenStack::Core
 
         def initialize(options={})
-          @openstack_auth_token = options[:openstack_auth_token]
+          initialize_identity options
 
-          unless @openstack_auth_token
-            missing_credentials = Array.new
-            @openstack_api_key  = options[:openstack_api_key]
-            @openstack_username = options[:openstack_username]
+          @openstack_service_type   = options[:openstack_service_type] || ['volume']
+          @openstack_service_name   = options[:openstack_service_name]
+          @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
 
-            missing_credentials << :openstack_api_key  unless @openstack_api_key
-            missing_credentials << :openstack_username unless @openstack_username
-            raise ArgumentError, "Missing required arguments: #{missing_credentials.join(', ')}" unless missing_credentials.empty?
-          end
-
-          @openstack_tenant               = options[:openstack_tenant]
-          @openstack_auth_uri             = URI.parse(options[:openstack_auth_url])
-          @openstack_management_url       = options[:openstack_management_url]
-          @openstack_must_reauthenticate  = false
-          @openstack_service_type         = options[:openstack_service_type] || ['volume']
-          @openstack_service_name         = options[:openstack_service_name]
-          @openstack_region               = options[:openstack_region]
-
-          @openstack_endpoint_type        = options[:openstack_endpoint_type] || 'adminURL'
-          @connection_options = options[:connection_options] || {}
-
-          @current_user = options[:current_user]
-          @current_tenant = options[:current_tenant]
+          @connection_options       = options[:connection_options] || {}
 
           authenticate
 
-          @persistent = options[:persistent] || false
+          @persistent                       = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
-        end
-
-        def credentials
-          { :provider                 => 'openstack',
-            :openstack_auth_url       => @openstack_auth_uri.to_s,
-            :openstack_auth_token     => @auth_token,
-            :openstack_management_url => @openstack_management_url,
-            :current_user             => @current_user,
-            :current_tenant           => @current_tenant }
-        end
-
-        def reload
-          @connection.reset
         end
 
         def request(params)
@@ -202,41 +174,6 @@ module Fog
 
         private
 
-        def authenticate
-          if !@openstack_management_url || @openstack_must_reauthenticate
-            options = {
-              :openstack_region   => @openstack_region,
-              :openstack_tenant   => @openstack_tenant,
-              :openstack_api_key  => @openstack_api_key,
-              :openstack_username => @openstack_username,
-              :openstack_auth_uri => @openstack_auth_uri,
-              :openstack_auth_token => @openstack_must_reauthenticate ? nil : @openstack_auth_token,
-              :openstack_service_type => @openstack_service_type,
-              :openstack_service_name => @openstack_service_name,
-              :openstack_endpoint_type => @openstack_endpoint_type
-            }
-
-            credentials = Fog::OpenStack.authenticate(options, @connection_options)
-
-            @current_user = credentials[:user]
-            @current_tenant = credentials[:tenant]
-
-            @openstack_must_reauthenticate = false
-            @auth_token = credentials[:token]
-            @openstack_management_url = credentials[:server_management_url]
-            uri = URI.parse(@openstack_management_url)
-          else
-            @auth_token = @openstack_auth_token
-            uri = URI.parse(@openstack_management_url)
-          end
-
-          @host   = uri.host
-          @path   = uri.path
-          @path.sub!(/\/$/, '')
-          @port   = uri.port
-          @scheme = uri.scheme
-          true
-        end
       end
     end
   end


### PR DESCRIPTION
cleanup of https://github.com/fog/fog/pull/3642

"I noticed, that only compute and network use the core method `initialize_identity`, which enabled this services to be used with a v3 keystone - the other did not work.

Additionally I added the v3 parameters to the recognized parameters for all services and
instead of duplicating a lot of code, I took the chance to reuse the common stuff from core."