### PR TITLE
Adding #get_by_id for Fog::Compute::VcloudDirector::VmCustomizations

### DIFF
--- a/lib/fog/vcloud_director/models/compute/vm_customizations.rb
+++ b/lib/fog/vcloud_director/models/compute/vm_customizations.rb
@@ -8,6 +8,21 @@ module Fog
         model Fog::Compute::VcloudDirector::VmCustomization
 
         attribute :vm
+
+        private
+
+        def get_by_id(item_id)
+          item = service.get_vm_customization(item_id).body
+          add_id_from_href!(item)
+          item
+        end
+
+        # The HREF returned for a VM customization object is actually the VM
+        # HREF suffixed with '/guestCustomizationSection/' so we cannot use
+        # service.add_id_from_href! like all other collections.
+        def add_id_from_href!(item={})
+          item[:id] = item[:href].gsub('/guestCustomizationSection/', '').split('/').last
+        end
       end
     end
   end


### PR DESCRIPTION
This method is necessary for functions such as #reload to function on
a VM customization.  This also allows users who set and save a customization
to re-fetch it to get values such as the VM administrator password.