### PR TITLE
Add instance_types support to oVirt provider

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -88,7 +88,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("opennebula")
   s.add_development_dependency("pry")
   s.add_development_dependency("rake")
-  s.add_development_dependency("rbovirt", "0.0.32")
+  s.add_development_dependency("rbovirt", "0.1.3")
   s.add_development_dependency("rbvmomi")
   s.add_development_dependency("rubocop")
   s.add_development_dependency("shindo", "~> 0.3.4")

--- a/lib/fog/ovirt/compute.rb
+++ b/lib/fog/ovirt/compute.rb
@@ -13,6 +13,8 @@ module Fog
       collection :servers
       model      :template
       collection :templates
+      model      :instance_type
+      collection :instance_types
       model      :cluster
       collection :clusters
       model      :interface
@@ -37,6 +39,8 @@ module Fog
       request :get_virtual_machine
       request :list_templates
       request :get_template
+      request :list_instance_types
+      request :get_instance_type
       request :list_clusters
       request :get_cluster
       request :add_interface

--- a/lib/fog/ovirt/models/compute/instance_type.rb
+++ b/lib/fog/ovirt/models/compute/instance_type.rb
@@ -1,0 +1,39 @@
+module Fog
+  module Compute
+    class Ovirt
+      class InstanceType < Fog::Model
+        identity :id
+
+        attr_accessor :raw
+
+        attribute :name
+        attribute :description
+        attribute :memory
+        attribute :cores
+        attribute :creation_time
+        attribute :os
+        attribute :ha
+        attribute :ha_priority
+        attribute :display
+        attribute :usb
+        attribute :migration_downtime
+        attribute :type
+        attribute :status
+        attribute :cpu_shares
+        attribute :boot_menu
+        attribute :origin
+        attribute :stateless
+        attribute :delete_protected
+        attribute :sso
+        attribute :timezone
+        attribute :migration
+        attribute :io_threads
+        attribute :memory_garanteed
+
+        def to_s
+          name
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/ovirt/models/compute/instance_types.rb
+++ b/lib/fog/ovirt/models/compute/instance_types.rb
@@ -1,0 +1,20 @@
+require 'fog/core/collection'
+require 'fog/ovirt/models/compute/instance_type'
+
+module Fog
+  module Compute
+    class Ovirt
+      class InstanceTypes < Fog::Collection
+        model Fog::Compute::Ovirt::InstanceType
+
+        def all(filters = {})
+          load service.list_instance_types(filters)
+        end
+
+        def get(id)
+          new service.get_instance_type(id)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/ovirt/models/compute/server.rb
+++ b/lib/fog/ovirt/models/compute/server.rb
@@ -23,6 +23,7 @@ module Fog
         attribute :host
         attribute :cluster
         attribute :template
+        attribute :instance_type
         attribute :interfaces
         attribute :volumes
         attribute :raw

--- a/lib/fog/ovirt/requests/compute/get_instance_type.rb
+++ b/lib/fog/ovirt/requests/compute/get_instance_type.rb
@@ -1,0 +1,17 @@
+module Fog
+  module Compute
+    class Ovirt
+      class Real
+        def get_instance_type(id)
+          ovirt_attrs client.instance_type(id)
+        end
+      end
+      class Mock
+        def get_instance_type(id)
+          xml = read_xml 'instance_type.xml'
+          ovirt_attrs OVIRT::InstanceType::new(self, Nokogiri::XML(xml).root)
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/ovirt/requests/compute/list_instance_types.rb
+++ b/lib/fog/ovirt/requests/compute/list_instance_types.rb
@@ -1,0 +1,19 @@
+module Fog
+  module Compute
+    class Ovirt
+      class Real
+        def list_instance_types(filters = {})
+          client.instance_types(filters).map {|ovirt_obj| ovirt_attrs ovirt_obj}
+        end
+      end
+      class Mock
+        def list_instance_types(filters = {})
+          xml = read_xml 'instance_types.xml'
+          Nokogiri::XML(xml).xpath('/instance_types/instance_type').map do |t|
+            ovirt_attrs OVIRT::InstanceType::new(self, t)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/fog/ovirt/requests/compute/mock_files/instance_type.xml
+++ b/lib/fog/ovirt/requests/compute/mock_files/instance_type.xml
@@ -1,0 +1,42 @@
+<instance_types>
+<instance_type href="/api/instancetypes/00000009-0009-0009-0009-0000000002fa" id="00000009-0009-0009-0009-0000000002fa">
+  <name>Large</name>
+  <description>Large instance type</description>
+  <link href="/api/instancetypes/00000009-0009-0009-0009-0000000002fa/nics" rel="nics"/>
+  <link href="/api/instancetypes/00000009-0009-0009-0009-0000000002fa/watchdogs" rel="watchdogs"/>
+  <link href="/api/instancetypes/00000009-0009-0009-0009-0000000002fa/graphicsconsoles" rel="graphicsconsoles"/>
+  <memory>8589934592</memory>
+  <cpu>
+    <topology sockets="2" cores="1" threads="1"/>
+  </cpu>
+  <os>
+    <boot dev="hd"/>
+  </os>
+  <creation_time>2014-05-05T02:30:00.000+05:30</creation_time>
+  <high_availability>
+    <enabled>false</enabled>
+    <priority>0</priority>
+  </high_availability>
+  <display>
+    <type>spice</type>
+    <monitors>1</monitors>
+    <single_qxl_pci>false</single_qxl_pci>
+    <smartcard_enabled>false</smartcard_enabled>
+  </display>
+  <usb>
+    <enabled>false</enabled>
+  </usb>
+  <migration_downtime>-1</migration_downtime>
+  <migration>
+    <auto_converge>inherit</auto_converge>
+    <compressed>inherit</compressed>
+  </migration>
+  <io>
+    <threads>0</threads>
+  </io>
+  <memory_policy>
+    <guaranteed>8589934592</guaranteed>
+    <ballooning>false</ballooning>
+  </memory_policy>
+</instance_type>
+</instance_types>

