### PR TITLE
#3900 Escape VM name in OpenNebula allocator

### DIFF
--- a/lib/fog/opennebula/requests/compute/vm_allocate.rb
+++ b/lib/fog/opennebula/requests/compute/vm_allocate.rb
@@ -13,7 +13,7 @@ module Fog
 
           xml = ::OpenNebula::VirtualMachine.build_xml
           vm  = ::OpenNebula::VirtualMachine.new(xml, client)
-          rc = vm.allocate(attr[:flavor].to_s + "\nNAME=" + attr[:name])
+          rc = vm.allocate(attr[:flavor].to_s + "\nNAME=\"" + attr[:name] + "\"") 
 
           # irb(main):050:0> vm.allocate(s.flavor.to_s + "\nNAME=altest5")
           # => #<OpenNebula::Error:0x00000002a50760 @message="[VirtualMachineAllocate] User [42] : Not authorized to perform CREATE VM.", @errno=512>


### PR DESCRIPTION
>...
  INFO fog: compute!
"CPU=1\nVCPU=12\nMEMORY=16384\nDISK=[\"DRIVER\"=\"qcow2\", \"IMAGE_ID\"=\"206\"]\nNIC=[MODEL=\"\",NETWORK_ID=\"13\"]\nOS=[\"ARCH\"=\"x86_64\", \"BOOT\"=\"hd\"]\nGRAPHICS=[\"LISTEN\"=\"192.168.0.4\", \"PORT\"=\"5602\", \"TYPE\"=\"spice\"]\nRAW=[\"DATA\"=\"<devices>   <memballoon model='virtio'/> </devices> <memory unit='MiB'>16384</memory> <currentMemory unit='MiB'>2048</currentMemory>\", \"TYPE\"=\"kvm\"]\n\n\nNAME=My Team - Virtual Machine [Web] [Ubuntu]"
ERROR warden: Error occurred: [VirtualMachineAllocate] Error allocating a new virtual machine. Parse error: syntax error, unexpected VARIABLE, expecting EQUAL or EQUAL_EMPTY at line 11, columns 382:387
...
I just dumped the XML sent to OpenNebula to show that it doesn't escape the VM name.