### PR TITLE
Deprecate delete_server for destroy_server

### DIFF
--- a/lib/fog/digitalocean/compute_v2.rb
+++ b/lib/fog/digitalocean/compute_v2.rb
@@ -21,7 +21,7 @@ module Fog
       request :change_kernel
       request :create_server
       request :create_ssh_key
-      request :delete_server
+      request :destroy_server
       request :delete_ssh_key
       request :disable_backups
       request :enable_ipv6

--- a/lib/fog/digitalocean/requests/compute_v2/destroy_server.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/destroy_server.rb
@@ -4,6 +4,10 @@ module Fog
       # noinspection RubyStringKeysInHashInspection
       class Real
         def delete_server(server_id)
+          Fog::Logger.warning("delete_server method has been deprecated, use destroy_server instead")
+          destroy_server(server_id)
+        end
+        def destroy_server(server_id)
           request(
             :expects         => [204],
             :headers         => {
@@ -17,7 +21,10 @@ module Fog
 
       # noinspection RubyStringKeysInHashInspection
       class Mock
-        def delete_server(_)
+        def delete_server(server_id)
+          destroy_server(server_id)
+        end
+        def destroy_server(_)
           response        = Excon::Response.new
           response.status = 204
           response


### PR DESCRIPTION
Ref #3803 
Use destroy_server to maintain consistent destroy api.