### PR TITLE
[openstack] Add get_server_password support to openstack compute API

### DIFF
--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -71,6 +71,7 @@ module Fog
       request :list_servers_detail
       request :create_server
       request :get_server_details
+      request :get_server_password
       request :update_server
       request :delete_server
 

--- a/lib/fog/openstack/requests/compute/get_server_password.rb
+++ b/lib/fog/openstack/requests/compute/get_server_password.rb
@@ -1,0 +1,28 @@
+module Fog
+  module Compute
+    class OpenStack
+      class Real
+        def get_server_password(server_id)
+          request(
+              :expects  => [200, 203],
+              :method   => 'GET',
+              :path     => "servers/#{server_id}/os-server-password.json"
+          )
+        end
+      end
+
+      class Mock
+        def get_server_password(server_id)
+          response = Excon::Response.new
+          if server = list_servers_detail.body['servers'].find {|_| _['id'] == server_id}
+            response.status = [200, 203][rand(1)]
+            response.body = { 'server' => server }
+            response
+          else
+            raise Fog::Compute::OpenStack::NotFound
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
I added the get_server_password functionality to get the password of the instances from openstack Compute API v2.1