### PR TITLE
change get_raw replacement regex from />/ to /=>/ for output XML

### DIFF
--- a/lib/fog/opennebula/models/compute/flavor.rb
+++ b/lib/fog/opennebula/models/compute/flavor.rb
@@ -48,24 +48,24 @@ module Fog
           return "CPU=#{vcpu.to_f/10}\n" unless cpu
           return "CPU=#{vcpu}\n" if cpu.to_i > vcpu.to_i
           "CPU=#{cpu}\n"
-        end  
+        end
 
         def get_vcpu
           self.vcpu = 1 unless vcpu
           "VCPU=#{vcpu}\n"
-        end  
+        end
 
         def get_memory
           self.memory = 128 unless memory
           "MEMORY=#{memory}\n"
-        end  
+        end
 
         def get_raw
           return "" unless raw
           ret = "RAW=#{raw}\n"
           ret.gsub!(/\{/, '[')
           ret.gsub!(/\}/, ']')
-          ret.gsub!(/>/,'')
+          ret.gsub!(/=>/,'=')
           ret
         end
 
@@ -82,7 +82,7 @@ module Fog
           ret.gsub!(/\{/, '[')
           ret.gsub!(/\}/, ']')
           ret.gsub!(/>/,'')
-          ret 
+          ret
         end
 
         def get_os
@@ -91,16 +91,16 @@ module Fog
           ret.gsub!(/\{/, '[')
           ret.gsub!(/\}/, ']')
           ret.gsub!(/>/,'')
-          ret 
+          ret
         end
 
         def get_graphics
-          return "" unless graphics 
+          return "" unless graphics
           ret = "GRAPHICS=#{graphics}\n"
           ret.gsub!(/\{/, '[')
           ret.gsub!(/\}/, ']')
           ret.gsub!(/>/,'')
-          ret 
+          ret
         end
 
         def get_nic
@@ -115,26 +115,26 @@ module Fog
           #ret.gsub!(/\{/, '[')
           #ret.gsub!(/\}/, ']')
           #ret.gsub!(/>/,'')
-          ret 
+          ret
         end
 
         def get_sched_ds_requirements
