### PR TITLE
[DigitalOcean] Added filtering capabilities to images request.

### DIFF
--- a/lib/fog/digitalocean/models/compute_v2/images.rb
+++ b/lib/fog/digitalocean/models/compute_v2/images.rb
@@ -12,7 +12,7 @@ module Fog
         # @raise [Fog::Compute::DigitalOceanV2::ServiceError]
         # @see https://developers.digitalocean.com/documentation/v2/#list-all-images
         def all(filters = {})
-          data = service.list_images.body["images"]
+          data = service.list_images(filters).body["images"]
           load(data)
         end
 

--- a/lib/fog/digitalocean/requests/compute_v2/list_images.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_images.rb
@@ -2,11 +2,11 @@ module Fog
   module Compute
     class DigitalOceanV2
       class Real
-        def list_images
+        def list_images(filters = {})
           request(
             :expects => [200],
             :method  => 'GET',
-            :path    => '/v2/images'
+            :path    => "/v2/images?#{filters.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join("&")}"
           )
         end
       end


### PR DESCRIPTION
* Added filtering hash to list_images request.
* Appended filter query to list images request url
* Passed existing filtering hash from all method at images collection model to the request call.

Current query does not show all available images. In addition the **all** method at the images does not pass the filters param to the request query. The behavior of the method differs from the API one since it's just the default call.