### PR TITLE
[vcloud_director] Add vdc.networks

### DIFF
--- a/lib/fog/vcloud_director/models/compute/networks.rb
+++ b/lib/fog/vcloud_director/models/compute/networks.rb
@@ -11,6 +11,7 @@ module Fog
         model Fog::Compute::VcloudDirector::Network
 
         attribute :organization
+        attribute :vdc
 
         def query_type
           "orgVdcNetwork"
@@ -46,8 +47,12 @@ module Fog
         end
 
         def item_list
-          data = service.get_organization(organization.id).body
-          items = data[:Link].select { |link| link[:type] == "application/vnd.vmware.vcloud.orgNetwork+xml" }
+          items = if vdc
+            vdc.available_networks.select {|link| link[:type] == "application/vnd.vmware.vcloud.network+xml"}
+          else
+            data = service.get_organization(organization.id).body
+            data[:Link].select { |link| link[:type] == "application/vnd.vmware.vcloud.orgNetwork+xml" }
+          end
           items.each{|item| service.add_id_from_href!(item) }
           items
         end

--- a/lib/fog/vcloud_director/models/compute/vdc.rb
+++ b/lib/fog/vcloud_director/models/compute/vdc.rb
@@ -31,7 +31,7 @@ module Fog
         end
         
         def networks
-          requires :id
+          requires :available_networks
           service.networks(:vdc => self)
         end
       end

--- a/lib/fog/vcloud_director/models/compute/vdc.rb
+++ b/lib/fog/vcloud_director/models/compute/vdc.rb
@@ -29,6 +29,11 @@ module Fog
           requires :id
           service.vapps(:vdc => self)
         end
+        
+        def networks
+          requires :id
+          service.networks(:vdc => self)
+        end
       end
     end
   end


### PR DESCRIPTION
As well as `org.networks` which gets all the networks in an organization, it is useful to have `vdc.networks` that only gets the networks relevant to a specific virtual DC.