### PR TITLE
Bring back compatibility with Ruby < 2.0

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -75,7 +75,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("docker-api", ">= 1.13.6")
   s.add_development_dependency("fission")
-  s.add_development_dependency("mime-types", "~>2.99")
+  s.add_development_dependency("mime-types", "< 3.0")
   s.add_development_dependency("minitest")
   s.add_development_dependency("minitest-stub-const")
   s.add_development_dependency("opennebula")

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -75,6 +75,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("docker-api", ">= 1.13.6")
   s.add_development_dependency("fission")
+  s.add_development_dependency("mime-types", "~>2.99")
   s.add_development_dependency("minitest")
   s.add_development_dependency("minitest-stub-const")
   s.add_development_dependency("opennebula")


### PR DESCRIPTION
The `mime-types` dependency isn't set to a specific version. As a result, the latest version is used, which requires `mime-types-data` in turn breaks compatibility with ruby <2.0 since ruby >=2.0 is one of its dependencies.

This PR simply specifies the latest non-breaking version of `mime-types` in the `gemspec`.

Fixes: https://github.com/fog/fog/issues/3775.