### PR TITLE
vCloud Director: Add a #storage_only to disks

### DIFF
--- a/lib/fog/vcloud_director/models/compute/disks.rb
+++ b/lib/fog/vcloud_director/models/compute/disks.rb
@@ -33,7 +33,8 @@ module Fog
           items
         end
         
-        # Filters out all the controllers (returns only resource_type == 17)
+        # Returns only disk drives (OVF resource type 17) and not controllers,
+        # etc. See <https://blogs.vmware.com/vapp/2009/11/virtual-hardware-in-ovf-part-1.html>
         def storage_only
           select {|d| d.resource_type == 17}
         end

--- a/lib/fog/vcloud_director/models/compute/disks.rb
+++ b/lib/fog/vcloud_director/models/compute/disks.rb
@@ -32,6 +32,11 @@ module Fog
           end
           items
         end
+        
+        # Filters out all the controllers (returns only resource_type == 17)
+        def storage_only
+          select {|d| d.resource_type == 17}
+        end
       end
     end
   end


### PR DESCRIPTION
The standard behaviour of `vm.disks` returns all disk hardware including SCSI/IDE controllers.

This tiny PR adds a `vm.disks.storage_only` that returns only those disks that have a resource type of 17 (indicating that they're actually disks and not controllers).