### PR TITLE
[rackspace] Add support for get_vnc_console request to compute_v2

### DIFF
--- a/lib/fog/rackspace/compute_v2.rb
+++ b/lib/fog/rackspace/compute_v2.rb
@@ -117,6 +117,7 @@ module Fog
       request :list_virtual_interfaces
       request :create_virtual_interface
       request :delete_virtual_interface
+      request :get_vnc_console
 
       class Mock < Fog::Rackspace::Service
         include Fog::Rackspace::MockData

--- a/lib/fog/rackspace/docs/compute_v2.md
+++ b/lib/fog/rackspace/docs/compute_v2.md
@@ -120,7 +120,7 @@ To see a list of requests supported by the service:
 	
 This returns:
 
-	:list_servers, :get_server, :create_server, :update_server, :delete_server, :change_server_password, :reboot_server, :rebuild_server, :resize_server, :confirm_resize_server, :revert_resize_server, :list_images, :get_image, :list_flavors, :get_flavor, :attach_volume, :get_attachment, :list_attachments, :delete_attachment
+	:list_servers, :get_server, :create_server, :update_server, :delete_server, :change_server_password, :reboot_server, :rebuild_server, :resize_server, :confirm_resize_server, :revert_resize_server, :list_images, :get_image, :list_flavors, :get_flavor, :attach_volume, :get_attachment, :list_attachments, :delete_attachment, :get_vnc_console
 
 
 #### Example Request

--- a/lib/fog/rackspace/models/compute_v2/server.rb
+++ b/lib/fog/rackspace/models/compute_v2/server.rb
@@ -618,6 +618,20 @@ module Fog
           @virtual_interfaces ||= Fog::Compute::RackspaceV2::VirtualInterfaces.new :server => self, :service => service
         end
 
+        # VNC Console URL
+        # @param [String] Type of vnc console to get ('novnc' or 'xvpvnc')
+        # @return [String] returns URL to vnc console
+        # @raise [Fog::Compute::RackspaceV2::NotFound] - HTTP 404
+        # @raise [Fog::Compute::RackspaceV2::BadRequest] - HTTP 400
+        # @raise [Fog::Compute::RackspaceV2::InternalServerError] - HTTP 500
+        # @raise [Fog::Compute::RackspaceV2::ServiceError]
+        # @note This URL will time out due to inactivity
+        def get_vnc_console(console_type = "xvpvnc")
+          requires :identity
+          data = service.get_vnc_console(identity, console_type)
+          data.body['console']['url']
+        end
+
         private
 
         def adminPass=(new_admin_pass)

--- a/lib/fog/rackspace/requests/compute_v2/get_vnc_console.rb
+++ b/lib/fog/rackspace/requests/compute_v2/get_vnc_console.rb
@@ -1,0 +1,45 @@
+module Fog
+  module Compute
+    class RackspaceV2
+      class Real
+        # Get a vnc console for an instance.
+        #
+        # === Parameters
+        # * server_id <~String> - The ID of the server.
+        # * console_type <~String> - Type of vnc console to get ('novnc' or 'xvpvnc').
+        # === Returns
+        # * response <~Excon::Response>:
+        #   * body <~Hash>:
+        #     * url <~String>
+        #     * type <~String>
+        def get_vnc_console(server_id, console_type)
+          data = {
+            'os-getVNCConsole' => {
+              'type' => console_type
+            }
+          }
+          request(
+            :body => Fog::JSON.encode(data),
+            :expects => [200],
+            :method => 'POST',
+            :path => "servers/#{server_id}/action"
+          )
+        end # def get_vnc_console
+      end # class Real
+
+      class Mock
+        def get_vnc_console(server_id, console_type)
+          response = Excon::Response.new
+          response.status = 200
+          response.body = {
+            "console" => {
+              "url"  => "http://192.168.27.100:6080/vnc_auto.html?token=c3606020-d1b7-445d-a88f-f7af48dd6a20",
+              "type" => "novnc"
+            }
+          }
+          response
+        end # def get_vnc_console
+      end # class Mock
+    end # class OpenStack
+  end # module Compute
+end # module Fog

--- a/tests/rackspace/requests/compute_v2/server_tests.rb
+++ b/tests/rackspace/requests/compute_v2/server_tests.rb
@@ -164,5 +164,9 @@ Shindo.tests('Fog::Compute::RackspaceV2 | server_tests', ['rackspace']) do
     tests('#delete_server').succeeds do
       service.delete_server(server_id)
     end
+
+    tests('#get_vnc_console').succeeds do
+      service.get_vnc_console(server_id, 'novnc')
+    end
   end
 end


### PR DESCRIPTION
Add support for `get_vnc_console` to the Rackspace provider. `get_vnc_console` returns a URL to a HTML5 based VNC client.

Rackspace documentation: https://developer.rackspace.com/docs/cloud-servers/v2/developer-guide/#get-console

```server.get_vnc_console('novnc') => "https://dfw.servers.console.rackspacecloud.com:443/console?token=b40c6057-4bcb-4ee7-a359-dcecc752b379"```

Note: These URLs expire with inactivity.

This is basically a copy of OpenStack's support to the Rackspace provider.