### PR TITLE
rework floating_ip object

### DIFF
--- a/lib/fog/openstack/models/network/floating_ip.rb
+++ b/lib/fog/openstack/models/network/floating_ip.rb
@@ -21,7 +21,7 @@ module Fog
           requires :floating_network_id
           merge_attributes(service.create_floating_ip(self.floating_network_id,
 
-                                                    self.attributes).body['floatingip'])
+                                                      self.attributes).body['floatingip'])
           self
         end
 
@@ -33,6 +33,29 @@ module Fog
           requires :id
           service.delete_floating_ip(self.id)
           true
+        end
+
+        def associate(port_id, fixed_ip_address = nil)
+          requires :id
+          options = if !fixed_ip_address.nil?
+                      { 'fixed_ip_address': fixed_ip_address }
+                    else
+                      {}
+                    end
+          merge_attributes(service.associate_floating_ip(self.id,
+                                                         port_id,
+                                                         options).body['floatingip'])
+        end
+
+        def disassociate(fixed_ip_address = nil)
+          requires :id
+          options = if !fixed_ip_address.nil?
+                      { 'fixed_ip_address': fixed_ip_address }
+                    else
+                      {}
+                    end
+          merge_attributes(service.disassociate_floating_ip(self.id,
+                                                            options).body['floatingip'])
         end
       end
     end

--- a/lib/fog/openstack/network.rb
+++ b/lib/fog/openstack/network.rb
@@ -174,7 +174,17 @@ module Fog
                   'tenant_id'        => tenant_id,
                 }
               },
-              :floating_ips => {},
+              :floating_ips => {
+                '00000000-0000-0000-0000-000000000000' => {
+                  'id'               => '00000000-0000-0000-0000-000000000000',
+                  'port_id'             => nil,
+                  'tenant_id'           => tenant_id,
+                  'floating_network_id'    => network_id,
+                  'router_id'           => '00000000-0000-0000-0000-000000000000',
+                  'floating_ip_address' => '66.66.66.66',
+
+                }
+              },
               :routers => {},
               :lb_pools => {},
               :lb_members => {},

--- a/lib/fog/openstack/requests/network/associate_floating_ip.rb
+++ b/lib/fog/openstack/requests/network/associate_floating_ip.rb
@@ -25,21 +25,16 @@ module Fog
 
       class Mock
         def associate_floating_ip(floating_ip_id, port_id, options = {})
-          response = Excon::Response.new
-          response.status = 201
-          data = {
-            'id'                  => '00000000-0000-0000-0000-000000000000',
-            'router_id'           => '00000000-0000-0000-0000-000000000000',
-            'tenant_id'           => options["tenant_id"],
-            'floating_network_id' => options["floating_network_id"],
-            'fixed_ip_address'    => options["fixed_ip_address"],
-            'floating_ip_address' => options["floating_ip_address"],
-            'port_id'             => port_id,
-          }
-
-          self.data[:floating_ips][data['floating_ip_id']] = data
-          response.body = { 'floatingip' => data }
-          response
+          if data = self.data[:floating_ips][floating_ip_id]
+            response = Excon::Response.new
+            response.status = 201
+            data['port_id'] = port_id
+            data['fixed_ip_address'] = options[:fixed_ip_address]
+            response.body = { 'floatingip' => data }
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
         end
       end
     end

--- a/lib/fog/openstack/requests/network/create_floating_ip.rb
+++ b/lib/fog/openstack/requests/network/create_floating_ip.rb
@@ -28,7 +28,7 @@ module Fog
           response = Excon::Response.new
           response.status = 201
           data = {
-            'id'                  => floating_network_id,
+            'id'                  => Fog::UUID.uuid,
             'floating_network_id' => floating_network_id,
             'port_id'             => options[:port_id],
             'tenant_id'           => options[:tenant_id],

--- a/lib/fog/openstack/requests/network/disassociate_floating_ip.rb
+++ b/lib/fog/openstack/requests/network/disassociate_floating_ip.rb
@@ -25,21 +25,16 @@ module Fog
 
       class Mock
         def disassociate_floating_ip(floating_ip_id, options = {})
-          response = Excon::Response.new
-          response.status = 200
-          data = {
-            'id'                  => '00000000-0000-0000-0000-000000000000',
-            'router_id'           => nil,
-            'tenant_id'           => options["tenant_id"],
-            'floating_network_id' => options["floating_network_id"],
-            'fixed_ip_address'    => nil,
-            'floating_ip_address' => options["floating_ip_address"],
-            'port_id'             => options["port_id"],
-          }
-
-          self.data[:floating_ips][data['floating_ip_id']] = data
-          response.body = { 'floatingip' => data }
-          response
+          if data = self.data[:floating_ips][floating_ip_id]
+            response = Excon::Response.new
+            response.status = 201
+            data['port_id'] = nil
+            data['fixed_ip_address'] = nil
+            response.body = { 'floatingip' => data }
+            response
+          else
+            raise Fog::Network::OpenStack::NotFound
+          end
         end
       end
     end

--- a/lib/fog/openstack/requests/network/get_floating_ip.rb
+++ b/lib/fog/openstack/requests/network/get_floating_ip.rb
@@ -14,20 +14,10 @@ module Fog
       class Mock
         def get_floating_ip(floating_ip_id)
           response = Excon::Response.new
+
           if data = self.data[:floating_ips][floating_ip_id]
             response.status = 200
-            response.body = {
-              "floatingip" => {
-                "id"                  => "00000000-0000-0000-0000-000000000000",
-                # changed
-                # "floating_ip_id" => floating_ip_id,
-                "port_id"             => data["port_id"],
-                "tenant_id"           => data["tenant_id"],
-                "fixed_ip_address"    => data["fixed_ip_address"],
-                "router_id"           => "00000000-0000-0000-0000-000000000000",
-                "floating_ip_address" => data["floating_ip_address"],
-              }
-            }
+            response.body = { 'floatingip' => data }
             response
           else
             raise Fog::Network::OpenStack::NotFound


### PR DESCRIPTION
- added `associate` and `disassociate` into floating_ip objet
- make mock requests concern `floating_ip` to have same behaviors as compute's