### PR TITLE
Cloud Director supports multiple peer subnets.

### DIFF
--- a/lib/fog/vcloud_director/generators/compute/edge_gateway_service_configuration.rb
+++ b/lib/fog/vcloud_director/generators/compute/edge_gateway_service_configuration.rb
@@ -66,12 +66,13 @@ module Fog
                       xml.Netmask subnet[:Netmask]
                     }
                   end
-                  peer_subnet_config = tunnel_config[:PeerSubnet]
-                  xml.PeerSubnet {
-                    xml.Name peer_subnet_config[:Name]
-                    xml.Gateway peer_subnet_config[:Gateway]
-                    xml.Netmask peer_subnet_config[:Netmask]
-                  }
+                  tunnel_config[:PeerSubnet].each do |subnet|
+                    xml.PeerSubnet {
+                      xml.Name subnet[:Name]
+                      xml.Gateway subnet[:Gateway]
+                      xml.Netmask subnet[:Netmask]
+                    }
+                  end
                   xml.SharedSecret tunnel_config[:SharedSecret]
                   xml.SharedSecretEncrypted tunnel_config[:SharedSecretEncrypted] if tunnel_config.key?(:SharedSecretEncrypted)
                   xml.EncryptionProtocol tunnel_config[:EncryptionProtocol]

--- a/tests/vcloud_director/requests/compute/edge_gateway_tests.rb
+++ b/tests/vcloud_director/requests/compute/edge_gateway_tests.rb
@@ -26,11 +26,11 @@ Shindo.tests('Compute::VcloudDirector | edge gateway requests', ['vclouddirector
           :PeerId => "1223-123UDH-12321",
           :LocalIpAddress => "192.168.90.90",
           :LocalId => "202UB-9602-UB629",
-          :PeerSubnet => {
+          :PeerSubnet => [{
             :Name => "192.168.0.0/18",
             :Gateway => "192.168.0.0",
             :Netmask => "255.255.192.0",
-          },
+          }],
           :SharedSecret => "dont tell anyone",
           :SharedSecretEncrypted => "false",
           :EncryptionProtocol => "AES",


### PR DESCRIPTION
As with local_subnets, Vcloud-director supports
multiple peer_subnets. This is a needed feature if
you want to have multiple subnets talk
over the same VPN tunnel.