### PR TITLE
[openstack] Removes URI::encode call on parameteres

### DIFF
--- a/lib/fog/openstack/requests/baremetal/set_node_maintenance.rb
+++ b/lib/fog/openstack/requests/baremetal/set_node_maintenance.rb
@@ -3,17 +3,11 @@ module Fog
     class OpenStack
       class Real
         def set_node_maintenance(node_uuid, parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
           request(
             :expects => [200, 202, 204],
             :method => 'PUT',
             :path => "nodes/#{node_uuid}/maintenance",
-            :query   => query
+            :query   => parameters
           )
         end
       end

--- a/lib/fog/openstack/requests/baremetal/unset_node_maintenance.rb
+++ b/lib/fog/openstack/requests/baremetal/unset_node_maintenance.rb
@@ -3,17 +3,11 @@ module Fog
     class OpenStack
       class Real
         def unset_node_maintenance(node_uuid, parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
           request(
             :expects => [200, 202, 204],
             :method => 'DELETE',
             :path => "nodes/#{node_uuid}/maintenance",
-            :query   => query
+            :query   => parameters
           )
         end
       end

--- a/lib/fog/openstack/requests/compute/list_services.rb
+++ b/lib/fog/openstack/requests/compute/list_services.rb
@@ -3,17 +3,11 @@ module Fog
     class OpenStack
       class Real
         def list_services(parameters=nil)
-          if parameters
-            query = parameters.each { |k, v| parameters[k] = URI::encode(v) }
-          else
-            query = {}
-          end
-
           request(
             :expects => [200, 203],
             :method  => 'GET',
             :path    => 'os-services',
-            :query   => query
+            :query   => parameters
           )
         end
       end


### PR DESCRIPTION
which causes NoMethodError in ruby's uri/rfc2396_parser.rb
when passed parameter's value is ie. Fixnum.