### PR TITLE
relax dependency for fog-ecloud

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-aws", ">= 0.6.0")
   s.add_dependency("fog-brightbox", "~> 0.4")
   s.add_dependency("fog-dynect", "~> 0.0.2")
-  s.add_dependency("fog-ecloud", "= 0.1.1")
+  s.add_dependency("fog-ecloud", "~> 0.1")
   s.add_dependency("fog-google", ">= 0.0.2")
   s.add_dependency("fog-local")
   s.add_dependency("fog-powerdns", ">= 0.1.1")


### PR DESCRIPTION
allow any version less than 1.0.0

fixes #3679