### PR TITLE
[OpenStack] service retrieval also pass options on unscoped fallback

### DIFF
--- a/lib/fog/openstack/core.rb
+++ b/lib/fog/openstack/core.rb
@@ -331,7 +331,7 @@ module Fog
         end
 
         token, body = retrieve_tokens_v3(options, connection_options)
-        service = get_service_v3(body, service_type, service_name, openstack_region)
+        service = get_service_v3(body, service_type, service_name, openstack_region, options)
       end
 
       unless service


### PR DESCRIPTION
Same as in [line 307](https://github.com/MaPoCaCe/fog/blob/9589cad1c6332427415fb91ca49e8ae8af732c5b/lib/fog/openstack/core.rb#L307) the options should be passed to the service retrieval.

FYI: I stumbled upon this, when I needed the option `openstack_endpoint_path_matches` passed to select the correct identity version.