### PR TITLE
Ensure root user behaves like Rackspace defaults

### DIFF
--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -619,7 +619,11 @@ module Fog
         end
 
         def password_lock
-          "passwd -l #{username}" unless attributes[:no_passwd_lock]
+          if !attributes[:no_passwd_lock].nil?
+            Fog::Logger.warning("Rackspace[:no_passwd_lock] is deprecated since it is now the default behavior, use Rackspace[:passwd_lock] instead")
+          end
+
+          "passwd -l #{username}" if attributes[:passwd_lock]
         end
 
         def user_data_encoded

--- a/lib/fog/rackspace/models/compute_v2/servers.rb
+++ b/lib/fog/rackspace/models/compute_v2/servers.rb
@@ -27,8 +27,8 @@ module Fog
         # @raise [Fog::Compute::RackspaceV2::BadRequest] - HTTP 400
         # @raise [Fog::Compute::RackspaceV2::InternalServerError] - HTTP 500
         # @raise [Fog::Compute::RackspaceV2::ServiceError]
-        # @note This method is compatible with Cloud Servers utlizing RackConnect ***if and only if***
-        #       provided the attribute "no_passwd_lock" set to *true*.
+        # @note This method is incompatible with Cloud Servers utlizing RackConnect ***if and only if***
+        #       provided the attribute "passwd_lock" left at *false*.
         # @example
         #   service.servers.bootstrap :name => 'bootstrap-server',
         #                             :flavor_id => service.flavors.first.id,

--- a/tests/rackspace/models/compute_v2/server_tests.rb
+++ b/tests/rackspace/models/compute_v2/server_tests.rb
@@ -228,27 +228,27 @@ Shindo.tests('Fog::Compute::RackspaceV2 | server', ['rackspace']) do
       Fog::SSH::Mock.data[@address].first[:commands]
     }
 
-    test("leaves user unlocked only when requested") do
-      create_server.call(ATTRIBUTES.merge(:no_passwd_lock => true))
-      commands.call.none? { |c| c =~ /passwd\s+-l\s+root/ }
+    test("lock user when requested") do
+      create_server.call(ATTRIBUTES.merge(:passwd_lock => true))
+      commands.call.one? { |c| c =~ /passwd\s+-l\s+root/ }
     end
 
     test("provide a password when the passed isn't locked") do
       pwd = create_server.call(
-        ATTRIBUTES.merge(:no_passwd_lock => true)
+        ATTRIBUTES.merge(:passwd_lock => false)
       ).password
 
       # shindo expects a boolean not truthyness :-(
       !!pwd
     end
 
-    test("locks user by default") do
+    test("leaves user unlocked by default") do
       create_server.call(ATTRIBUTES)
-      commands.call.one? { |c| c =~ /passwd\s+-l\s+root/ }
+      commands.call.none? { |c| c =~ /passwd\s+-l\s+root/ }
     end
 
     test("nils password when password is locked") do
-      pwd = create_server.call(ATTRIBUTES).password
+      pwd = create_server.call(ATTRIBUTES.merge(:passwd_lock => true)).password
       pwd.nil?
     end
   end


### PR DESCRIPTION
Swap the logic for `:no_passwd_lock` making it `:passwd_lock`. Per #3715, we really should make our defaults the same as Rackspace's. Because so many projects rely on the fog library, and can't all add this option to pass through, we should default to the same behaviors you'd get on vanilla Rackspace.

This change is backwards compatible, but still warns those who have explicitly set :no_passwd_lock to any specific value.

Fixes #3715. RE: #2494.