### PR TITLE
[OpenStack] Users can be created without a tenant ID or password

### DIFF
--- a/lib/fog/openstack/models/identity_v2/user.rb
+++ b/lib/fog/openstack/models/identity_v2/user.rb
@@ -28,7 +28,7 @@ module Fog
 
           def save
             raise Fog::Errors::Error.new('Resaving an existing object may create a duplicate') if persisted?
-            requires :name, :tenant_id, :password
+            requires :name
             enabled = true if enabled.nil?
             data = service.create_user(name, password, email, tenant_id, enabled)
             merge_attributes(data.body['user'])
@@ -62,7 +62,11 @@ module Fog
           end
 
           def roles(tenant_id = self.tenant_id)
-            service.list_roles_for_user_on_tenant(tenant_id, self.id).body['roles']
+            if tenant_id
+              service.list_roles_for_user_on_tenant(tenant_id, self.id).body['roles']
+            else
+              []
+            end
           end
         end # class User
       end # class V2


### PR DESCRIPTION
See http://developer.openstack.org/api-ref-identity-admin-v2.html#admin-createUser

![screen shot 2015-11-16 at 12 23 51](https://cloud.githubusercontent.com/assets/98526/11181764/f5869078-8c5c-11e5-82ab-dae3bf032ae9.png)

Could I get your eyes on this @dhague ? I see you set the tenant_id as a required param but the API doc insists it's optional.

I have a use-case where it's necessary to initially create a user with no tenant assignment and then allow them to be assigned to tenants on request of the user afterwards.