### PR TITLE
OpenStack storage: remap standard Fog attributes (max_keys => limit)

### DIFF
--- a/lib/fog/openstack/models/storage/directories.rb
+++ b/lib/fog/openstack/models/storage/directories.rb
@@ -13,6 +13,12 @@ module Fog
         end
 
         def get(key, options = {})
+          remap_attributes(options, {
+            :delimiter  => 'delimiter',
+            :marker     => 'marker',
+            :max_keys   => 'limit',
+            :prefix     => 'prefix'
+          })
           data = service.get_container(key, options)
           directory = new(:key => key)
           for key, value in data.headers


### PR DESCRIPTION
Add remapping of standard Fog attributes, like max_keys, to directories.
This way users are not forced to add custom 'limit' attributes into the
higher level calls they make. This is important, as you might want to
write code that's compatible with multiple cloud providers. Explicitly
including 'limit' attribute breaks some APIs (e.g. Google Cloud Storage).
With this PR you can use standard fog max_keys to achieve limit functionality on
OpenStack SWIFT.

Note: this has not been fully tested and likely needs a bit more work.