### PR TITLE
version for fog-aliyun added in fog.gemspec

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -74,7 +74,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-vmfusion")
   s.add_dependency("fog-voxel")
   s.add_dependency("fog-xenserver")
-  s.add_dependency("fog-aliyun")
+  s.add_dependency("fog-aliyun",">= 0.1.0")
 
   s.add_development_dependency("docker-api", ">= 1.13.6")
   s.add_development_dependency("fission")


### PR DESCRIPTION
Version for fog-aliyun has been added in fog.gemspec as all versions of fog-aliyun prior to 0.1.0 have been removed

closes #3763 