### PR TITLE
Rackspace temporary URL special options

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -81,6 +81,9 @@ namespace :test do
   task :openstack do
       sh("export FOG_MOCK=#{mock} && bundle exec shindont tests/openstack")
   end
+  task :rackspace do
+      sh("export FOG_MOCK=#{mock} && bundle exec shindont tests/rackspace")
+  end
   task :cloudstack do
       sh("export FOG_MOCK=#{mock} && bundle exec shindont tests/cloudstack")
   end

--- a/lib/fog/rackspace/requests/storage/get_object_https_url.rb
+++ b/lib/fog/rackspace/requests/storage/get_object_https_url.rb
@@ -34,11 +34,11 @@ module Fog
           sig  = sig_to_hex(hmac.sign(string_to_sign))
 
           temp_url_query = {
-              temp_url_sig: sig,
-              temp_url_expires: expires
+              :temp_url_sig => sig,
+              :temp_url_expires => expires
           }
-          temp_url_query.merge!(inline: true) if options[:inline]
-          temp_url_query.merge!(filename: options[:filename]) if options[:filename]
+          temp_url_query.merge!(:inline => true) if options[:inline]
+          temp_url_query.merge!(:filename => options[:filename]) if options[:filename]
           temp_url_options = {
               :scheme => options[:scheme] || @uri.scheme,
               :host => @uri.host,

--- a/lib/fog/rackspace/requests/storage/get_object_https_url.rb
+++ b/lib/fog/rackspace/requests/storage/get_object_https_url.rb
@@ -33,8 +33,22 @@ module Fog
           hmac = Fog::HMAC.new('sha1', @rackspace_temp_url_key)
           sig  = sig_to_hex(hmac.sign(string_to_sign))
 
-          scheme = options[:scheme] ? options[:scheme] : @uri.scheme
-          "#{scheme}://#{@uri.host}#{object_path_escaped}?temp_url_sig=#{sig}&temp_url_expires=#{expires}"
+          temp_url_query = {
+              temp_url_sig: sig,
+              temp_url_expires: expires
+          }
+          temp_url_query.merge!(inline: true) if options[:inline]
+          temp_url_query.merge!(filename: options[:filename]) if options[:filename]
+          q = temp_url_query.map do |param, val|
+            "#{CGI.escape(param.to_s)}=#{CGI.escape(val.to_s)}"
+          end.join('&')
+          temp_url_options = {
+              :scheme => options[:scheme] || @uri.scheme,
+              :host => @uri.host,
+              :path => object_path_escaped,
+              :query => q
+          }
+          URI::Generic.build(temp_url_options).to_s
         end
 
         private

--- a/lib/fog/rackspace/requests/storage/get_object_https_url.rb
+++ b/lib/fog/rackspace/requests/storage/get_object_https_url.rb
@@ -39,14 +39,11 @@ module Fog
           }
           temp_url_query.merge!(inline: true) if options[:inline]
           temp_url_query.merge!(filename: options[:filename]) if options[:filename]
-          q = temp_url_query.map do |param, val|
-            "#{CGI.escape(param.to_s)}=#{CGI.escape(val.to_s)}"
-          end.join('&')
           temp_url_options = {
               :scheme => options[:scheme] || @uri.scheme,
               :host => @uri.host,
               :path => object_path_escaped,
-              :query => q
+              :query => temp_url_query.map { |param, val| "#{CGI.escape(param.to_s)}=#{CGI.escape(val.to_s)}" }.join('&')
           }
           URI::Generic.build(temp_url_options).to_s
         end

--- a/tests/rackspace/requests/storage/object_tests.rb
+++ b/tests/rackspace/requests/storage/object_tests.rb
@@ -1,3 +1,6 @@
+require 'uri'
+require 'cgi'
+
 Shindo.tests('Fog::Storage[:rackspace] | object requests', ["rackspace"]) do
 
   @directory = Fog::Storage[:rackspace].directories.create(:key => 'fogobjecttests')
@@ -6,6 +9,21 @@ Shindo.tests('Fog::Storage[:rackspace] | object requests', ["rackspace"]) do
     def override_path(path)
       @uri.path = path
     end
+  end
+
+  def parse_url(url_string)
+    uri = URI.parse(url_string)
+    query_hash = CGI.parse(uri.query)
+    query_hash.each do |k, v|
+      query_hash[k] = v[0] if query_hash[k].is_a?(Array) and query_hash[k].count == 1
+    end
+    {
+        :scheme => uri.scheme,
+        :host => uri.host,
+        :port => uri.port,
+        :path => uri.path,
+        :query => query_hash
+    }
   end
 
   tests('success') do
