### PR TITLE
Fixed issue with OpenStack Auth v2

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -261,9 +261,9 @@ module Fog
         raise Fog::Errors::NotFound, message
       end
 
-      if service['endpoints'].count > 1
-        regions = service["endpoints"].map{ |e| e['region'] }.uniq.join(',')
-        raise Fog::Errors::NotFound.new("Multiple regions available choose one of these '#{regions}'")
+      regions = service["endpoints"].map{ |e| e['region'] }.uniq
+      if regions.count > 1
+        raise Fog::Errors::NotFound.new("Multiple regions available choose one of these '#{regions.join(',')}'")
       end
 
       identity_service = get_service(body, identity_service_type) if identity_service_type


### PR DESCRIPTION
As mentioned in #3744 the "Multiple regions available choose one of these" exception could be raised even when there is only one region.

This happened as the check was performed directly on the array of endpoints, which might include more than one.