### PR TITLE
Add openstack_temp_url_key to the list of recognized options

### DIFF
--- a/lib/fog/openstack/storage.rb
+++ b/lib/fog/openstack/storage.rb
@@ -14,7 +14,7 @@ module Fog
                  :openstack_project_name, :openstack_project_id,
                  :openstack_project_domain, :openstack_user_domain, :openstack_domain_name,
                  :openstack_project_domain_id, :openstack_user_domain_id, :openstack_domain_id,
-                 :openstack_identity_prefix
+                 :openstack_identity_prefix, :openstack_temp_url_key
 
       model_path 'fog/openstack/models/storage'
       model       :directory


### PR DESCRIPTION
Hello guys, I noticed a warning when using ```:openstack_temp_url_key``` option for OpenStack storage which doesn't make much sense:
```
2015-12-18_08:11:07.54954 [fog][WARNING] Unrecognized arguments: openstack_temp_url_key
```

when in reality code still uses it and it is perfectly valid. See https://github.com/fog/fog/blob/master/lib/fog/openstack/requests/storage/get_object_https_url.rb#L39, https://github.com/fog/fog/blob/master/lib/fog/openstack/requests/storage/get_object_https_url.rb#L56.

I just whitelisted it as a recognized one. Please have a look and let me know if you have any questions.

Thanks!