### PR TITLE
[openstack] Workaround for installs using both Keystone v2 and v3.

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -12,7 +12,8 @@ module Fog
                  :openstack_endpoint_type,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                 :openstack_identity_prefix
 
       ## MODELS
       #

--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -67,6 +67,7 @@ module Fog
       attr_reader :openstack_domain_id
       attr_reader :openstack_user_domain_id
       attr_reader :openstack_project_domain_id
+      attr_reader :openstack_identity_prefix
 
       def initialize_identity options
         # Create @openstack_* instance variables from all :openstack_* options

--- a/lib/fog/openstack/identity_v2.rb
+++ b/lib/fog/openstack/identity_v2.rb
@@ -16,7 +16,8 @@ module Fog
                    :openstack_endpoint_type,
                    :openstack_project_name, :openstack_project_id,
                    :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                   :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                   :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                   :openstack_identity_prefix
 
         model_path 'fog/openstack/models/identity_v2'
         model :tenant
@@ -181,6 +182,7 @@ module Fog
 
             @openstack_service_type   = options[:openstack_service_type] || ['identity']
             @openstack_service_name   = options[:openstack_service_name]
+            @identity_prefix          = options[:openstack_identity_prefix] ? "/#{options[:openstack_identity_prefix]}" : nil
 
             @connection_options       = options[:connection_options] || {}
 
@@ -189,7 +191,7 @@ module Fog
             authenticate
 
             @persistent = options[:persistent] || false
-            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
+            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}#{@identity_prefix}", @persistent, @connection_options)
           end
         end
       end

--- a/lib/fog/openstack/identity_v3.rb
+++ b/lib/fog/openstack/identity_v3.rb
@@ -15,7 +15,7 @@ module Fog
                    :openstack_user_domain_id, :openstack_project_domain_id,
                    :openstack_api_key, :openstack_current_user_id, :openstack_userid, :openstack_username,
                    :current_user, :current_user_id, :current_tenant,
-                   :provider
+                   :provider, :openstack_identity_prefix
 
         model_path 'fog/openstack/models/identity_v3'
         model :domain
@@ -159,6 +159,7 @@ module Fog
 
             @openstack_service_type   = options[:openstack_service_type] || ['identity_v3','identityv3','identity']
             @openstack_service_name   = options[:openstack_service_name]
+            @identity_prefix          = options[:openstack_identity_prefix] ? "/#{options[:openstack_identity_prefix]}" : nil
 
             @connection_options       = options[:connection_options] || {}
 
@@ -168,7 +169,7 @@ module Fog
             authenticate
 
             @persistent = options[:persistent] || false
-            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
+            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}#{@identity_prefix}", @persistent, @connection_options)
           end
         end
       end

--- a/lib/fog/openstack/image_v1.rb
+++ b/lib/fog/openstack/image_v1.rb
@@ -18,7 +18,8 @@ module Fog
                    :openstack_endpoint_type,
                    :openstack_project_name, :openstack_project_id,
                    :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                   :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                   :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                   :openstack_identity_prefix
 
         model_path 'fog/openstack/models/image_v1'
 

--- a/lib/fog/openstack/image_v2.rb
+++ b/lib/fog/openstack/image_v2.rb
@@ -18,7 +18,8 @@ module Fog
                    :openstack_endpoint_type,
                    :openstack_project_name, :openstack_project_id,
                    :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                   :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                   :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                   :openstack_identity_prefix
 
         model_path 'fog/openstack/models/image_v2'
 

--- a/lib/fog/openstack/metering.rb
+++ b/lib/fog/openstack/metering.rb
@@ -12,7 +12,8 @@ module Fog
                  :openstack_endpoint_type,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                 :openstack_identity_prefix
 
       model_path 'fog/openstack/models/metering'
 

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -14,7 +14,8 @@ module Fog
                  :openstack_endpoint_type,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                 :openstack_identity_prefix
 
       ## MODELS
       #

--- a/lib/fog/openstack/orchestration.rb
+++ b/lib/fog/openstack/orchestration.rb
@@ -12,7 +12,8 @@ module Fog
                  :openstack_endpoint_type,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                 :openstack_identity_prefix
 
       model_path 'fog/openstack/models/orchestration'
       model       :stack

--- a/lib/fog/openstack/planning.rb
+++ b/lib/fog/openstack/planning.rb
@@ -14,7 +14,8 @@ module Fog
                  :openstack_endpoint_type,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                 :openstack_identity_prefix
 
       ## MODELS
       #

--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -13,7 +13,8 @@ module Fog
                  :openstack_endpoint_type,
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id
+                 :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                 :openstack_identity_prefix
 
       model_path 'fog/openstack/models/storage'
       model       :directory

--- a/lib/fog/openstack/volume.rb
+++ b/lib/fog/openstack/volume.rb
@@ -11,7 +11,8 @@ module Fog
                            :openstack_endpoint_type,
                            :openstack_project_name, :openstack_project_id,
                            :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
-                           :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id]
+                           :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
+                           :openstack_identity_prefix]
 
       # Fog::Image::OpenStack.new() will return a Fog::Volume::OpenStack::V2 or a Fog::Volume::OpenStack::V1,
       #  choosing the V2 by default, as V1 is deprecated since OpenStack Juno


### PR DESCRIPTION
Introduces a new optional parameter for OpenStack.

```ruby
  openstack_identity_prefix: "v2.0"
```

This gets inserted wholesale into calls to the identity service (not including the original token request).

On systems where Keystone v2 is left in for compatibility in addition to Keystone v3 being present, it is recommended to remove the API version from the identity endpoints in Keystone's database. This means the client is then responsible for selecting which version of the API to use.

Since Keystone returns `host:5000/`, it's up to the client to add on `v2.0` or `v3`.

If left blank, the identity URL returned by Keystone's service catalogue is used unmodified. If you need to select between v2 and v3 then set it as above.