### PR TITLE
[DigitalOcean] - Failed requests fail to log because of Bluebox

### DIFF
--- a/lib/fog/digitalocean/compute_v2.rb
+++ b/lib/fog/digitalocean/compute_v2.rb
@@ -93,7 +93,7 @@ module Fog
           rescue Excon::Errors::HTTPStatusError => error
             raise case error
                     when Excon::Errors::NotFound
-                      Fog::Compute::Bluebox::NotFound.slurp(error)
+                      NotFound.slurp(error)
                     else
                       error
                   end


### PR DESCRIPTION
If you're just loading fog/digitalocean in your application and some
request fails, no logs will be provided. Instead an error 'uninitialized
constant Fog::Compute::Bluebox' will show up. This is because for some
reason DO calls Bluebox::NotFound when a request fails.