### PR TITLE
vCloud Director: Add support for reconfigureVm and a VM's description

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -225,6 +225,7 @@ module Fog
       request :post_power_off_vapp
       request :post_power_on_vapp
       request :post_reboot_vapp
+      request :post_reconfigure_vm
       request :post_remove_all_snapshots
       request :post_reset_vapp
       request :post_revert_snapshot

--- a/lib/fog/vcloud_director/models/compute/vm.rb
+++ b/lib/fog/vcloud_director/models/compute/vm.rb
@@ -165,7 +165,7 @@ module Fog
           end
           response = service.post_reconfigure_vm(id, options)
           service.process_task(response.body)
-          reload_single_vm
+          options.each {|k,v| attributes[k] = v}
         end
         
         def ready?

--- a/lib/fog/vcloud_director/models/compute/vm.rb
+++ b/lib/fog/vcloud_director/models/compute/vm.rb
@@ -11,6 +11,7 @@ module Fog
         attribute :vapp_name
         attribute :name
         attribute :type
+        attribute :description
         attribute :href
         attribute :status
         attribute :operating_system

--- a/lib/fog/vcloud_director/models/compute/vm.rb
+++ b/lib/fog/vcloud_director/models/compute/vm.rb
@@ -161,7 +161,7 @@ module Fog
         def reconfigure(options)
           options[:name] ||= name # name has to be sent
           # Delete those things that are not changing for performance
-          [:cpu, :memory].each do |k|
+          [:cpu, :memory, :description].each do |k|
             options.delete(k) if options.key? k and options[k] == attributes[k]
           end
           response = service.post_reconfigure_vm(id, options)

--- a/lib/fog/vcloud_director/models/compute/vm.rb
+++ b/lib/fog/vcloud_director/models/compute/vm.rb
@@ -154,7 +154,20 @@ module Fog
             service.process_task(response.body)
           end
         end
-
+        
+        # Reconfigure a VM using any of the options documented in
+        # post_reconfigure_vm
+        def reconfigure(options)
+          options[:name] ||= name # name has to be sent
+          # Delete those things that are not changing for performance
+          [:cpu, :memory].each do |k|
+            options.delete(k) if options.key? k and options[k] == attributes[k]
+          end
+          response = service.post_reconfigure_vm(id, options)
+          service.process_task(response.body)
+          reload_single_vm
+        end
+        
         def ready?
           reload
           status == 'on'

--- a/lib/fog/vcloud_director/parsers/compute/vm.rb
+++ b/lib/fog/vcloud_director/parsers/compute/vm.rb
@@ -33,6 +33,10 @@ module Fog
             when 'IpAddress'
               @response[:vm][:ip_address] = value
             when 'Description'
+              # Assume the very first Description we find is the VM description
+              if !@response[:vm][:description]
+                @response[:vm][:description] = value
+              end
               if @in_operating_system
                 @response[:vm][:operating_system] = value
                 @in_operating_system = false

--- a/lib/fog/vcloud_director/parsers/compute/vms.rb
+++ b/lib/fog/vcloud_director/parsers/compute/vms.rb
@@ -43,6 +43,10 @@ module Fog
               when 'IpAddress'
                 @vm[:ip_address] = value
               when 'Description'
+                if !@vm[:description]
+                  # Assume the first description we find is the VM description
+                  @vm[:description] = value
+                end
                 if @in_operating_system
                   @vm[:operating_system] = value
                   @in_operating_system = false

--- a/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
@@ -12,6 +12,7 @@ module Fog
         # @param [Hash] options
         #
         # @option options [String] :name Change the VM's name [required].
+        # @option options [String] :description VM description
         # @option options [Integer] :cpu Number of CPUs
         # @option options [Integer] :memory Memory in MB
         #
@@ -32,6 +33,7 @@ module Fog
               :name => options[:name]
             }
             xml.Vm(attrs) do
+              xml.Description options[:description] if options[:description]
               virtual_hardware_section(xml, options)
             end
           end.to_xml
@@ -93,6 +95,7 @@ module Fog
             "Updating Virtual Machine #{data[:vms][id][:name]}(#{id})", 'vappUpdateVm', owner,
             :on_success => lambda do
               data[:vms][id][:name] = options[:name]
+              data[:vms][id][:description] = options[:description] if options[:description]
               data[:vms][id][:cpu_count] = options[:cpu] if options[:cpu]
               data[:vms][id][:memory_in_mb] = options[:memory] if options[:memory]
             end

--- a/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
@@ -76,6 +76,40 @@ module Fog
         end
         
       end
