### PR TITLE
[Rackspace] Fix set node type for Rackspace load balancer

### DIFF
--- a/lib/fog/rackspace/requests/load_balancers/create_node.rb
+++ b/lib/fog/rackspace/requests/load_balancers/create_node.rb
@@ -15,7 +15,7 @@ module Fog
             data['nodes'][0]['weight'] = options[:weight]
           end
           if options.key? :type
-            data['node']['type'] = options[:type]
+            data['nodes'][0]['type'] = options[:type]
           end
           request(
             :body     => Fog::JSON.encode(data),

--- a/tests/rackspace/requests/load_balancers/node_tests.rb
+++ b/tests/rackspace/requests/load_balancers/node_tests.rb
@@ -23,6 +23,13 @@ Shindo.tests('Fog::Rackspace::LoadBalancers | node_tests', ['rackspace']) do
         end
 
         @lb.wait_for { ready? }
+        tests('#create_node with type').formats(NODES_FORMAT) do
+          data = @service.create_node(@lb.id, '1.1.1.4', 80, 'ENABLED', { :type => 'PRIMARY' }).body
+          @nodes_created << data['nodes'][0]['id']
+          data
+        end
+
+        @lb.wait_for { ready? }
         tests("#list_nodes(#{@lb.id})").formats(NODES_FORMAT) do
           @service.list_nodes(@lb.id).body
         end


### PR DESCRIPTION
Fixed bug building the node type request. I also added a test for setting the node type.

I run into this issue trying to set a failover node:

https://community.rackspace.com/products/f/25/t/4377