### PR TITLE
[docker] Fixing bad namespace on errors

### DIFF
--- a/lib/fog/fogdocker/requests/compute/container_action.rb
+++ b/lib/fog/fogdocker/requests/compute/container_action.rb
@@ -13,9 +13,9 @@ module Fog
             result
           end
         rescue Docker::Error::NotFoundError => e
-          raise Fog::Errors::Error::NotFound.new(e.message)
+          raise Fog::Errors::NotFound.new(e.message)
         rescue Docker::Error::TimeoutError => e
-          raise Fog::Errors::Error::TimeoutError.new(e.message)
+          raise Fog::Errors::TimeoutError.new(e.message)
         rescue Docker::Error::UnauthorizedError => e
           raise Fog::Errors::Fogdocker::AuthenticationError.new(e.message)
         rescue Docker::Error::DockerError => e


### PR DESCRIPTION
Errors don't have an "Error" namespace so we're getting unintialized constant exceptions. See https://github.com/fog/fog-core/blob/d18398c44e9e8d57025874ed43a573434dbd0f95/lib/fog/core/errors.rb.