### PR TITLE
Digital Ocean request filtering fixes & test fixes 

### DIFF
--- a/lib/fog/digitalocean/models/compute_v2/flavors.rb
+++ b/lib/fog/digitalocean/models/compute_v2/flavors.rb
@@ -12,7 +12,7 @@ module Fog
         # @raise [Fog::Compute::DigitalOceanV2::ServiceError]
         # @see https://developers.digitalocean.com/documentation/v2/#list-all-sizes
         def all(filters = {})
-          data = service.list_flavors.body["sizes"]
+          data = service.list_flavors(filters).body["sizes"]
           load(data)
         end
       end

--- a/lib/fog/digitalocean/models/compute_v2/ssh_keys.rb
+++ b/lib/fog/digitalocean/models/compute_v2/ssh_keys.rb
@@ -13,8 +13,8 @@ module Fog
         # @raise [Fog::Compute::DigitalOceanV2::InternalServerError] - HTTP 500
         # @raise [Fog::Compute::DigitalOceanV2::ServiceError]
         # @see https://developers.digitalocean.com/documentation/v2/#list-all-keys
-        def all(filters={})
-          data = service.list_ssh_keys()
+        def all(filters = {})
+          data = service.list_ssh_keys(filters)
           links = data.body["links"]
           get_paged_links(links)
           keys = data.body["ssh_keys"]

--- a/lib/fog/digitalocean/requests/compute_v2/list_flavors.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_flavors.rb
@@ -2,18 +2,18 @@ module Fog
   module Compute
     class DigitalOceanV2
       class Real
-        def list_flavors
+        def list_flavors(filters = {})
           request(
             :expects => [200],
             :method  => 'GET',
-            :path    => '/v2/sizes'
+            :path    => "/v2/sizes#{filters.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join("&")}"
           )
         end
       end
 
     # noinspection RubyStringKeysInHashInspection
       class Mock
-        def list_flavors
+        def list_flavors(filters = {})
           response        = Excon::Response.new
           response.status = 200
           response.body   = {

--- a/lib/fog/digitalocean/requests/compute_v2/list_servers.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_servers.rb
@@ -19,7 +19,10 @@ module Fog
           response.body = {
               "status" => "OK",
               "droplets"  => self.data[:servers],
-              "total"  => self.data[:meta]["total"]
+              "links" => {},
+              "meta" => {
+                "total" => data[:servers].count
+              }
           }
           response
         end

--- a/lib/fog/digitalocean/requests/compute_v2/list_ssh_keys.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_ssh_keys.rb
@@ -14,13 +14,22 @@ module Fog
       # noinspection RubyStringKeysInHashInspection
       class Mock
         def list_ssh_keys(filters = {})
-          response = Excon::Response.new
+          response        = Excon::Response.new
           response.status = 200
-          response.body = {
-            "ssh_keys" => data[:ssh_keys],
-            "links" => {},
+          response.body   = {
+            "ssh_keys" => data[:ssh_keys] ||
+              [
+                {
+                  "id" => 512189,
+                  "fingerprint" => "3b:16:bf:e4:8b:00:8b:b8:59:8c:a9:d3:f0:19:45:fa",
+                  "public_key" => "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAAQQDDHr/jh2Jy4yALcK4JyWbVkPRaWmhck3IgCoeOO3z1e2dBowLh64QAM+Qb72pxekALga2oi4GvT+TlWNhzPH4V example",
+                  "name" => "My SSH Public Key"
+                }
+              ],
+            "links" => {
+            },
             "meta" => {
-              "total" => data[:ssh_keys].count
+              "total" => data[:ssh_keys].count || 1
             }
           }
           response

--- a/lib/fog/digitalocean/requests/compute_v2/list_ssh_keys.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_ssh_keys.rb
@@ -2,18 +2,18 @@ module Fog
   module Compute
     class DigitalOceanV2
       class Real
-        def list_ssh_keys
+        def list_ssh_keys(filters = {})
           request(
             :expects => [200],
             :method => 'GET',
-            :path => 'v2/account/keys',
+            :path => "v2/account/keys#{filters.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join("&")}",
           )
         end
       end
 
       # noinspection RubyStringKeysInHashInspection
       class Mock
-        def list_ssh_keys
+        def list_ssh_keys(filters = {})
           response = Excon::Response.new
           response.status = 200
           response.body = {

--- a/tests/digitalocean/requests/compute_v2/list_ssh_keys_tests.rb
+++ b/tests/digitalocean/requests/compute_v2/list_ssh_keys_tests.rb
@@ -1,0 +1,20 @@
+Shindo.tests('Fog::Compute::DigitalOceanV2 | list_ssh_keys request', ['digitalocean', 'compute']) do
+  service = Fog::Compute.new(:provider => 'DigitalOcean', :version => 'V2')
+
+  ssh_key_format = {
+    'id' => Integer,
+    'fingerprint' => String,
+    'public_key' => String,
+    'name' => String,
+  }
+
+  tests('success') do
+    tests('#list_ssh_keys') do
+      service.list_ssh_keys.body['ssh_keys'].each do |ssh_key|
+        tests('format').data_matches_schema(ssh_key_format) do
+          ssh_key
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes the filtering for the `list_ssh_keys`, and `list_flavors` requests. Also fixes tests for `list_servers` to pass again and add tests for `list_ssh_keys`.