### PR TITLE
Strip port number from host header

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -30,6 +30,7 @@ module Fog
         PORT        = 443
         SCHEME      = 'https'
         API_VERSION = '5.1'
+        OMIT_DEFAULT_PORT = true
       end
 
       class ServiceError < Fog::VcloudDirector::Errors::ServiceError; end
@@ -337,6 +338,7 @@ module Fog
           @vcloud_director_password = options[:vcloud_director_password]
           @vcloud_director_username = options[:vcloud_director_username]
           @connection_options = options[:connection_options] || {}
+          @connection_options[:omit_default_port] = Fog::Compute::VcloudDirector::Defaults::OMIT_DEFAULT_PORT unless @connection_option[:omit_default_port]
           @host       = options[:vcloud_director_host]
           @path       = options[:path]        || Fog::Compute::VcloudDirector::Defaults::PATH
           @persistent = options[:persistent]  || false


### PR DESCRIPTION
Excon by default adds the default port to the host header for each request
e.g hostname.example.com:443

Some Cloud Providers use filter rules on HAProxy or similar to control API paths to different backends. In our case the ruleset required will increase if we need to filter for port number as well as host headers where this is not specified. 

rfc2616 specifies that the port number should be appended to the host header if it is not the default port. However, 443 IS the default port for https (as specified in rfc2818) Although I accept that this could be seen as ambiguous given that the rfc2818 refers to HTTP over TLS rather than HTTP as defined in rfc2616.

Basically what I'm trying to say (in a long winded rounadbout way..) is should we make ":omit_default_port" (as supported by Excon) the default for vCloud Director  connections? 
If so I think this PR covers it whilst allowing users to override manually if required.