+      
+      class Mock
+        def post_reconfigure_vm(id, options={})
+          unless vm = data[:vms][id]
+            raise Fog::Compute::VcloudDirector::Forbidden.new(
+              'This operation is denied.'
+            )
+          end
+          
+          owner = {
+            :href => make_href("vApp/#{id}"),
+            :type => 'application/vnd.vmware.vcloud.vApp+xml'
+          }
+          task_id = enqueue_task(
+            "Updating Virtual Machine #{data[:vms][id][:name]}(#{id})", 'vappUpdateVm', owner,
+            :on_success => lambda do
+              data[:vms][id][:name] = options[:name]
+              data[:vms][id][:cpu_count] = options[:cpu] if options[:cpu]
+              data[:vms][id][:memory_in_mb] = options[:memory] if options[:memory]
+            end
+          )
+          body = {
+            :xmlns => xmlns,
+            :xmlns_xsi => xmlns_xsi,
+            :xsi_schemaLocation => xsi_schema_location,
+          }.merge(task_body(task_id))
+
+          Excon::Response.new(
+            :status => 202,
+            :headers => {'Content-Type' => "#{body[:type]};version=#{api_version}"},
+            :body => body
+          )
+        end
+      end
     end
   end
 end

--- a/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_reconfigure_vm.rb
@@ -1,0 +1,81 @@
+module Fog
+  module Compute
+    class VcloudDirector
+      class Real
+        
+        # Updates VM configuration.
+        #
+        # This operation is asynchronous and returns a task that you can
+        # monitor to track the progress of the request.
+        #
+        # @param [String] id Object identifier of the VM.
+        # @param [Hash] options
+        #
+        # @option options [String] :name Change the VM's name [required].
+        # @option options [Integer] :cpu Number of CPUs
+        # @option options [Integer] :memory Memory in MB
+        #
+        # @return [Excon::Response]
+        #   * body<~Hash>:
+        #     * :Tasks<~Hash>:
+        #       * :Task<~Hash>:
+        #
+        # @see http://pubs.vmware.com/vcd-51/topic/com.vmware.vcloud.api.reference.doc_51/doc/operations/POST-ReconfigureVm.html
+        # @since vCloud API version 5.1
+        def post_reconfigure_vm(id, options={})
+          
+          body = Nokogiri::XML::Builder.new do |xml|
+            attrs = {
+              :xmlns => 'http://www.vmware.com/vcloud/v1.5',
+              'xmlns:ovf' => 'http://schemas.dmtf.org/ovf/envelope/1',
+              'xmlns:rasd' => 'http://schemas.dmtf.org/wbem/wscim/1/cim-schema/2/CIM_ResourceAllocationSettingData',
+              :name => options[:name]
+            }
+            xml.Vm(attrs) do
+              virtual_hardware_section(xml, options)
+            end
+          end.to_xml
+          
+          request(
+            :body    => body,
+            :expects => 202,
+            :headers => {'Content-Type' => 'application/vnd.vmware.vcloud.vm+xml'},
+            :method  => 'POST',
+            :parser  => Fog::ToHashDocument.new,
+            :path    => "vApp/#{id}/action/reconfigureVm"
+          )
+        end
+        
+        private
+        
+        def virtual_hardware_section(xml, options)
+          return unless options[:cpu] or options[:memory]
+          xml['ovf'].VirtualHardwareSection do
+            xml['ovf'].Info 'Virtual Hardware Requirements'
+            cpu_section(xml, options[:cpu]) if options[:cpu]
+            memory_section(xml, options[:memory]) if options[:memory]
+          end
+        end
+        
+        def cpu_section(xml, cpu)
+          xml['ovf'].Item do
+            xml['rasd'].AllocationUnits 'hertz * 10 ^ 6'
+            xml['rasd'].InstanceID 5
+            xml['rasd'].ResourceType 3
+            xml['rasd'].VirtualQuantity cpu.to_i
+          end
+        end
+        
+        def memory_section(xml, memory)
+          xml['ovf'].Item do
+            xml['rasd'].AllocationUnits 'byte * 2^20'
+            xml['rasd'].InstanceID 6
+            xml['rasd'].ResourceType 4
+            xml['rasd'].VirtualQuantity memory.to_i
+          end
+        end
+        
+      end
+    end
+  end
+end


### PR DESCRIPTION
Sorry for raising a PR with two purposes here, but they're quite entwined in my fork.

1. Adds support for reading the `Description` property of VMs.
2. Adds some minimal support for the all-encompassing `reconfigureVm` method of the vCloud Director API. Specifically, you can use the `vm.reconfigure` method to set the following properties:

* `name`
* `cpu`
* `memory`
* `description`

[I know there is already support for PUT `cpu` and PUT `memory` but this method allows people to set them both (and other properties) simultaneously so it's a bit faster. The other two properties previously had no way of being edited in Fog.]