### PR TITLE
rework mock openstack snapshot to have same behavior as servers...

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -895,3 +895,4 @@
 * Обоев Рулон ибн Хаттаб <me@nomadrain.com>
 * 应俊 <yj2317916@gmail.com>
 * Raul Roa <raulroa@playfulcorp.com>
+* zhitongLBN <z.liu@linkbynet.com>

--- a/lib/fog/openstack/compute.rb
+++ b/lib/fog/openstack/compute.rb
@@ -292,7 +292,8 @@ module Fog
                 'cores'          => 20,
                 'ram'            => 51200
               },
-              :volumes => {}
+              :volumes => {},
+              :snapshots => {}
             }
           end
         end

--- a/lib/fog/openstack/requests/compute/create_volume_snapshot.rb
+++ b/lib/fog/openstack/requests/compute/create_volume_snapshot.rb
@@ -23,20 +23,27 @@ module Fog
 
       class Mock
         def create_volume_snapshot(volume_id, name, description, force=false)
-          response = Excon::Response.new
-          response.status = 202
-          response.body = {
-            "snapshot"=> {
-               "status"=>"creating",
-               "display_name"=>name,
-               "created_at"=>Time.now,
-               "display_description"=>description,
-               "volume_id"=>volume_id,
-               "id"=>"5",
-               "size"=>1
+          volume_response = get_volume_details(volume_id)
+          volume = volume_response.data[:body]['volume']
+          unless volume.nil?
+            response = Excon::Response.new
+            data = {
+              "status" => "availble",
+              "name" => name,
+              "created_at" => Time.now,
+              "description" => description,
+              "volume_id" => volume_id,
+              "id" => Fog::Mock.random_numbers(2),
+              "size" => volume['size']
             }
-          }
-          response
+
+            self.data[:snapshots][data['id']] = data
+            response.body = { "snapshot" => data }
+            response.status = 202
+            response
+          else
+            raise Fog::Compute::OpenStack::NotFound
+          end
         end
       end
     end

--- a/lib/fog/openstack/requests/compute/delete_snapshot.rb
+++ b/lib/fog/openstack/requests/compute/delete_snapshot.rb
@@ -15,6 +15,11 @@ module Fog
         def delete_snapshot(snapshot_id)
           response = Excon::Response.new
           response.status = 204
+          if list_snapshots_detail.body['snapshots'].find { |_| _['id'] == snapshot_id }
+            self.data[:snapshots].delete(snapshot_id)
+          else
+            raise Fog::Compute::OpenStack::NotFound
+          end
           response
         end
       end

--- a/lib/fog/openstack/requests/compute/get_snapshot_details.rb
+++ b/lib/fog/openstack/requests/compute/get_snapshot_details.rb
@@ -14,19 +14,14 @@ module Fog
       class Mock
         def get_snapshot_details(snapshot_id)
           response = Excon::Response.new
-          response.status = 200
-          response.body = {
-            'snapshot' => {
-              'id'                 => '1',
-              'display_name'        => Fog::Mock.random_letters(rand(8) + 5),
-              'display_description' => Fog::Mock.random_letters(rand(12) + 10),
-              'size'               => 3,
-              'volume_id'           => '4',
-              'status'             => 'online',
-              'created_at'          => Time.now
-            }
-          }
-          response
+          if snapshot = list_snapshots_detail.body['snapshots'].find{
+            |_| _['id'] == snapshot_id }
+            response.status = 200
+            response.body = { 'snapshot' => snapshot }
+            response
+          else
+            raise Fog::Compute::OpenStack::NotFound
+          end
         end
       end
     end

--- a/lib/fog/openstack/requests/compute/list_snapshots.rb
+++ b/lib/fog/openstack/requests/compute/list_snapshots.rb
@@ -30,9 +30,8 @@ module Fog
         def list_snapshots(options = true)
           response = Excon::Response.new
           response.status = 200
-          response.body = {
-            'snapshots' => [get_snapshot_details.body["snapshot"]]
-          }
+          snapshots = self.data[:snapshots].values
+          response.body = { 'snapshots' => snapshots }
           response
         end
       end

--- a/lib/fog/openstack/requests/compute/list_snapshots_detail.rb
+++ b/lib/fog/openstack/requests/compute/list_snapshots_detail.rb
@@ -16,9 +16,8 @@ module Fog
         def list_snapshots_detail(options = {})
           response = Excon::Response.new
           response.status = 200
-          response.body = {
-            'snapshots' => [get_snapshot_details.body["snapshot"]]
-          }
+          snapshots = self.data[:snapshots].values
+          response.body = { 'snapshots' => snapshots }
           response
         end
       end


### PR DESCRIPTION
should solve issue  #3836
* Making openstack mock snapshots functions behave the same way as servers
* Solve the problem that calling `get_snapshots` but not giving `snapshot_id` in `list_snapshots` function
* Now should have the mock `volume` in data before to create mock volume `snapshot`(cause it'll have to find the size of volume that it try to snapshot)
