### PR TITLE
vCloud Director: Add lots more mocks

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -689,6 +689,9 @@ module Fog
                 :name => org_name,
                 :uuid => uuid
               },
+              
+              :tags => {},
+              
               :tasks => {},
 
               :vapps => {

--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -506,12 +506,16 @@ module Fog
       class Mock
         attr_reader :end_point, :api_version
 
+        # This is used in some mocks so it's a method rather than a variable
+        def default_network_uuid
+          @default_network_uuid ||= uuid
+        end
+
         def data
           @@data ||= Hash.new do |hash, key|
 
             vdc1_uuid = uuid
             vdc2_uuid = uuid
-            default_network_uuid = uuid
             uplink_network_uuid  = uuid
             isolated_vdc1_network_uuid = uuid
             isolated_vdc2_network_uuid = uuid
@@ -521,6 +525,7 @@ module Fog
             vapp2vm1_id = "vm-#{uuid}"
             vapp2vm2_id = "vm-#{uuid}"
             catalog_uuid = uuid
+            template_uuid = uuid
 
             hash[key] = {
               :catalogs => {
@@ -533,6 +538,7 @@ module Fog
                   :type    => 'vAppTemplate',
                   :name    => 'vAppTemplate 1',
                   :catalog => catalog_uuid,
+                  :template_id => template_uuid
                 }
               },
               :disks => {},

--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -541,7 +541,13 @@ module Fog
                   :template_id => template_uuid
                 }
               },
