### PR TITLE
Fixing gemspec conflicts with 1.9

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ group :development, :test do
   # This is here because gemspec doesn't support require: false
   gem "netrc", :require => false
   gem "octokit", :require => false
-  gem 'rspec', :require => false
+  gem "rspec", :require => false
 end
 
 gemspec

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -44,10 +44,12 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md]
 
-  s.add_dependency("fog-core", "~> 1.42")
+  s.add_dependency("fog-core", "~> 1.43")
   s.add_dependency("fog-json")
   s.add_dependency("fog-xml", "~> 0.1.1")
-
+  
+  # JSON locked for Ruby 1.9, remove once deprecated
+  s.add_dependency("json", ">= 1.8", "< 2.0")
   s.add_dependency("ipaddress", "~> 0.5")
 
   # Modular providers (please keep sorted)


### PR DESCRIPTION
First pass at fixing dependencies.

We really-really should think about dropping 1.9 sooner.