### PR TITLE
Vcloud-director create-snapshot for vm/vapp

### DIFF
--- a/lib/fog/vcloud_director/compute.rb
+++ b/lib/fog/vcloud_director/compute.rb
@@ -250,6 +250,7 @@ module Fog
       request :post_upload_disk
       request :post_upload_media
       request :post_upload_vapp_template
+      request :post_create_snapshot
       request :put_catalog_item_metadata_item_metadata
       request :put_cpu
       request :put_disk_metadata_item_metadata

--- a/lib/fog/vcloud_director/generators/compute/create_snapshot.rb
+++ b/lib/fog/vcloud_director/generators/compute/create_snapshot.rb
@@ -1,0 +1,25 @@
+module Fog
+  module Generators
+    module Compute
+      module VcloudDirector
+        # @see http://pubs.vmware.com/vcd-56/topic/com.vmware.ICbase/PDF/vcd_56_api_guide.pdf @page 121
+        class CreateSnapshot
+          attr_reader :attrs
+
+          def initialize(attrs={})
+            @attrs = attrs
+          end
+
+          def generate_xml
+            attrs = @attrs
+            Nokogiri::XML::Builder.new do
+              CreateSnapshotParams('xmlns' => 'http://www.vmware.com/vcloud/v1.5', 'memory' => attrs[:memory], 'name' => attrs[:name], 'quiesce' => attrs[:quiesce]) {
+                Description attrs[:Description] if attrs.key?(:Description)
+              }
+            end.to_xml
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vcloud_director/requests/compute/post_create_snapshot.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_create_snapshot.rb
@@ -1,0 +1,21 @@
+module Fog
+  module Compute
+    class VcloudDirector
+      class Real
+        require 'fog/vcloud_director/generators/compute/create_snapshot'
+        def post_create_snapshot(id, options={})
+          body = Fog::Generators::Compute::VcloudDirector::CreateSnapshot.new(options).generate_xml
+
+          request(
+            :body => body,
+            :expects => 202,
+            :headers => { 'Content-Type' => 'application/vnd.vmware.vcloud.recomposeVAppParams+xml' },
+            :method => 'POST',
+            :parser => Fog::ToHashDocument.new,
+            :path => "vApp/#{id}/action/createSnapshot"
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/vcloud_director/requests/compute/post_create_snapshot.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_create_snapshot.rb
@@ -9,7 +9,7 @@ module Fog
           request(
             :body => body,
             :expects => 202,
-            :headers => { 'Content-Type' => 'application/vnd.vmware.vcloud.recomposeVAppParams+xml' },
+            :headers => { 'Content-Type' => 'application/vnd.vmware.vcloud.createSnapshotParams+xml' },
             :method => 'POST',
             :parser => Fog::ToHashDocument.new,
             :path => "vApp/#{id}/action/createSnapshot"


### PR DESCRIPTION
I added two classes:
- lib/fog/vcloud_director/generators/compute/create_snapshot.rb
- lib/fog/vcloud_director/requests/compute/post_create_snapshot.rb
I also added the reference of the request in lib/fog/vcloud_director/compute.rb