-              :disks => {},
+              :disks => {
+                uuid => {
+                  :name => 'Hard Disk 1',
+                  :capacity => 10240,
+                  :parent_vm => vapp1vm1_id
+                }
+              },
               :edge_gateways => {
                 uuid => {
                   :name => 'MockEdgeGateway',

--- a/lib/fog/vcloud_director/requests/compute/get_catalog.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_catalog.rb
@@ -32,9 +32,30 @@ module Fog
               "No access to entity \"(com.vmware.vcloud.entity.catalog:#{id})\"."
             )
           end
-
-          Fog::Mock.not_implemented
-          catalog.is_used_here # avoid warning from syntax checker
+          
+          items = data[:catalog_items].select {|_,v| v[:catalog] == id}
+          
+          body = {
+            :href => make_href("catalog/#{id}"),
+            :type => 'application/vnd.vmware.vcloud.catalog+xml',
+            :id   => id,
+            :name => catalog[:name],
+            :CatalogItems => {
+              :CatalogItem => items.map do |uuid,item|
+                {
+                  :href => make_href("catalogItem/#{uuid}"),
+                  :id   => uuid,
+                  :name => item[:name],
+                  :type => 'application/vnd.vmware.vcloud.catalogItem+xml'
+                }
+              end
+            },
+          }
+          Excon::Response.new(
+            :status => 200,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
         end
       end
     end

--- a/lib/fog/vcloud_director/requests/compute/get_catalog_item.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_catalog_item.rb
@@ -20,6 +20,29 @@ module Fog
           )
         end
       end
+      class Mock
+        def get_catalog_item(id)
+          unless item = data[:catalog_items][id]
+            raise Fog::Compute::VcloudDirector::Forbidden.new(
+              "No access to entity \"(com.vmware.vcloud.entity.catalogItem:#{id})\"."
+            )
+          end
+          body = {
+            :href => make_href("catalogItem/#{id}"),
+            :id   => id,
+            :name => item[:name],
+            :type => 'application/vnd.vmware.vcloud.catalogItem+xml',
+            :Entity => {
+              :href => make_href("vAppTemplate/#{item[:template_id]}")              
+            }
+          }
+          Excon::Response.new(
+            :status => 200,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
+        end
+      end
     end
   end
 end

--- a/lib/fog/vcloud_director/requests/compute/get_metadata.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_metadata.rb
@@ -25,6 +25,17 @@ module Fog
           )
         end
       end
+      class Mock
+        def get_metadata(id)
+          tags = data[:tags][id] || {}
+          body = {:type => 'application/vnd.vmware.vcloud.metadata+xml', :metadata => tags}
+          Excon::Response.new(
+            :status => 200,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
+        end
+      end
     end
   end
 end

--- a/lib/fog/vcloud_director/requests/compute/get_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vapp.rb
@@ -63,6 +63,7 @@ module Fog
             :status => vm[:status],
             :deployed => vm[:deployed],
             :needsCustomization => vm[:needs_customization],
+            :Description => vm[:description],
             :"ovf:VirtualHardwareSection" => get_vm_virtual_hardware_section_body(id, vm),
             :"ovf:OperatingSystemSection" => get_vm_operating_system_section_body(id, vm),
             :NetworkConnectionSection     => get_vm_network_connection_section_body(id, vm),

--- a/lib/fog/vcloud_director/requests/compute/get_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vm.rb
@@ -23,6 +23,52 @@ module Fog
           )
         end
       end
+      class Mock
+        def get_vm(id)
+          vapp = get_vapp(id).body
+          vm = parse_vapp_to_vm(vapp)
+          body = {:type => vapp[:type], :vm => vm}
+          Excon::Response.new(
+            :status => 200,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
+        end
+        
+        # Mock equivalent of Fog::Parsers::Compute::VcloudDirector::Vm
+        def parse_vapp_to_vm(vapp)
+          parser = Fog::Parsers::Compute::VcloudDirector::Vm.new
+          vm = vapp.select {|k| [:href, :name, :status, :type].include? k}
+          network = vapp[:NetworkConnectionSection]
+          vm.merge({
+            :id => vapp[:href].split('/').last,
+            :status => parser.human_status(vapp[:status]),
+            :ip_address => network[:NetworkConnection][:IpAddress],
+            :description => vapp[:"ovf:OperatingSystemSection"][:"ovf:Description"],
+            :cpu => get_hardware(vapp, 3),
+            :memory => get_hardware(vapp, 4),
+            :disks => get_disks(vapp),
+            :links => [vapp[:GuestCustomizationSection][:Link]],
+          })
+        end
+        
+        def get_hardware(vapp, resource_type)
+          hardware = vapp[:"ovf:VirtualHardwareSection"][:"ovf:Item"]
+          item = hardware.find {|h| h[:"rasd:ResourceType"].to_i == resource_type}
+          if item and item.key? :"rasd:VirtualQuantity"
+            item[:"rasd:VirtualQuantity"].to_i
+          else
+            nil
+          end
+        end
+        
+        def get_disks(vapp)
+          hardware = vapp[:"ovf:VirtualHardwareSection"][:"ovf:Item"]
+          disks = hardware.select {|h| h[:"rasd:ResourceType"].to_i == 17}
+          disks.map {|d| {d[:"rasd:ElementName"] => d[:"rasd:HostResource"][:ns12_capacity].to_i}}
+        end
+        
+      end
     end
   end
 end

--- a/lib/fog/vcloud_director/requests/compute/get_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vm.rb
@@ -44,7 +44,7 @@ module Fog
             :id => vapp[:href].split('/').last,
             :status => parser.human_status(vapp[:status]),
             :ip_address => network[:NetworkConnection][:IpAddress],
-            :description => vapp[:"ovf:OperatingSystemSection"][:"ovf:Description"],
+            :description => vapp[:Description],
             :cpu => get_hardware(vapp, 3),
             :memory => get_hardware(vapp, 4),
             :disks => get_disks(vapp),

--- a/lib/fog/vcloud_director/requests/compute/get_vm_disks.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vm_disks.rb
@@ -26,6 +26,26 @@ module Fog
           )
         end
       end
+      class Mock
+        def get_vm_disks(id)
+          disks = data[:disks].values.select {|d| d[:parent_vm] == id}.each_with_index.map do |disk, i|
+            {
+              :address => i,
+              :description => disk[:description],
+              :name => disk[:name],
+              :id => (i+1)*1000,
+              :resource_type => 17,
+              :capacity => disk[:capacity],
+            }
+          end
+          body = {:type => 'application/vnd.vmware.vcloud.rasditemslist+xml', :disks => disks}
+          Excon::Response.new(
+            :status => 200,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
+        end
+      end
     end
   end
 end

--- a/lib/fog/vcloud_director/requests/compute/get_vm_network.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vm_network.rb
@@ -33,7 +33,7 @@ module Fog
           connection = network[:NetworkConnection]
           body = {
             :type => network[:type],
-            :id   => network[:href].split('/').last,
+            :id   => network[:href].split('/')[-2],
             :href => network[:href],
             :info => network[:"ovf:Info"],
             :primary_network_connection_index => network[:PrimaryNetworkConnectionIndex],

--- a/lib/fog/vcloud_director/requests/compute/get_vm_network.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vm_network.rb
@@ -26,6 +26,31 @@ module Fog
           )
         end
       end
+      class Mock
+        def get_vm_network(id)
+          vapp    = get_vapp(id).body
+          network = vapp[:NetworkConnectionSection]
+          connection = network[:NetworkConnection]
+          body = {
+            :type => network[:type],
+            :id   => network[:href].split('/').last,
+            :href => network[:href],
+            :info => network[:"ovf:Info"],
+            :primary_network_connection_index => network[:PrimaryNetworkConnectionIndex],
+            :network => connection[:network],
+            :needs_customization => connection[:needsCustomization],
+            :network_connection_index => connection[:NetworkConnectionIndex],
+            :is_connected => connection[:IsConnected],
+            :mac_address => connection[:MACAddress],
+            :ip_address_allocation_mode => connection[:IpAddressAllocationMode]
+          }
+          Excon::Response.new(
+            :status => 200,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
+        end
+      end
     end
   end
 end

--- a/lib/fog/vcloud_director/requests/compute/get_vms.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vms.rb
@@ -23,6 +23,29 @@ module Fog
           )
         end
       end
+      class Mock
+        def get_vms(id)
+          vapp = get_vapp(id).body
+          parser = Fog::Parsers::Compute::VcloudDirector::Vms.new
+          vms  = vapp[:Children][:Vm].map do |vm|
+            {
+              :id => vm[:href].split('/').last,
+              :vapp_id => vapp[:id],
+              :vapp_name => vapp[:name],
+              :name => vm[:name],
+              :type => vm[:type],
+              :href => vm[:href],
+              :ip_address => vm[:NetworkConnectionSection][:NetworkConnection][:IpAddress],
+            }
+          end
+          body = {:type => vapp[:type], :vms => vms}
+          Excon::Response.new(
+            :status => 200,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
+        end
+      end
     end
   end
 end

--- a/lib/fog/vcloud_director/requests/compute/get_vms.rb
+++ b/lib/fog/vcloud_director/requests/compute/get_vms.rb
@@ -27,17 +27,7 @@ module Fog
         def get_vms(id)
           vapp = get_vapp(id).body
           parser = Fog::Parsers::Compute::VcloudDirector::Vms.new
-          vms  = vapp[:Children][:Vm].map do |vm|
-            {
-              :id => vm[:href].split('/').last,
-              :vapp_id => vapp[:id],
-              :vapp_name => vapp[:name],
-              :name => vm[:name],
-              :type => vm[:type],
-              :href => vm[:href],
-              :ip_address => vm[:NetworkConnectionSection][:NetworkConnection][:IpAddress],
-            }
-          end
+          vms  = vapp[:Children][:Vm].map {|child| parse_vapp_to_vm(child) }
           body = {:type => vapp[:type], :vms => vms}
           Excon::Response.new(
             :status => 200,

--- a/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
+++ b/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
@@ -107,7 +107,7 @@ module Fog
       end
       
       class Mock
-        # Assume the template is a single VM with one network interface.
+        # Assume the template is a single VM with one network interface and one disk.
         def instantiate_vapp_template(vapp_name, template_id, options={})          
           unless data[:catalog_items].values.find {|i| i[:template_id] == template_id}
             raise Fog::Compute::VcloudDirector::Forbidden.new(
@@ -138,7 +138,8 @@ module Fog
                   {:parent_id => default_network_uuid }
                 ]
               }
-              data[:vms]["vm-#{uuid}"] = {
+              vm_id = "vm-#{uuid}"
+              data[:vms][vm_id] = {
                 :name => vapp_name,
                 :parent_vapp => vapp_id,
                 :nics => [
@@ -148,6 +149,11 @@ module Fog
                     :ip_address   => nil
                   }
                 ]
+              }
+              data[:disks][uuid] = {
+                :name => 'Hard Disk 1',
+                :capacity => 10240,
+                :parent_vm => vm_id
               }
             end
           )

--- a/lib/fog/vcloud_director/requests/compute/put_network_connection_system_section_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_network_connection_system_section_vapp.rb
@@ -116,6 +116,37 @@ module Fog
           )
         end
       end
+      class Mock
+        def put_network_connection_system_section_vapp(id, options={})
+          unless vm = data[:vms][id]
+            raise Fog::Compute::VcloudDirector::Forbidden.new(
+              'This operation is denied.'
+            )
+          end
+          
+          owner = {
+            :href => make_href("vApp/#{id}"),
+            :type => 'application/vnd.vmware.vcloud.vApp+xml'
+          }
+          task_id = enqueue_task(
+            "Updating Virtual Machine #{data[:vms][id][:name]}(#{id})", 'vappUpdateVm', owner,
+            :on_success => lambda do
+              data[:vms][id][:nics].first[:network_name] = options[:network]
+            end
+          )
+          body = {
+            :xmlns => xmlns,
+            :xmlns_xsi => xmlns_xsi,
+            :xsi_schemaLocation => xsi_schema_location,
+          }.merge(task_body(task_id))
+
+          Excon::Response.new(
+            :status => 202,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This pull request adds a lot more mocks to the vcloud_director provider.

Specifically, it adds mocks for:

* delete_vapp
* get_catalog
* get_catalog_item
* get_metadata
* get_vapp
* get_vm
* get_vm_disks
* get_vm_network
* get_vms
* post_instantiate_vapp_template
* post_power_on_vapp
* post_update_vapp_metadata
* put_network_connection_system_section_vapp

And fixes a bug in the get_vm_network mock (it was not pulling out the VM ID correctly from the href - I changed the code to match the 'real' parser).