### PR TITLE
[OpenStack] Enable list_snapshots_detailed request

### DIFF
--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -45,6 +45,7 @@ module Fog
 
       request :create_volume_snapshot
       request :list_snapshots
+      request :list_snapshots_detailed
       request :get_snapshot_details
       request :delete_snapshot
 

--- a/spec/fog/openstack/volume_spec.rb
+++ b/spec/fog/openstack/volume_spec.rb
@@ -325,6 +325,11 @@ RSpec.describe Fog::Volume::OpenStack do
   end
 
   # TODO: tests for snapshots
+  it 'responds to list_snapshots_detailed' do
+    expect(@service.respond_to?(:list_snapshots_detailed)).to be true
+  end
+
+
   # TODO: tests for quotas
 
 end


### PR DESCRIPTION
Deprecation warnings suggest:

> [fog][DEPRECATION] Calling `OpenStack[:volume].list_snapshots(true)` is deprecated, use `.list_snapshots_detailed` instead

However, `Fog::OpenStack::Volume` does not respond to `.list_snapshots_detailed`.
Adding that to the list of requests available to the OpenStack Volume service.

Added a super-simple test to make sure the Volume service now at least responds to `list_snapshots_detailed`.