### PR TITLE
fix method call name in openstack node destroy so that it will work

### DIFF
--- a/lib/fog/openstack/models/baremetal/nodes.rb
+++ b/lib/fog/openstack/models/baremetal/nodes.rb
@@ -27,7 +27,7 @@ module Fog
         alias_method :get, :find_by_uuid
 
         def destroy(uuid)
-          node = self.find_by_id(uuid)
+          node = self.find_by_uuid(uuid)
           node.destroy
         end
 


### PR DESCRIPTION
"find_by_id" is not defined. That's a typo that should be "find_by_uuid". It causes the below error if you try to call the destroy method. This commit fixes it.

Excon::Errors::BadRequest: Expected([200, 204]) <=> Actual(400 Bad Request)
excon.error.response
  :body          => "{\"error_message\": \"{\\\"debuginfo\\\": null, \\\"faultcode\\\": \\\"Client\\\", \\\"faultstring\\\": \\\"Unknown argument: \\\\\\\"id\\\\\\\"\\\"}\"}"

	from /opt/rh/ruby193/root/usr/share/gems/gems/excon-0.45.3/lib/excon/middlewares/expects.rb:10:in `response_call'
	from /opt/rh/ruby193/root/usr/share/gems/gems/excon-0.45.3/lib/excon/middlewares/response_parser.rb:8:in `response_call'
	from /opt/rh/ruby193/root/usr/share/gems/gems/excon-0.45.3/lib/excon/connection.rb:372:in `response'
	from /opt/rh/ruby193/root/usr/share/gems/gems/excon-0.45.3/lib/excon/connection.rb:236:in `request'
	from /opt/rh/ruby193/root/usr/share/gems/gems/fog-core-1.32.0/lib/fog/core/connection.rb:81:in `request'
	from /opt/rh/ruby193/root/usr/share/gems/gems/fog-1.32.0/lib/fog/openstack/baremetal.rb:295:in `request'
	from /opt/rh/ruby193/root/usr/share/gems/gems/fog-1.32.0/lib/fog/openstack/requests/baremetal/list_nodes_detailed.rb:10:in `list_nodes_detailed'
	from /opt/rh/ruby193/root/usr/share/gems/gems/fog-1.32.0/lib/fog/openstack/models/baremetal/nodes.rb:36:in `method_missing'
	from /opt/rh/ruby193/root/usr/share/gems/gems/fog-1.32.0/lib/fog/openstack/models/baremetal/nodes.rb:30:in `destroy'