### PR TITLE
[vsphere] - unable to add more than 7 disks

### DIFF
--- a/lib/fog/vsphere/requests/compute/create_vm.rb
+++ b/lib/fog/vsphere/requests/compute/create_vm.rb
@@ -122,18 +122,23 @@ module Fog
         end
 
         def create_disk disk, index = 0, operation = :add, controller_key = 1000
+          if (index > 6) then
+            _index = index + 1
+          else
+            _index = index
+          end
           payload = {
             :operation     => operation,
             :fileOperation => operation == :add ? :create : :destroy,
             :device        => RbVmomi::VIM.VirtualDisk(
-              :key           => disk.key || index,
+              :key           => disk.key || _index,
               :backing       => RbVmomi::VIM.VirtualDiskFlatVer2BackingInfo(
                 :fileName        => "[#{disk.datastore}]",
                 :diskMode        => disk.mode.to_sym,
                 :thinProvisioned => disk.thin
               ),
               :controllerKey => controller_key,
-              :unitNumber    => index,
+              :unitNumber    => _index,
               :capacityInKB  => disk.size
             )
           }


### PR DESCRIPTION
Hi, This is a fix for creating a vm with more than 7 disks. The issue exists because the SCSI controller takes ID 7, and the fog library creates disks generally based on array key (in the case of Foreman anyway). #3728  