### PR TITLE
Added case to reboot gracefully if toolsOld

### DIFF
--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -157,7 +157,7 @@ module Fog
         end
 
         def tools_running?
-          tools_state == "toolsOk"
+          ["toolsOk","toolsOld"].include? tools_state
         end
 
         # defines VNC attributes on the hypervisor


### PR DESCRIPTION
https://www.vmware.com/support/developer/converter-sdk/conv50_apireference/vim.vm.GuestInfo.ToolsStatus.html

Having a response of `tools_state` == `toolsOld` is ok in my opinion since tools functionality doesn't change drastically revision to revision. 

Currently vSphere will force stop your assets if your vmware tools aren't up to date (even by one small revision). This behaviour is not optimal. 

The `tools_running?` check is only used in one place, the stop command in server.rb.