### PR TITLE
Fix Digital Ocean V2 ssh key creation

### DIFF
--- a/lib/fog/digitalocean/requests/compute_v2/create_ssh_key.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/create_ssh_key.rb
@@ -13,7 +13,7 @@ module Fog
           encoded_body = Fog::JSON.encode(create_options)
 
           request(
-            :expects => [202],
+            :expects => [201],
             :headers => {
               'Content-Type' => "application/json; charset=UTF-8",
             },
@@ -28,7 +28,7 @@ module Fog
       class Mock
         def create_ssh_key(name, public_key)
           response        = Excon::Response.new
-          response.status = 202
+          response.status = 201
 
           response.body ={
             'ssh_key' => {


### PR DESCRIPTION
The Digital Ocean V2 API returns a 201 on success when creating an ssh key, not a 202: https://developers.digitalocean.com/documentation/v2/#create-a-new-key

I've verified this works locally.  Currently, fog throws an excon exception upon successful creation of an ssh key