### PR TITLE
Fix distributed port group switches support for cloning with multiple networks

### DIFF
--- a/lib/fog/vsphere/models/compute/network.rb
+++ b/lib/fog/vsphere/models/compute/network.rb
@@ -7,6 +7,7 @@ module Fog
         attribute :name
         attribute :datacenter
         attribute :accessible # reachable by at least one hypervisor
+        attribute :virtualswitch
 
         def to_s
           name

--- a/lib/fog/vsphere/requests/compute/list_networks.rb
+++ b/lib/fog/vsphere/requests/compute/list_networks.rb
@@ -20,10 +20,11 @@ module Fog
 
         def network_attributes network, datacenter
           {
-            :id         => managed_obj_id(network),
-            :name       => network.name,
-            :accessible => network.summary.accessible,
-            :datacenter => datacenter,
+            :id            => managed_obj_id(network),
+            :name          => network.name,
+            :accessible    => network.summary.accessible,
+            :datacenter    => datacenter,
+            :virtualswitch => network.class.to_s == "DistributedVirtualPortgroup" ? network.config.distributedVirtualSwitch.name : nil
           }
         end
       end

--- a/lib/fog/vsphere/requests/compute/vm_clone.rb
+++ b/lib/fog/vsphere/requests/compute/vm_clone.rb
@@ -652,20 +652,17 @@ module Fog
 
 
         def modify_template_nics_specs(template_path, new_nics, datacenter)
-          #new_spec_operation = RbVmomi::VIM::VirtualDeviceConfigSpecOperation('new')
-          #remove_spec_operation = RbVmomi::VIM::VirtualDeviceConfigSpecOperation('remove')
-
           template_nics = list_vm_interfaces(template_path, datacenter).map do |old_attributes|
             Fog::Compute::Vsphere::Interface.new(old_attributes)
           end
           specs = []
 
           template_nics.each do |interface|
-            specs << create_interface(interface, interface.key, :remove)
+            specs << create_interface(interface, interface.key, :remove, :datacenter => datacenter)
           end
 
           new_nics.each do |interface|
-            specs << create_interface(interface, 0, :add)
+            specs << create_interface(interface, 0, :add, :datacenter => datacenter)
           end
 
           return specs


### PR DESCRIPTION
We were not passing the datacenter parameter when searching for networks,
which caused issues when searching for distributed switches attributes

Also, I've extracted the virtualswitch parameter to the network model,
which allows to specify the virtualswitch value for the network interface
based on the network data later. Our workflow is letting the user
to choose what network should be the nic attached to and then creating
the networks correspondingly and we use the network object for that.