@@ -41,7 +59,13 @@ Shindo.tests('Fog::Storage[:rackspace] | object requests', ["rackspace"]) do
       storage.extend RackspaceStorageHelpers
       storage.override_path('/fake_version/fake_tenant')
       object_url = storage.get_object_http_url('fogobjecttests', 'fog_object', expires_at)
-      object_url =~ /http:\/\/.*clouddrive.com\/[^\/]+\/[^\/]+\/fogobjecttests\/fog_object\?temp_url_sig=7e69a73092e333095a70b3be826a7350fcbede86&temp_url_expires=1344149532/
+      url = parse_url(object_url)
+      [
+         url[:host] =~ /.*clouddrive\.com$/,
+         url[:path] =~ /\/fogobjecttests\/fog_object$/,
+         url[:query]['temp_url_sig'] == '7e69a73092e333095a70b3be826a7350fcbede86',
+         url[:query]['temp_url_expires'] == '1344149532'
+      ].all?
     end
 
     # an object key with no special characters
@@ -52,6 +76,13 @@ Shindo.tests('Fog::Storage[:rackspace] | object requests', ["rackspace"]) do
       storage.override_path('/fake_version/fake_tenant')
       object_url = storage.get_object_https_url('fogobjecttests', 'fog_object', expires_at)
       object_url =~ /https:\/\/.*clouddrive.com\/[^\/]+\/[^\/]+\/fogobjecttests\/fog_object\?temp_url_sig=7e69a73092e333095a70b3be826a7350fcbede86&temp_url_expires=1344149532/
+      url = parse_url(object_url)
+      [
+          url[:host] =~ /.*clouddrive\.com$/,
+          url[:path] =~ /\/fogobjecttests\/fog_object$/,
+          url[:query]['temp_url_sig'] == '7e69a73092e333095a70b3be826a7350fcbede86',
+          url[:query]['temp_url_expires'] == '1344149532'
+      ].all?
     end
 
     # an object key nested under a /
@@ -62,6 +93,13 @@ Shindo.tests('Fog::Storage[:rackspace] | object requests', ["rackspace"]) do
       storage.override_path('/fake_version/fake_tenant')
       object_url = storage.get_object_https_url('fogobjecttests', 'fog/object', expires_at)
       object_url =~ /https:\/\/.*clouddrive.com\/[^\/]+\/[^\/]+\/fogobjecttests\/fog\/object\?temp_url_sig=3e99892828804e3d0fdadd18c543b688591ca8b8&temp_url_expires=1344149532/
+      url = parse_url(object_url)
+      [
+          url[:host] =~ /.*clouddrive\.com$/,
+          url[:path] =~ /\/fogobjecttests\/fog\/object$/,
+          url[:query]['temp_url_sig'] == '3e99892828804e3d0fdadd18c543b688591ca8b8',
+          url[:query]['temp_url_expires'] == '1344149532'
+      ].all?
     end
 
     # an object key containing a -
@@ -72,6 +110,13 @@ Shindo.tests('Fog::Storage[:rackspace] | object requests', ["rackspace"]) do
       storage.override_path('/fake_version/fake_tenant')
       object_url = storage.get_object_https_url('fogobjecttests', 'fog-object', expires_at)
       object_url =~ /https:\/\/.*clouddrive.com\/[^\/]+\/[^\/]+\/fogobjecttests\/fog-object\?temp_url_sig=a24dd5fc955a57adce7d1b5bc4ec2c7660ab8396&temp_url_expires=1344149532/
+      url = parse_url(object_url)
+      [
+          url[:host] =~ /.*clouddrive\.com$/,
+          url[:path] =~ /\/fogobjecttests\/fog-object$/,
+          url[:query]['temp_url_sig'] == 'a24dd5fc955a57adce7d1b5bc4ec2c7660ab8396',
+          url[:query]['temp_url_expires'] == '1344149532'
+      ].all?
     end
 
     tests("put_object with block") do


### PR DESCRIPTION
Hi!

Rackspace CloudFiles has some [custom options](http://docs.rackspace.com/files/api/v1/cf-devguide/content/TempURL_File_Name_Overrides-d1e213.html) for a private file's temporary URL. This update allows using both `inline` and `filename` options.