### PR TITLE
Added label to Guest Properties

### DIFF
--- a/lib/fog/vcloud_director/requests/compute/put_product_sections.rb
+++ b/lib/fog/vcloud_director/requests/compute/put_product_sections.rb
@@ -22,7 +22,10 @@ module Fog
             section[:user_configurable] ||= true
             section[:type]              ||= "string"
             section[:password]          ||= false
-            xml += "<ovf:Property ovf:userConfigurable='#{section[:user_configurable]}' ovf:type='#{section[:type]}' ovf:password='#{section[:password]}' ovf:key='#{section[:id]}' ovf:value='#{section[:value]}'/>"
+            xml += "<ovf:Property ovf:userConfigurable='#{section[:user_configurable]}' ovf:type='#{section[:type]}' ovf:password='#{section[:password]}' ovf:key='#{section[:id]}' ovf:value='#{section[:value]}'>"
+            xml += "<ovf:Label>#{section[:id]}</ovf:Label>"
+            xml += "</ovf:Property>"
+            
           end
 
           xml += '</ovf:ProductSection>'


### PR DESCRIPTION
The current method for setting GuestProperties on vApps & VMs does not set the <ovf:Label> tag. 
this means that via vCloud Director UI Guest Property Key names are not shown, only values.

I've added the tag and tested.