--- a/lib/fog/ovirt/requests/compute/mock_files/instance_types.xml
+++ b/lib/fog/ovirt/requests/compute/mock_files/instance_types.xml
@@ -1,0 +1,197 @@
+<instance_types>
+<instance_type href="/api/instancetypes/00000009-0009-0009-0009-0000000002fa" id="00000009-0009-0009-0009-0000000002fa">
+<name>Large</name>
+<description>Large instance type</description>
+<link href="/api/instancetypes/00000009-0009-0009-0009-0000000002fa/nics" rel="nics"/>
+<link href="/api/instancetypes/00000009-0009-0009-0009-0000000002fa/watchdogs" rel="watchdogs"/>
+<link href="/api/instancetypes/00000009-0009-0009-0009-0000000002fa/graphicsconsoles" rel="graphicsconsoles"/>
+<memory>8589934592</memory>
+<cpu>
+<topology sockets="2" cores="1" threads="1"/>
+</cpu>
+<os>
+<boot dev="hd"/>
+</os>
+<creation_time>2014-05-05T02:30:00.000+05:30</creation_time>
+<high_availability>
+<enabled>false</enabled>
+<priority>0</priority>
+</high_availability>
+<display>
+<type>spice</type>
+<monitors>1</monitors>
+<single_qxl_pci>false</single_qxl_pci>
+<smartcard_enabled>false</smartcard_enabled>
+</display>
+<usb>
+<enabled>false</enabled>
+</usb>
+<migration_downtime>-1</migration_downtime>
+<migration>
+<auto_converge>inherit</auto_converge>
+<compressed>inherit</compressed>
+</migration>
+<io>
+<threads>0</threads>
+</io>
+<memory_policy>
+<guaranteed>8589934592</guaranteed>
+</memory_policy>
+</instance_type>
+<instance_type href="/api/instancetypes/00000007-0007-0007-0007-000000000210" id="00000007-0007-0007-0007-000000000210">
+<name>Medium</name>
+<description>Medium instance type</description>
+<link href="/api/instancetypes/00000007-0007-0007-0007-000000000210/nics" rel="nics"/>
+<link href="/api/instancetypes/00000007-0007-0007-0007-000000000210/watchdogs" rel="watchdogs"/>
+<link href="/api/instancetypes/00000007-0007-0007-0007-000000000210/graphicsconsoles" rel="graphicsconsoles"/>
+<memory>4294967296</memory>
+<cpu>
+<topology sockets="2" cores="1" threads="1"/>
+</cpu>
+<os>
+<boot dev="hd"/>
+</os>
+<creation_time>2014-05-05T02:30:00.000+05:30</creation_time>
+<high_availability>
+<enabled>false</enabled>
+<priority>0</priority>
+</high_availability>
+<display>
+<type>spice</type>
+<monitors>1</monitors>
+<single_qxl_pci>false</single_qxl_pci>
+<smartcard_enabled>false</smartcard_enabled>
+</display>
+<usb>
+<enabled>false</enabled>
+</usb>
+<migration_downtime>-1</migration_downtime>
+<migration>
+<auto_converge>inherit</auto_converge>
+<compressed>inherit</compressed>
+</migration>
+<io>
+<threads>0</threads>
+</io>
+<memory_policy>
+<guaranteed>4294967296</guaranteed>
+</memory_policy>
+</instance_type>
+<instance_type href="/api/instancetypes/00000005-0005-0005-0005-000000000190" id="00000005-0005-0005-0005-000000000190">
+<name>Small</name>
+<description>Small instance type</description>
+<link href="/api/instancetypes/00000005-0005-0005-0005-000000000190/nics" rel="nics"/>
+<link href="/api/instancetypes/00000005-0005-0005-0005-000000000190/watchdogs" rel="watchdogs"/>
+<link href="/api/instancetypes/00000005-0005-0005-0005-000000000190/graphicsconsoles" rel="graphicsconsoles"/>
+<memory>2147483648</memory>
+<cpu>
+<topology sockets="1" cores="1" threads="1"/>
+</cpu>
+<os>
+<boot dev="hd"/>
+</os>
+<creation_time>2014-05-05T02:30:00.000+05:30</creation_time>
+<high_availability>
+<enabled>false</enabled>
+<priority>0</priority>
+</high_availability>
+<display>
+<type>spice</type>
+<monitors>1</monitors>
+<single_qxl_pci>false</single_qxl_pci>
+<smartcard_enabled>false</smartcard_enabled>
+</display>
+<usb>
+<enabled>false</enabled>
+</usb>
+<migration_downtime>-1</migration_downtime>
+<migration>
+<auto_converge>inherit</auto_converge>
+<compressed>inherit</compressed>
+</migration>
+<io>
+<threads>0</threads>
+</io>
+<memory_policy>
+<guaranteed>2147483648</guaranteed>
+</memory_policy>
+</instance_type>
+<instance_type href="/api/instancetypes/00000003-0003-0003-0003-0000000000ce" id="00000003-0003-0003-0003-0000000000ce">
+<name>Tiny</name>
+<description>Tiny instance type</description>
+<link href="/api/instancetypes/00000003-0003-0003-0003-0000000000ce/nics" rel="nics"/>
+<link href="/api/instancetypes/00000003-0003-0003-0003-0000000000ce/watchdogs" rel="watchdogs"/>
+<link href="/api/instancetypes/00000003-0003-0003-0003-0000000000ce/graphicsconsoles" rel="graphicsconsoles"/>
+<memory>536870912</memory>
+<cpu>
+<topology sockets="1" cores="1" threads="1"/>
+</cpu>
+<os>
+<boot dev="hd"/>
+</os>
+<creation_time>2014-05-05T02:30:00.000+05:30</creation_time>
+<high_availability>
+<enabled>false</enabled>
+<priority>0</priority>
+</high_availability>
+<display>
+<type>spice</type>
+<monitors>1</monitors>
+<single_qxl_pci>false</single_qxl_pci>
+<smartcard_enabled>false</smartcard_enabled>
+</display>
+<usb>
+<enabled>false</enabled>
+</usb>
+<migration_downtime>-1</migration_downtime>
+<migration>
+<auto_converge>inherit</auto_converge>
+<compressed>inherit</compressed>
+</migration>
+<io>
+<threads>0</threads>
+</io>
+<memory_policy>
+<guaranteed>536870912</guaranteed>
+</memory_policy>
+</instance_type>
+<instance_type href="/api/instancetypes/0000000b-000b-000b-000b-000000000082" id="0000000b-000b-000b-000b-000000000082">
+<name>XLarge</name>
+<description>Extra Large instance type</description>
+<link href="/api/instancetypes/0000000b-000b-000b-000b-000000000082/nics" rel="nics"/>
+<link href="/api/instancetypes/0000000b-000b-000b-000b-000000000082/watchdogs" rel="watchdogs"/>
+<link href="/api/instancetypes/0000000b-000b-000b-000b-000000000082/graphicsconsoles" rel="graphicsconsoles"/>
+<memory>17179869184</memory>
+<cpu>
+<topology sockets="4" cores="1" threads="1"/>
+</cpu>
+<os>
+<boot dev="hd"/>
+</os>
+<creation_time>2014-05-05T02:30:00.000+05:30</creation_time>
+<high_availability>
+<enabled>false</enabled>
+<priority>0</priority>
+</high_availability>
+<display>
+<type>spice</type>
+<monitors>1</monitors>
+<single_qxl_pci>false</single_qxl_pci>
+<smartcard_enabled>false</smartcard_enabled>
+</display>
+<usb>
+<enabled>false</enabled>
+</usb>
+<migration_downtime>-1</migration_downtime>
+<migration>
+<auto_converge>inherit</auto_converge>
+<compressed>inherit</compressed>
+</migration>
+<io>
+<threads>0</threads>
+</io>
+<memory_policy>
+<guaranteed>17179869184</guaranteed>
+</memory_policy>
+</instance_type>
+</instance_types>


### PR DESCRIPTION
Add instance_types support to oVirt provider. Depends on https://github.com/abenari/rbovirt/pull/117 merged today, but not released ATM.