### PR TITLE
[vsphere] add support for taking snapshot

### DIFF
--- a/lib/fog/vsphere/compute.rb
+++ b/lib/fog/vsphere/compute.rb
@@ -86,6 +86,7 @@ module Fog
       request :list_customfields
       request :get_vm_first_scsi_controller
       request :set_vm_customvalue
+      request :vm_take_snapshot
 
       module Shared
         attr_reader :vsphere_is_vcenter

--- a/lib/fog/vsphere/models/compute/server.rb
+++ b/lib/fog/vsphere/models/compute/server.rb
@@ -148,6 +148,11 @@ module Fog
           new_vm
         end
 
+        def take_snapshot(options = {})
+          requires :instance_uuid
+          service.vm_take_snapshot(options.merge('instance_uuid' => instance_uuid))
+        end
+
         def ready?
           power_state == "poweredOn"
         end

--- a/lib/fog/vsphere/requests/compute/vm_take_snapshot.rb
+++ b/lib/fog/vsphere/requests/compute/vm_take_snapshot.rb
@@ -1,0 +1,37 @@
+module Fog
+  module Compute
+    class Vsphere
+      class Real
+        def vm_take_snapshot(options = {})
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.key? 'instance_uuid'
+          raise ArgumentError, "name is a required parameter" unless options.key? 'name'
+          vm = get_vm_ref(options['instance_uuid'])
+          task = vm.CreateSnapshot_Task(
+            name: options['name'],
+            description: options['description'] || '',
+            memory: options['memory'] || true,
+            quiesce: options['quiesce'] || false
+          )
+
+          task.wait_for_completion
+
+          {
+            'task_state' => task.info.state,
+            'was_cancelled' => task.info.cancelled
+          }
+        end
+      end
+
+      class Mock
+        def vm_take_snapshot(options = {})
+          raise ArgumentError, "instance_uuid is a required parameter" unless options.key? 'instance_uuid'
+          raise ArgumentError, "name is a required parameter" unless options.key? 'name'
+          {
+            'task_state' => 'success',
+            'was_cancelled' => false
+          }
+        end
+      end
+    end
+  end
+end

--- a/tests/helper.rb
+++ b/tests/helper.rb
@@ -3,6 +3,7 @@ ENV['FOG_CREDENTIAL'] = ENV['FOG_CREDENTIAL'] || 'default'
 
 require 'fog'
 require 'fog/bin' # for available_providers and registered_providers
+require 'ostruct'
 
 Excon.defaults.merge!(:debug_request => true, :debug_response => true)
 

--- a/tests/vsphere/models/compute/server_tests.rb
+++ b/tests/vsphere/models/compute/server_tests.rb
@@ -10,6 +10,10 @@ Shindo.tests('Fog::Compute[:vsphere] | server model', ['vsphere']) do
         test(action) { server.respond_to? action }
         test("#{action} returns successfully") { server.send(action.to_sym) ? true : false }
       end
+      test('take_snapshot') do
+        test('responds') { server.respond_to? 'take_snapshot'}
+        test('returns successfully') { server.take_snapshot('name' => 'foobar').kind_of? Hash }
+      end
     end
     tests('have attributes') do
       model_attribute_hash = server.attributes

--- a/tests/vsphere/requests/compute/vm_take_snapshot_tests.rb
+++ b/tests/vsphere/requests/compute/vm_take_snapshot_tests.rb
@@ -1,0 +1,19 @@
+Shindo.tests('Fog::Compute[:vsphere] | vm_take_snapshot request', ['vsphere']) do
+
+  compute = Fog::Compute[:vsphere]
+
+  powered_off_vm = nil
+
+  tests('The response should') do
+    response = compute.vm_take_snapshot('instance_uuid' => powered_off_vm, 'name' => 'foobar')
+    test('be a kind of Hash') { response.kind_of? Hash }
+    test('should have a task_state key') { response.key? 'task_state' }
+    test('should have a was_cancelled key') { response.key? 'was_cancelled' }
+  end
+
+  tests('The expected options') do
+    raises(ArgumentError, 'raises ArgumentError when instance_uuid option is missing') { compute.vm_take_snapshot('name' => 'foobar') }
+    raises(ArgumentError, 'raises ArgumentError when name option is missing') { compute.vm_take_snapshot('instance_uuid' => powered_off_vm) }
+  end
+
+end


### PR DESCRIPTION
Hi,
 
This is the first improvement of vsphere provider for fog. It adds the ability to take snapshot only, it simply adds take_snapshot method to compute model.
 
The functions list_snapshot and revert to snapshot will follow in the future.
 
Best regards
ireznice