### PR TITLE
[openstack] Snapshot manipulation using Openstack Cinder service

### DIFF
--- a/lib/fog/openstack/models/volume/snapshot.rb
+++ b/lib/fog/openstack/models/volume/snapshot.rb
@@ -1,0 +1,32 @@
+require 'fog/openstack/models/model'
+
+module Fog
+  module Volume
+    class OpenStack
+      class Snapshot < Fog::OpenStack::Model
+        identity :id
+
+        attribute :display_name
+        attribute :display_description
+        attribute :volume_id
+        attribute :status
+        attribute :size
+        attribute :created_at
+        attribute :metadata
+
+        def save(force=false)
+          requires :volume_id, :name, :description
+          data = service.create_volume_snapshot(volume_id, name, description, force)
+          merge_attributes(data.body['snapshot'])
+          true
+        end
+
+        def destroy
+          requires :id
+          service.delete_snapshot(id)
+          true
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/models/volume/snapshots.rb
+++ b/lib/fog/openstack/models/volume/snapshots.rb
@@ -1,0 +1,37 @@
+require 'fog/openstack/models/collection'
+require 'fog/openstack/models/volume/snapshot'
+
+module Fog
+  module Volume
+    class OpenStack
+      class Snapshots < Fog::OpenStack::Collection
+        model Fog::Volume::OpenStack::Snapshot
+
+        def all(options = {})
+          if !options.is_a?(Hash)
+            if options
+              Fog::Logger.deprecation('Calling OpenStack[:volume].snapshots.all(true) is deprecated, use .snapshots.all')
+            else
+              Fog::Logger.deprecation('Calling OpenStack[:volume].snapshots.all(false) is deprecated, use .snapshots.summary')
+            end
+            load_response(service.list_snapshots(options), 'snapshots')
+          else
+            load_response(service.list_snapshots_detailed(options), 'snapshots')
+          end
+        end
+
+        def summary(options = {})
+          load_response(service.list_snapshots(options), 'snapshots')
+        end
+
+        def get(snapshot_id)
+          if snapshot = service.get_snapshot_details(snapshot_id).body['snapshot']
+            new(snapshot)
+          end
+        rescue Fog::Volume::OpenStack::NotFound
+          nil
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -28,6 +28,9 @@ module Fog
       model       :transfer
       collection  :transfers
 
+      model       :snapshot
+      collection  :snapshots
+
       request_path 'fog/openstack/requests/volume'
 
        # Volume


### PR DESCRIPTION
In, current version, snapshot manipulation is using Nova Endpoint, it couldn't show metadata of a snapshot, but Cinder Endpoint can.

So, I've cloned Snapshot method from Compute model to Volume model for using Cinder Endpoint.

The result when get Snapshot by Compute model:

```
=>   <Fog::Compute::OpenStack::Snapshot
    id="91361632-5ea8-4ca5-8e35-b8dd4568d4f8",
    name="1231231231_rootdisk@2015-08-04",
    description="",
    volume_id="c63ff7aa-4858-41ea-8bac-b09a9c0a155f",
    status="available",
    size=20,
    created_at="2015-08-04T04:08:09.000000"
  >
```

^ No metadata here

And, the result from Volume model:

```
<Fog::Volume::OpenStack::Snapshot
    id="91361632-5ea8-4ca5-8e35-b8dd4568d4f8",
    display_name="1231231231_rootdisk@2015-08-04",
    display_description="",
    volume_id="c63ff7aa-4858-41ea-8bac-b09a9c0a155f",
    status="available",
    size=20,
    created_at="2015-08-04T04:08:09.000000",
    metadata={"type"=>"backup", "job_id"=>"55bee7bcf4ebf4920800000e"}
  >
```