### PR TITLE
Fix deprecation warnings

### DIFF
--- a/lib/fog/openstack/models/compute/server.rb
+++ b/lib/fog/openstack/models/compute/server.rb
@@ -212,7 +212,7 @@ module Fog
         def security_groups
           requires :id
 
-          groups = service.list_security_groups(id).body['security_groups']
+          groups = service.list_security_groups(:server_id => id).body['security_groups']
 
           groups.map do |group|
             Fog::Compute::OpenStack::SecurityGroup.new group.merge({:service => service})

--- a/lib/fog/openstack/models/orchestration/stack.rb
+++ b/lib/fog/openstack/models/orchestration/stack.rb
@@ -45,7 +45,7 @@ module Fog
         end
 
         def resources(options={})
-          @resources ||= service.resources.all(self, options)
+          @resources ||= service.resources.all({:stack => self}.merge(options))
         end
 
         def events(options={})

--- a/lib/fog/openstack/requests/compute/list_security_groups.rb
+++ b/lib/fog/openstack/requests/compute/list_security_groups.rb
@@ -29,7 +29,15 @@ module Fog
       end
 
       class Mock
-        def list_security_groups(server_id = nil)
+        def list_security_groups(options = {})
+          if options.is_a?(Hash)
+            server_id = options.delete(:server_id)
+            query = options
+          else
+            server_id = options
+            query = {}
+          end
+
           security_groups = self.data[:security_groups].values
 
           groups = if server_id then


### PR DESCRIPTION
A couple fixes to internal calls that were causing deprecation warnings.

The warnings I was seeing were:

> Calling OpenStack[:compute].list_security_groups(server_id) is deprecated, use .list_security_groups(:server_id => value) instead

And,

> Calling OpenStack[:orchestration].list_resources(stack, options) is deprecated, call .list_resources(:stack => stack) or .list_resources(:stack_name => value, :stack_id => value) instead