### PR TITLE
Adding postinstall message

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,19 @@ fog is the Ruby cloud services library, top to bottom:
 [![Code Climate](https://codeclimate.com/github/fog/fog/badges/gpa.svg)](https://codeclimate.com/github/fog/fog)
 [![Gem Version](https://badge.fury.io/rb/fog.svg)](http://badge.fury.io/rb/fog)
 
+## Dependency Notice
+
+Currently all fog providers are getting separated into metagems to lower the
+load time and dependency count.
+
+If there's a metagem available for your cloud provider, e.g. `fog-aws`,
+you should be using it instead of requiring the full fog collection to avoid 
+unnecessary dependencies.
+
+'fog' should be required explicitly only if:  
+- The provider you use doesn't yet have a metagem available.
+- You require Ruby 1.9.3 support.
+
 ## Getting Started
 
 The easiest way to learn fog is to install the gem and use the interactive console.

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -98,4 +98,21 @@ Gem::Specification.new do |s|
 
   s.files = `git ls-files`.split("\n")
   s.test_files = `git ls-files -- {spec,tests}/*`.split("\n")
+
+  postinstall_message =  <<-POSTINST
+------------------------------
+Thank you for installing fog!
+
+IMPORTANT NOTICE:
+If there's a metagem available for your cloud provider, e.g. `fog-aws`,
+you should be using it instead of requiring the full fog collection to avoid
+unnecessary dependencies.
+
+'fog' should be required explicitly only if:
+- The provider you use doesn't yet have a metagem available.
+- You require Ruby 1.9.3 support.
+------------------------------
+  POSTINST
+
+  s.post_install_message = postinstall_message
 end


### PR DESCRIPTION
Adding a simple postinstall message + README section to tell users not to use
fog gem if they require only specific dependencies.

Here's how it looks like:
```
λ gem install --local ./fog-1.38.0.gem                                                                                                                                                                                     (1)
------------------------------
Thank you for installing fog!

IMPORTANT NOTICE:
If there's a metagem available for your cloud provider, e.g. `fog-aws`,
you should be using it instead of requiring the full fog collection to avoid
unnecessary dependencies.

'fog' should be required explicitly only if:
- The provider you use doesn't yet have a metagem available.
- You require Ruby 1.9.3 support.
------------------------------
Successfully installed fog-1.38.0
Parsing documentation for fog-1.38.0
Installing ri documentation for fog-1.38.0
Done installing documentation for fog after 18 seconds
1 gem installed
```

Fixing #3876