### PR TITLE
Standardize the `:state` alias to `:status`

### DIFF
--- a/lib/fog/digitalocean/models/compute_v2/server.rb
+++ b/lib/fog/digitalocean/models/compute_v2/server.rb
@@ -13,7 +13,7 @@ module Fog
         attribute :disk
         attribute :locked
         attribute :created_at
-        attribute :status
+        attribute :status,    :aliases => 'state'
         attribute :backup_ids
         attribute :snapshot_ids
         attribute :features


### PR DESCRIPTION
It seems that every other plugin expect `:state` for instance, https://github.com/fog/fog/blob/master/lib/fog/openstack/models/compute/server.rb#L34. DO needs to have the alias of `:state` to `:status` to help some down stream usage. 

Consistancy is the key to happiness :)