### PR TITLE
[WIP/RFC] initial support for OpenStack Volume API v2

### DIFF
--- a/lib/fog/openstack/models/volume/volume.rb
+++ b/lib/fog/openstack/models/volume/volume.rb
@@ -6,8 +6,10 @@ module Fog
       class Volume < Fog::OpenStack::Model
         identity :id
 
-        attribute :display_name,        :aliases => 'displayName'
-        attribute :display_description, :aliases => 'displayDescription'
+        # NOTE: The attributes "name" and "description" are called
+        # "display_name" and "display_description" in API version v1.
+        attribute :name,                :aliases => ['display_name', 'displayName', :display_name]
+        attribute :description,         :aliases => ['display_description', 'displayDescription', :display_description]
         attribute :metadata
         attribute :status
         attribute :size
@@ -21,8 +23,8 @@ module Fog
         attribute :tenant_id,           :aliases => 'os-vol-tenant-attr:tenant_id'
 
         def save
-          requires :display_name, :size
-          data = service.create_volume(display_name, display_description, size, attributes)
+          requires :name, :size
+          data = service.create_volume(name, description, size, attributes)
           merge_attributes(data.body['volume'])
           true
         end
@@ -41,6 +43,13 @@ module Fog
 
         def ready?
           status == 'available'
+        end
+
+        def display_name
+          name
+        end
+        def display_description
+          description
         end
       end
     end

--- a/lib/fog/openstack/models/volume/volume.rb
+++ b/lib/fog/openstack/models/volume/volume.rb
@@ -6,8 +6,6 @@ module Fog
       class Volume < Fog::OpenStack::Model
         identity :id
 
-        # NOTE: The attributes "name" and "description" are called
-        # "display_name" and "display_description" in API version v1.
         attribute :name,                :aliases => ['display_name', 'displayName', :display_name]
         attribute :description,         :aliases => ['display_description', 'displayDescription', :display_description]
         attribute :metadata
@@ -21,6 +19,13 @@ module Fog
         attribute :attachments
         attribute :source_volid
         attribute :tenant_id,           :aliases => 'os-vol-tenant-attr:tenant_id'
+
+        # NOTE: The attributes "name" and "description" are called
+        # "display_name" and "display_description" in API version v1.
+        alias_method :display_name,         :name
+        alias_method :display_name=,        :name=
+        alias_method :display_description,  :description
+        alias_method :display_description=, :description=
 
         def save
           requires :name, :size
@@ -43,13 +48,6 @@ module Fog
 
         def ready?
           status == 'available'
-        end
-
-        def display_name
-          name
-        end
-        def display_description
-          description
         end
       end
     end

--- a/lib/fog/openstack/requests/volume/create_volume.rb
+++ b/lib/fog/openstack/requests/volume/create_volume.rb
@@ -3,11 +3,17 @@ module Fog
     class OpenStack
       class Real
         def create_volume(name, description, size, options={})
+          # some attributes have different keys depending on the volume API version
+          name_key, desc_key = [ 'name', 'description' ]
+          if @volume_api_version == 'v1'
+            name_key, desc_key = [ 'display_name', 'display_description' ]
+          end
+
           data = {
             'volume' => {
-              'display_name'        => name,
-              'display_description' => description,
-              'size'                => size
+              name_key => name,
+              desc_key => description,
+              'size'   => size
             }
           }
 
@@ -31,18 +37,18 @@ module Fog
           response.status = 202
           response.body = {
             'volume' => {
-              'id'                  => Fog::Mock.random_numbers(2),
-              'display_name'        => name,
-              'display_description' => description,
-              'metadata'            => options['metadata'] || {},
-              'size'                => size,
-              'status'              => 'creating',
-              'snapshot_id'         => options[:snapshot_id] || nil,
-              'image_id'            => options[:imageRef] || nil,
-              'volume_type'         => nil,
-              'availability_zone'   => 'nova',
-              'created_at'          => Time.now,
-              'attachments'         => []
+              'id'                => Fog::Mock.random_numbers(2),
+              'name'              => name,
+              'description'       => description,
+              'metadata'          => options['metadata'] || {},
+              'size'              => size,
+              'status'            => 'creating',
+              'snapshot_id'       => options[:snapshot_id] || nil,
+              'image_id'          => options[:imageRef] || nil,
+              'volume_type'       => nil,
+              'availability_zone' => 'nova',
+              'created_at'        => Time.now,
+              'attachments'       => []
             }
           }
           response

--- a/lib/fog/openstack/requests/volume/create_volume_snapshot.rb
+++ b/lib/fog/openstack/requests/volume/create_volume_snapshot.rb
@@ -3,12 +3,18 @@ module Fog
     class OpenStack
       class Real
         def create_volume_snapshot(volume_id, name, description, force=false)
