### PR TITLE
fix linode kernel selection bug

### DIFF
--- a/lib/fog/linode/models/compute/kernels.rb
+++ b/lib/fog/linode/models/compute/kernels.rb
@@ -12,7 +12,7 @@ module Fog
         end
 
         def get(id)
-          new kernels(id).first
+          new kernels(id).select {|kernel| kernel[:id] == id }.first
         rescue Fog::Compute::Linode::NotFound
           nil
         end


### PR DESCRIPTION
I'm using knife-linode which depends on fog.
And it turned out that it doesn't pay attention to kernel ID provided. It instead just selects the first kernel from kernel list response.
This pull request is to fix the issue.