### PR TITLE
[OpenStack] image v2 correct images find_by_* and find_attribute

### DIFF
--- a/lib/fog/openstack/models/image_v2/images.rb
+++ b/lib/fog/openstack/models/image_v2/images.rb
@@ -42,7 +42,7 @@ module Fog
 
           def method_missing(method_sym, *arguments, &block)
             if method_sym.to_s =~ /^find_by_(.*)$/
-              load(service.list_images_detailed($1, arguments.first).body['images'])
+              load(service.list_images($1.to_sym => arguments.first).body['images'])
             else
               super
             end
@@ -58,7 +58,7 @@ module Fog
 
           def find_attribute(attribute, value)
             attribute = attribute.to_s.gsub("find_by_", "")
-            load(service.list_images_detailed(attribute, value).body['images'])
+            load(service.list_images(attribute.to_sym => value).body['images'])
           end
         end
       end


### PR DESCRIPTION
- fix what most probably is a copy paste error evolving from v1
- v2 only has the `list_images` request that accepts hash arguments only