### PR TITLE
[openstack]reset api path by network model set tenant 

### DIFF
--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -238,14 +238,7 @@ module Fog
           @connection_options     = options[:connection_options] || {}
 
           authenticate
-
-          @path.sub!(/\/$/, '')
-          unless @path.match(SUPPORTED_VERSIONS)
-            @path = "/" + Fog::OpenStack.get_supported_version(SUPPORTED_VERSIONS,
-                                                               @openstack_management_uri,
-                                                               @auth_token,
-                                                               @connection_options)
-          end
+          set_api_path
 
           @persistent = options[:persistent] || false
           @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
@@ -284,6 +277,15 @@ module Fog
           response
         end
 
+        def set_api_path
+          @path.sub!(/\/$/, '')
+          unless @path.match(SUPPORTED_VERSIONS)
+            @path = "/" + Fog::OpenStack.get_supported_version(SUPPORTED_VERSIONS,
+                                                               @openstack_management_uri,
+                                                               @auth_token,
+                                                               @connection_options)
+          end
+        end
       end
     end
   end

--- a/lib/fog/openstack/requests/network/set_tenant.rb
+++ b/lib/fog/openstack/requests/network/set_tenant.rb
@@ -6,6 +6,7 @@ module Fog
           @openstack_must_reauthenticate = true
           @openstack_tenant = tenant.to_s
           authenticate
+          set_api_path
         end
       end
 


### PR DESCRIPTION
Api path has been reset called the network set tenants

call authenticateby network set tenant 
https://github.com/fog/fog/blob/master/lib/fog/openstack/requests/network/set_tenant.rb#L8

reset api path by openstack core
https://github.com/fog/fog/blob/master/lib/fog/openstack/core.rb#L151

api path must be set 
https://github.com/fog/fog/blob/master/lib/fog/openstack/network.rb#L242