### PR TITLE
Revert "If the management URL has no path, use the one in the auth URI."

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -151,7 +151,6 @@ module Fog
         @host   = @openstack_management_uri.host
         @path   = @openstack_management_uri.path
         @path.sub!(/\/$/, '')
-        @path   = @openstack_auth_uri.path.scan(/(\/v\d(\.\d+)?)/)[0][0] if @path.empty?
         @port   = @openstack_management_uri.port
         @scheme = @openstack_management_uri.scheme
 


### PR DESCRIPTION
This reverts commit f17419049162a582268e0bace3edd4fdc17527d4.

Seems to cause some issues elsewhere in the code not caught by the current test suite but emerging from staging tests.