+          # some attributes have different keys depending on the volume API version
+          name_key, desc_key = [ 'name', 'description' ]
+          if @volume_api_version == 'v1'
+            name_key, desc_key = [ 'display_name', 'display_description' ]
+          end
+
           data = {
             'snapshot' => {
-              'volume_id'           => volume_id,
-              'display_name'        => name,
-              'display_description' => description,
-              'force'               => force
+              'volume_id' => volume_id,
+              name_key    => name,
+              desc_key    => description,
+              'force'     => force
             }
           }
 
@@ -28,9 +34,9 @@ module Fog
           response.body = {
             "snapshot"=> {
                "status"=>"creating",
-               "display_name"=>name,
+               "name"=>name,
                "created_at"=>Time.now,
-               "display_description"=>description,
+               "description"=>description,
                "volume_id"=>volume_id,
                "id"=>"5",
                "size"=>1

--- a/lib/fog/openstack/requests/volume/get_snapshot_details.rb
+++ b/lib/fog/openstack/requests/volume/get_snapshot_details.rb
@@ -17,13 +17,13 @@ module Fog
           response.status = 200
           response.body = {
             'snapshot' => {
-              'id'                 => '1',
-              'display_name'        => 'Snapshot1',
-              'display_description' => 'Volume1 snapshot',
-              'size'               => 1,
-              'volume_id'           => '1',
-              'status'             => 'available',
-              'created_at'          => Time.now
+              'id'          => '1',
+              'name'        => 'Snapshot1',
+              'description' => 'Volume1 snapshot',
+              'size'        => 1,
+              'volume_id'   => '1',
+              'status'      => 'available',
+              'created_at'  => Time.now
             }
           }
           response

--- a/lib/fog/openstack/requests/volume/get_volume_details.rb
+++ b/lib/fog/openstack/requests/volume/get_volume_details.rb
@@ -17,16 +17,16 @@ module Fog
           response.status = 200
           response.body = {
             'volume' => {
-              'id'                  => '1',
-              'display_name'        => Fog::Mock.random_letters(rand(8) + 5),
-              'display_description' => Fog::Mock.random_letters(rand(12) + 10),
-              'size'                => 3,
-              'volume_type'         => nil,
-              'snapshot_id'         => '4',
-              'status'              => 'online',
-              'availability_zone'   => 'nova',
-              'created_at'          => Time.now,
-              'attachments'         => []
+              'id'                => '1',
+              'name'              => Fog::Mock.random_letters(rand(8) + 5),
+              'description'       => Fog::Mock.random_letters(rand(12) + 10),
+              'size'              => 3,
+              'volume_type'       => nil,
+              'snapshot_id'       => '4',
+              'status'            => 'online',
+              'availability_zone' => 'nova',
+              'created_at'        => Time.now,
+              'attachments'       => []
             }
           }
           response

--- a/lib/fog/openstack/requests/volume/list_volumes.rb
+++ b/lib/fog/openstack/requests/volume/list_volumes.rb
@@ -32,9 +32,9 @@ module Fog
           response.status = 200
           self.data[:volumes] ||= [
             { "status" => "available",
-              "display_description" => "test 1 desc",
+              "description" => "test 1 desc",
               "availability_zone" => "nova",
-              "display_name" => "Volume1",
+              "name" => "Volume1",
               "attachments" => [{}],
               "volume_type" => nil,
               "snapshot_id" => nil,
@@ -43,9 +43,9 @@ module Fog
               "created_at" => Time.now,
               "metadata" => {} },
             { "status" => "available",
-              "display_description" => "test 2 desc",
+              "description" => "test 2 desc",
               "availability_zone" => "nova",
-              "display_name" => "Volume2",
+              "name" => "Volume2",
               "attachments" => [{}],
               "volume_type" => nil,
               "snapshot_id" => nil,

--- a/lib/fog/openstack/requests/volume/list_volumes_detailed.rb
+++ b/lib/fog/openstack/requests/volume/list_volumes_detailed.rb
@@ -18,9 +18,9 @@ module Fog
           response.status = 200
           self.data[:volumes] ||= [
             { "status" => "available",
-              "display_description" => "test 1 desc",
+              "description" => "test 1 desc",
               "availability_zone" => "nova",
-              "display_name" => "Volume1",
+              "name" => "Volume1",
               "attachments" => [{}],
               "volume_type" => nil,
               "snapshot_id" => nil,
@@ -29,9 +29,9 @@ module Fog
               "created_at" => Time.now,
               "metadata" => {} },
             { "status" => "available",
-              "display_description" => "test 2 desc",
+              "description" => "test 2 desc",
               "availability_zone" => "nova",
-              "display_name" => "Volume2",
+              "name" => "Volume2",
               "attachments" => [{}],
               "volume_type" => nil,
               "snapshot_id" => nil,

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -90,8 +90,11 @@ module Fog
 
           management_url = URI.parse(options[:openstack_auth_url])
           management_url.port = 8776
-          management_url.path = '/v1'
+          management_url.path = '/v2'
           @openstack_management_url = management_url.to_s
+
+          # Right now, we always mock the v2 API.
+          @volume_api_version = 'v2'
 
           @data ||= { :users => {} }
           unless @data[:users].find {|u| u['name'] == options[:openstack_username]}
@@ -128,7 +131,9 @@ module Fog
         def initialize(options={})
           initialize_identity options
 
-          @openstack_service_type   = options[:openstack_service_type] || ['volume']
+          # TODO: I put "volumev2" first because v2 should be preferred over
+          # v1; however this is not respected in Fog::OpenStack::Core::get_service[_v3] yet
+          @openstack_service_type   = options[:openstack_service_type] || ['volumev2','volume']
           @openstack_service_name   = options[:openstack_service_name]
           @openstack_endpoint_type  = options[:openstack_endpoint_type] || 'adminURL'
 
@@ -136,7 +141,22 @@ module Fog
 
           authenticate
 
-          @persistent                       = options[:persistent] || false
+          # this module supports both v1 and v2 of the volume API (the only
+          # backwards-incompatible change is that "display_name" and
+          # "display_description" attributes of volumes and snapshots are
+          # called "name" and "description" in v2)
+          api_version = @path.match(/\bv[12]\b/)
+          unless api_version
+            raise Fog::OpenStack::Errors::ServiceUnavailable.new(
+                    "OpenStack volume binding only supports API version 1 or 2")
+          end
+          @volume_api_version = api_version.to_s # either "v1" or "v2"
+          # NOTE: This variable (@volume_api_version) can be checked in
+          # requests that are only implemented by the v2 API, to raise the
+          # proper Fog::OpenStack::Errors::ServiceUnavailable exception if the
+          # connection uses v1.
+
+          @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
         end
 

--- a/spec/fog/openstack/shared_context.rb
+++ b/spec/fog/openstack/shared_context.rb
@@ -32,6 +32,9 @@ RSpec.shared_context 'OpenStack specs with VCR' do
     # read arguments
     expect(@vcr_directory = options[:vcr_directory]).to be_a(String)
     expect(@service_class = options[:service_class]).to be_a(Class)
+    if @service_options = options[:service_options]
+      expect(@service_options).to be_a(Hash)
+    end
 
     # determine mode of operation
     use_recorded = !ENV.has_key?('OS_AUTH_URL')
@@ -90,6 +93,10 @@ RSpec.shared_context 'OpenStack specs with VCR' do
           # :openstack_user_domain    => ENV['OS_USER_DOMAIN_NAME']    || 'Default',
           # :openstack_project_domain => ENV['OS_PROJECT_DOMAIN_NAME'] || 'Default',
         }
+      end
+
+      if @service_options
+        options.merge!(@service_options)
       end
       @service = @service_class.new(options) unless @service
     end

--- a/spec/fog/openstack/volume_spec.rb
+++ b/spec/fog/openstack/volume_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe Fog::Volume::OpenStack do
   before :all do
     setup_vcr_and_service(
       :vcr_directory => 'spec/fog/openstack/volume',
-      :service_class => Fog::Volume::OpenStack
+      :service_class => Fog::Volume::OpenStack,
+      :service_options => { :openstack_service_type => ['volume'] } # force API version v1
     )
   end
 
@@ -231,7 +232,8 @@ RSpec.describe Fog::Volume::OpenStack do
         :openstack_region         => ENV['OS_REGION_NAME']         || 'RegionOne',
         :openstack_api_key        => ENV['OS_PASSWORD_OTHER']      || 'devstack',
         :openstack_username       => ENV['OS_USERNAME_OTHER']      || 'demo',
-        :openstack_tenant         => ENV['OS_PROJECT_NAME_OTHER']  || 'demo'
+        :openstack_tenant         => ENV['OS_PROJECT_NAME_OTHER']  || 'demo',
+        :openstack_service_type   => ['volume'] # enforce usage of Volume V1 API
       )
 
       # check that recipient cannot see the transfer object
@@ -309,7 +311,8 @@ RSpec.describe Fog::Volume::OpenStack do
         :openstack_region         => ENV['OS_REGION_NAME']         || 'RegionOne',
         :openstack_api_key        => ENV['OS_PASSWORD_OTHER']      || 'devstack',
         :openstack_username       => ENV['OS_USERNAME_OTHER']      || 'demo',
-        :openstack_tenant         => ENV['OS_PROJECT_NAME_OTHER']  || 'demo'
+        :openstack_tenant         => ENV['OS_PROJECT_NAME_OTHER']  || 'demo',
+        :openstack_service_type   => ['volume'] # enforce usage of Volume V1 API
       )
 
       # delete transfer again


### PR DESCRIPTION
Since the backwards-incompatible changes between v1 and v2 are tiny (only two attributes of volumes and snapshots have been renamed), I try to avoid code duplication and handle the changed attribute names gracefully.

This PR is in no way finished (there is no test coverage for v2, and I might also have to improve the get_service logic a bit), but I'm posting it already for some early feedback. I'll post line comments on the exact parts.