### PR TITLE
[VCLOUD_DIRECTOR] add builder gem dependency and require

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency('nokogiri', '~> 1.5', '>= 1.5.11')
   s.add_dependency('ipaddress', '~>0.5')
+  s.add_dependency('builder', '>=3.2.2')
 
   # Modular providers
   s.add_dependency("fog-brightbox")

--- a/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
+++ b/lib/fog/vcloud_director/requests/compute/instantiate_vapp_template.rb
@@ -1,3 +1,5 @@
+require 'builder'
+
 module Fog
   module Compute
     class VcloudDirector


### PR DESCRIPTION
instantiating vApp templates uses Builder for the XML. This is not required (and therefore throws a namespace error) and the Gem is not included in the gemfile.
Added both and seems to work now. Surprised this slipped through previously though. Guess someone had builder installed already!