### PR TITLE
Limit 1.9.3 tests to use older Net::SSH

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,9 @@ sudo: false
 script: bundle exec rake travis
 
 rvm:
-  - 1.9
   - 2.0
   - 2.1
   - 2.2
-  - jruby-19mode
   - jruby-head
 
 gemfile:
@@ -18,6 +16,11 @@ gemfile:
 
 matrix:
   fast_finish: true
+  include:
+    - rvm: 1.9
+      gemfile: gemfiles/Gemfile-ruby-1.9.3
+    - rvm: jruby-19mode
+      gemfile: gemfiles/Gemfile-ruby-1.9.3
   allow_failures:
     - rvm: jruby-head
     - rvm: 2.2

--- a/gemfiles/Gemfile-ruby-1.9.3
+++ b/gemfiles/Gemfile-ruby-1.9.3
@@ -1,0 +1,12 @@
+source "https://rubygems.org"
+
+gem "net-ssh", "< 3.0"
+
+group :development, :test do
+  # This is here because gemspec doesn"t support require: false
+  gem "coveralls", :require => false
+  gem "netrc", :require => false
+  gem "octokit", :require => false
+end
+
+gemspec :path => "../"


### PR DESCRIPTION
Net::SSH 3.0 dropped support for Ruby 1.9.3 so older Rubies should
declare the dependency to avoid bundling problems.