-          return "" unless sched_ds_requirements 
+          return "" unless sched_ds_requirements
           %Q|SCHED_DS_REQUIREMENTS="#{sched_ds_requirements.gsub(/"/){ %q(\") }}"\n|
         end
 
         def get_sched_ds_rank
-          return "" unless sched_ds_rank 
+          return "" unless sched_ds_rank
           %Q|SCHED_DS_RANK="#{sched_ds_rank.gsub(/"/){ %q(\") }}"\n|
         end
 
         def get_sched_requirements
-          return "" unless sched_requirements 
+          return "" unless sched_requirements
           %Q|SCHED_REQUIREMENTS="#{sched_requirements.gsub(/"/){ %q(\") }}"\n|
         end
 
         def get_sched_rank
-          return "" unless sched_rank 
+          return "" unless sched_rank
           %Q|SCHED_RANK="#{sched_rank.gsub(/"/){ %q(\") }}"\n|
         end
 

--- a/lib/fog/opennebula/requests/compute/template_pool.rb
+++ b/lib/fog/opennebula/requests/compute/template_pool.rb
@@ -21,6 +21,9 @@
 # OS=[
 #     ARCH="x86_64",
 #     BOOT="network,hd" ]
+# RAW=[
+#   DATA="<cpu match='exact'><model fallback='allow'>core2duo</model></cpu>",
+#   TYPE="kvm" ]
 
 
 module Fog
@@ -37,7 +40,7 @@ module Fog
             templates.info!(-2, filter[:id], filter[:id])
           end # if filter[:id].nil?
 
-          templates = templates.map do |t| 
+          templates = templates.map do |t|
             # filtering by name
             # done here, because OpenNebula:TemplatePool does not support something like .delete_if
             if filter[:name] && filter[:name].is_a?(String) && !filter[:name].empty?
@@ -51,8 +54,8 @@ module Fog
             end
 
             h = Hash[
-              :id => t.to_hash["VMTEMPLATE"]["ID"], 
-              :name => t.to_hash["VMTEMPLATE"]["NAME"], 
+              :id => t.to_hash["VMTEMPLATE"]["ID"],
+              :name => t.to_hash["VMTEMPLATE"]["NAME"],
               :content => t.template_str,
               :USER_VARIABLES => "" # Default if not set in template
             ]
@@ -67,7 +70,7 @@ module Fog
                   vnet = networks.get(n["NETWORK_ID"].to_s)
                 elsif n["NETWORK"]
                   vnet = networks.get_by_name(n["NETWORK"].to_s)
-                else 
+                else
                   next
                 end
                 h["NIC"] << interfaces.new({ :vnet => vnet, :model => n["MODEL"] || "virtio" })
@@ -87,15 +90,15 @@ module Fog
             else
               # should i break?
             end
-          
+
             # every key should be lowercase
             ret_hash = {}
-            h.each_pair do |k,v| 
-              ret_hash.merge!({k.downcase => v}) 
+            h.each_pair do |k,v|
+              ret_hash.merge!({k.downcase => v})
             end
             ret_hash
           end
-          
+
           templates.delete nil
           raise Fog::Compute::OpenNebula::NotFound, "Flavor/Template not found" if templates.empty?
           templates
@@ -107,7 +110,7 @@ module Fog
           nic1 = Mock_nic.new
           nic1.vnet = networks.first
 
-          [ 
+          [
             {
               :content => %Q{
                 NAME = mock-vm
@@ -131,14 +134,14 @@ module Fog
                 'ARCH' => 'x86_64'
               },
               :graphics => {},
-              :raw => {},
+              :raw => %|["DATA"=>"<cpu match='exact'><model fallback='allow'>core2duo</model></cpu>", "TYPE"=>"kvm"]|,
               :context => {},
               :user_variables => {}
             }
           ]
         end
 
-        class Mock_nic 
+        class Mock_nic
           attr_accessor :vnet
 
           def id

--- a/tests/opennebula/models/compute/flavor_tests.rb
+++ b/tests/opennebula/models/compute/flavor_tests.rb
@@ -9,7 +9,6 @@ Shindo.tests('Fog::Compute[:opennebula] | flavor model', ['opennebula']) do
     end
     tests('have attributes') do
       model_attribute_hash = flavor.attributes
-      attributes = 
       tests("The flavor model should respond to") do
         [:name, :id, :to_label, :to_s, :get_cpu, :get_vcpu, :get_memory, :get_raw, :get_disk, :get_os,
           :get_graphics, :get_nic, :get_sched_ds_requirements, :get_sched_ds_rank, :get_sched_requirements,
@@ -31,6 +30,7 @@ Shindo.tests('Fog::Compute[:opennebula] | flavor model', ['opennebula']) do
     test('have a 666 MB memory') { flavor.get_memory == "MEMORY=666\n" }
     test('have a 666 CPUs') { flavor.get_vcpu == "VCPU=666\n" }
 
+    test('raw parsed properly') { flavor.get_raw == %|RAW=["DATA"="<cpu match='exact'><model fallback='allow'>core2duo</model></cpu>", "TYPE"="kvm"]\n| }
   end
 
 end


### PR DESCRIPTION
OpenNebula template may include RAW data. And if RAW data is like this:
```xml
RAW=["DATA"=>"<cpu match='exact'><model fallback='allow'>core2duo</model></cpu>", "TYPE"=>"kvm"]
```
Then current implementation replaces all '>' with ''. So output template will be:
```xml
RAW=["DATA"="<cpu match='exact'<model fallback='allow'core2duo</model</cpu", "TYPE"="kvm"]
```
And it generates an error. So i patch it to generating output like this:
```xml
RAW=["DATA"="<cpu match='exact'><model fallback='allow'>core2duo</model></cpu>", "TYPE"="kvm"]
```