### PR TITLE
Openstack missing passing of unscoped_token

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -97,13 +97,15 @@ module Fog
       end
 
       def credentials
-        options =  { :provider => 'openstack',
-          :openstack_auth_url       => @openstack_auth_uri.to_s,
-          :openstack_auth_token     => @auth_token,
+        options =  {
+          :provider                    => 'openstack',
+          :openstack_auth_url          => @openstack_auth_uri.to_s,
+          :openstack_auth_token        => @auth_token,
           :openstack_identity_endpoint => @openstack_identity_public_endpoint,
-          :current_user             => @current_user,
-          :current_user_id          => @current_user_id,
-          :current_tenant           => @current_tenant }
+          :current_user                => @current_user,
+          :current_user_id             => @current_user_id,
+          :current_tenant              => @current_tenant,
+          :unscoped_token              => @unscoped_token}
         openstack_options.merge options
       end
 
@@ -139,6 +141,7 @@ module Fog
           @openstack_must_reauthenticate = false
           @auth_token = credentials[:token]
           @openstack_management_url = credentials[:server_management_url]
+          @unscoped_token = credentials[:unscoped_token]
         else
           @auth_token = @openstack_auth_token
         end


### PR DESCRIPTION
In the https://github.com/fog/fog/commit/803d46791f5cfe75c99084c49519af6d63248f9b
refactoring, the unscoped token passing to credentials has
been deleted. So adding unscoped token to 2 missing places.

Plus aligning the =>, so the code is more readable