### PR TITLE
Digital Ocean list_* requests pass query params to Excon

### DIFF
--- a/lib/fog/digitalocean/requests/compute_v2/list_flavors.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_flavors.rb
@@ -6,7 +6,8 @@ module Fog
           request(
             :expects => [200],
             :method  => 'GET',
-            :path    => "/v2/sizes#{filters.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join("&")}"
+            :path    => "/v2/sizes",
+            :query   => filters
           )
         end
       end

--- a/lib/fog/digitalocean/requests/compute_v2/list_images.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_images.rb
@@ -6,7 +6,8 @@ module Fog
           request(
             :expects => [200],
             :method  => 'GET',
-            :path    => "/v2/images?#{filters.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join("&")}"
+            :path    => "/v2/images",
+            :query   => filters
           )
         end
       end

--- a/lib/fog/digitalocean/requests/compute_v2/list_regions.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_regions.rb
@@ -6,7 +6,8 @@ module Fog
           request(
             :expects => [200],
             :method  => 'GET',
-            :path    => "/v2/regions?#{filters.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join("&")}"
+            :path    => "/v2/regions",
+            :query   => filters
           )
         end
       end

--- a/lib/fog/digitalocean/requests/compute_v2/list_servers.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_servers.rb
@@ -5,8 +5,9 @@ module Fog
         def list_servers(filters = {})
           request(
             :expects => [200],
-            :method => 'GET',
-            :path => "/v2/droplets?#{filters.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join("&")}"
+            :method  => 'GET',
+            :path    => "/v2/droplets",
+            :query   => filters
           )
         end
       end

--- a/lib/fog/digitalocean/requests/compute_v2/list_ssh_keys.rb
+++ b/lib/fog/digitalocean/requests/compute_v2/list_ssh_keys.rb
@@ -5,8 +5,9 @@ module Fog
         def list_ssh_keys(filters = {})
           request(
             :expects => [200],
-            :method => 'GET',
-            :path => "v2/account/keys#{filters.to_a.map { |x| "#{x[0]}=#{x[1]}" }.join("&")}",
+            :method  => 'GET',
+            :path    => "v2/account/keys",
+            :query   => filters
           )
         end
       end


### PR DESCRIPTION
Use Excon’s query parameter handling and escaping rather
than doing it manually.