### PR TITLE
[openstack] Add request for Cinder to get quota usage

### DIFF
--- a/lib/fog/openstack/requests/volume/get_quota_usage.rb
+++ b/lib/fog/openstack/requests/volume/get_quota_usage.rb
@@ -1,0 +1,44 @@
+module Fog
+  module Volume
+    class OpenStack
+      class Real
+        def get_quota_usage(tenant_id)
+          request(
+            :expects  => 200,
+            :method   => 'GET',
+            :path     => "/os-quota-sets/#{tenant_id}?usage=True"
+          )
+        end
+      end
+
+      class Mock
+        def get_quota_usage(tenant_id)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            'quota_set' => {
+              'gigabytes' => {
+                'reserved' => 0,
+                'limit'    => -1,
+                'in_use'   => 160
+              },
+              'snapshots' => {
+                'reserved' => 0,
+                'limit'    => 50,
+                'in_use'   => 3
+              },
+              'volumes' => {
+                'reserved' => 0,
+                'limit'    => 50,
+                'in_use'    => 5
+              },
+              'id' => tenant_id
+            }
+          }
+          response
+        end
+      end
+
+    end
+  end
+end

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -63,6 +63,8 @@ module Fog
       request :get_quota
       request :get_quota_defaults
 
+      request :get_quota_usage
+
       request :set_tenant
 
       class Mock


### PR DESCRIPTION
by the discusion in #3688 
Adding new request to get quota usage of Cinder.

Usage:

```
Fog::Volume.new(arg).get_quota_usage('21087bce688b49dbaec1a11da8105b12')

=> #<Excon::Response:0x007f9e616ebed0
 @body=
  "{\"quota_set\": {\"gigabytes_SAS\": {\"reserved\": 0, \"limit\": 2000, \"in_use\": 180}, \"gigabytes\": {\"reserved\": 0, \"limit\": -1, \"in_use\": 180}, \"backup_gigabytes\": {\"reserved\": 0, \"limit\": 1000, \"in_use\": 0}, \"snapshots_SAS\": {\"reserved\": 0, \"limit\": -1, \"in_use\": 4}, \"snapshots\": {\"reserved\": 0, \"limit\": 50, \"in_use\": 4}, \"volumes_SAS\": {\"reserved\": 0, \"limit\": -1, \"in_use\": 5}, \"snapshots_TRUESSD\": {\"reserved\": 0, \"limit\": -1, \"in_use\": 0}, \"volumes\": {\"reserved\": 0, \"limit\": 50, \"in_use\": 5}, \"gigabytes_TRUESSD\": {\"reserved\": 0, \"limit\": 200, \"in_use\": 0}, \"volumes_TRUESSD\": {\"reserved\": 0, \"limit\": -1, \"in_use\": 0}, \"backups\": {\"reserved\": 0, \"limit\": 10, \"in_use\": 0}, \"id\": \"21087bce688b49dbaec1a11da8105b12\"}}",
 @data=
  {:body=>
    {"quota_set"=>
      {"gigabytes_SAS"=>{"reserved"=>0, "limit"=>2000, "in_use"=>180},
       "gigabytes"=>{"reserved"=>0, "limit"=>-1, "in_use"=>180},
       "backup_gigabytes"=>{"reserved"=>0, "limit"=>1000, "in_use"=>0},
       "snapshots_SAS"=>{"reserved"=>0, "limit"=>-1, "in_use"=>4},
       "snapshots"=>{"reserved"=>0, "limit"=>50, "in_use"=>4},
       "volumes_SAS"=>{"reserved"=>0, "limit"=>-1, "in_use"=>5},
       "snapshots_TRUESSD"=>{"reserved"=>0, "limit"=>-1, "in_use"=>0},
       "volumes"=>{"reserved"=>0, "limit"=>50, "in_use"=>5},
       "gigabytes_TRUESSD"=>{"reserved"=>0, "limit"=>200, "in_use"=>0},
       "volumes_TRUESSD"=>{"reserved"=>0, "limit"=>-1, "in_use"=>0},
       "backups"=>{"reserved"=>0, "limit"=>10, "in_use"=>0},
       "id"=>"21087bce688b49dbaec1a11da8105b12"}},
```