### PR TITLE
[#3099] Remove Nokogiri constraint

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-xml", "~> 0.1.1")
 
   s.add_dependency("ipaddress", "~> 0.5")
-  s.add_dependency("nokogiri", "~> 1.5", ">= 1.5.11")
+  s.add_dependency("nokogiri")
 
   # Modular providers (please keep sorted)
   s.add_dependency("fog-atmos")


### PR DESCRIPTION
Since 1.8.7 compatibility has been dropped, we no longer need to lock to
the last usable version. This should allow usage of later Rails which
require newer nokogiri versions.