### PR TITLE
Removed 'filters' from ssh_key all method

### DIFF
--- a/lib/fog/digitalocean/models/compute_v2/ssh_keys.rb
+++ b/lib/fog/digitalocean/models/compute_v2/ssh_keys.rb
@@ -14,9 +14,9 @@ module Fog
         # @raise [Fog::Compute::DigitalOceanV2::ServiceError]
         # @see https://developers.digitalocean.com/documentation/v2/#list-all-keys
         def all(filters={})
-          data = service.list_ssh_keys(filters)
+          data = service.list_ssh_keys()
           links = data.body["links"]
-          get_paged_links(links) 
+          get_paged_links(links)
           keys = data.body["ssh_keys"]
           load(keys)
         end


### PR DESCRIPTION
- There needs to be no filter with the all method call.
- Removed an extra WS