### PR TITLE
Fix for setups where Keystone v2 and v3 are both available

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -151,6 +151,7 @@ module Fog
         @host   = @openstack_management_uri.host
         @path   = @openstack_management_uri.path
         @path.sub!(/\/$/, '')
+        @path   = @openstack_auth_uri.path.scan(/(\/v\d(\.\d+)?)/)[0][0] if @path.empty?
         @port   = @openstack_management_uri.port
         @scheme = @openstack_management_uri.scheme
 


### PR DESCRIPTION
If the management URL has no path, use the one in the auth URI.

This is something of a bandaid solution until a more long term solution is committed. I'll be leaving that in the capable hands of @dhague 

The underlying motivation here is that OpenStack recommend you use management endpoints that don't hard code the API version within it. This causes the `@path` variable to be empty, and so subsequent requests end up going to the wrong place and generating 404s. See the excon debug log below.

```
/Users/sean/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/excon-0.45.4/lib/excon/middlewares/expects.rb:6:in `response_call': Expected(200) <=> Actual(404 Not Found) (Fog::Identity::OpenStack::NotFound)
excon.error.request
  :chunk_size          => 1048576
  :ciphers             => "HIGH:!SSLv2:!aNULL:!eNULL:!3DES"
  :connect_timeout     => 5
  :debug_request       => true
  :debug_response      => true
  :expects             => 200
  :headers             => {
    "Accept"       => "application/json"
    "Content-Type" => "application/json"
    "Host"         => "REDACTED:35357"
    "User-Agent"   => "fog/1.36.0 fog-core/1.35.0"
    "X-Auth-Token" => "56faebf5d45f433e82834b550f2c4b80"
  }
  :host                => "REDACTED"
  :hostname            => "REDACTED"
  :idempotent          => false
  :instrumentor        => Excon::StandardInstrumentor
  :instrumentor_name   => "excon"
  :method              => "GET"
  :middlewares         => [
    Excon::Middleware::ResponseParser
    Excon::Middleware::Expects
    Excon::Middleware::Idempotent
    Excon::Middleware::Instrumentor
    Excon::Middleware::Mock
    Excon::Middleware::NewRelicCrossAppTracing
  ]
  :mock                => false
  :nonblock            => true
  :omit_default_port   => false
  :path                => "//OS-KSADM/roles" <---------- Empty @path variable creates path without API version
  :persistent          => false
  :port                => 35357
  :query               => {
  }
  :read_timeout        => 120
  :retries_remaining   => 4
  :retry_limit         => 4
  :scheme              => "http"
  :ssl_verify_peer     => true
  :tcp_nodelay         => false
  :thread_safe_sockets => true
  :uri_parser          => URI
  :versions            => "excon/0.45.4 (x86_64-darwin15) ruby/2.2.3"
  :write_timeout       => 120
excon.error.response
  :body          => "{\"error\": {\"message\": \"The resource could not be found.\", \"code\": 404, \"title\": \"Not Found\"}}"
  :headers       => {
    "Content-Length" => "93"
    "Content-Type"   => "application/json"
    "Date"           => "Fri, 04 Dec 2015 10:08:08 GMT"
    "Server"         => "Apache/2.4.7 (Ubuntu)"
    "Vary"           => "X-Auth-Token"
  }
  :local_address => "REDACTED"
  :local_port    => 60467
  :reason_phrase => "Not Found"
  :remote_ip     => "REDACTED"
  :status        => 404
  :status_line   => "HTTP/1.1 404 Not Found\r\n"
	from /Users/sean/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/excon-0.45.4/lib/excon/middlewares/response_parser.rb:8:in `response_call'
	from /Users/sean/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/excon-0.45.4/lib/excon/connection.rb:372:in `response'
	from /Users/sean/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/excon-0.45.4/lib/excon/connection.rb:236:in `request'
	from /Users/sean/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/fog-core-1.35.0/lib/fog/core/connection.rb:81:in `request'
	from /Users/sean/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/fog-bbe707e2b630/lib/fog/openstack/common.rb:20:in `request'
	from /Users/sean/.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/bundler/gems/fog-bbe707e2b630/lib/fog/openstack/requests/identity_v2/list_roles.rb:7:in `list_roles'
<snip>
```