### PR TITLE
vCloud Director queued tasks should not count as "non_running".

### DIFF
--- a/lib/fog/vcloud_director/models/compute/task.rb
+++ b/lib/fog/vcloud_director/models/compute/task.rb
@@ -35,7 +35,7 @@ module Fog
 
         def non_running?
           if @service.show_progress? && (@last_progress ||= 0) < 100
-            if status == 'running'
+            if status == 'running' || status == 'queued'
               Fog::Formatador.redisplay_progressbar(progress, 100, :label => operation_name, :started_at => start_time)
               @last_progress = progress
             elsif status == 'success'
@@ -43,7 +43,7 @@ module Fog
               @last_progress = 100
             end
           end
-          status != 'running'
+          ! %w(running queued).include?(status)
         end
 
         def cancel


### PR DESCRIPTION
In vCloud Air, created tasks end up in an initial state of "queued."
Fog currently treats these tasks as non_running and therefore stops
waiting for them.  Because the status is not yet successful, an
exception is raised.

I propose this change to treat a "queued" task as equivalent to
"running."