### PR TITLE
Use URI escape instead of CGI escape as of HTTP specification

### DIFF
--- a/lib/fog/cloudstack/core.rb
+++ b/lib/fog/cloudstack/core.rb
@@ -13,6 +13,8 @@ module Fog
     def self.escape(string)
       string = CGI::escape(string)
       string = string.gsub("+","%20")
+      # Escaped asterisk will cause malformed request
+      string = string.gsub("%2A","*")
       string
     end
 


### PR DESCRIPTION
In general, any requests with a asterisk (*) character is malformed.

The deep rooted reason is that at cloudstack core, CGI escape is used. As of HTTP specification, we should be using URI escape instead.