### PR TITLE
[openstack] Supporting installs that expose both keystone v2 and v3

### DIFF
--- a/lib/fog/openstack/identity_v2.rb
+++ b/lib/fog/openstack/identity_v2.rb
@@ -182,7 +182,6 @@ module Fog
 
             @openstack_service_type   = options[:openstack_service_type] || ['identity']
             @openstack_service_name   = options[:openstack_service_name]
-            @identity_prefix          = options[:openstack_identity_prefix] ? "/#{options[:openstack_identity_prefix]}" : nil
 
             @connection_options       = options[:connection_options] || {}
 
@@ -190,8 +189,12 @@ module Fog
 
             authenticate
 
+            if options[:openstack_identity_prefix]
+              @path = "/#{options[:openstack_identity_prefix]}/#{@path}"
+            end
+
             @persistent = options[:persistent] || false
-            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}#{@identity_prefix}", @persistent, @connection_options)
+            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
           end
         end
       end

--- a/lib/fog/openstack/identity_v3.rb
+++ b/lib/fog/openstack/identity_v3.rb
@@ -159,7 +159,6 @@ module Fog
 
             @openstack_service_type   = options[:openstack_service_type] || ['identity_v3','identityv3','identity']
             @openstack_service_name   = options[:openstack_service_name]
-            @identity_prefix          = options[:openstack_identity_prefix] ? "/#{options[:openstack_identity_prefix]}" : nil
 
             @connection_options       = options[:connection_options] || {}
 
@@ -168,8 +167,12 @@ module Fog
             @openstack_endpoint_path_matches = options[:openstack_endpoint_path_matches] ||= /\/v3/
             authenticate
 
+            if options[:openstack_identity_prefix]
+              @path = "/#{options[:openstack_identity_prefix]}/#{@path}"
+            end
+
             @persistent = options[:persistent] || false
-            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}#{@identity_prefix}", @persistent, @connection_options)
+            @connection = Fog::Core::Connection.new("#{@scheme}://#{@host}:#{@port}", @persistent, @connection_options)
           end
         end
       end


### PR DESCRIPTION
The management calls need the correct prefix prepending to all endpoints for systems that use Keystone v2 and v3. In these setups, the endpoint URLS are set up without the version so Keystone advertises them as

`https://yourserver.com:5000/` or `https://yourserver.com:35357`

instead of

`https://yourserver.com:5000/v2.0` or `https://yourserver.com:35357/v3/`.

This means that all keystone calls in future i.e. list users, domains, create roles etc etc will occur on the version of the API specified by the prefix.

```ruby
# In Config
openstack_identity_prefix: 'v3'
```

```
Listing domains for Keystone v3:
/v3/domains
```

or

```ruby
# In Config
openstack_identity_prefix: 'v2.0'
```

```
Listing users for Keystone v2:
/v2.0/users
```