### PR TITLE
Add #deploy to VcloudDirector::Vm

### DIFF
--- a/lib/fog/vcloud_director/README.md
+++ b/lib/fog/vcloud_director/README.md
@@ -410,7 +410,7 @@ vdc = org.vdcs.first
 vapp = vdc.vapps.get_by_name("segundo")
 vm = vapp.vms.get_by_name("DEVWEB")
 customization = vm.customization
-customization.compute_name = "NEWNAME"
+customization.computer_name = "NEWNAME"
 customization.enabled = false
 customization.script = "new userdata script"
 customization.save

--- a/lib/fog/vcloud_director/models/compute/vm.rb
+++ b/lib/fog/vcloud_director/models/compute/vm.rb
@@ -22,6 +22,17 @@ module Fog
         attribute :hard_disks, :aliases => :disks
         attribute :network_adapters
 
+        def deploy(options = {})
+          requires :id
+          begin
+            response = service.post_deploy_vapp(id, options)
+          rescue Fog::Compute::VcloudDirector::BadRequest => ex
+            Fog::Logger.debug(ex.message)
+            return false
+          end
+          service.process_task(response.body)
+        end
+
         def reload
           # when collection.vapp is nil, it means it's fatherless,
           # vms from different vapps are loaded in the same collection.


### PR DESCRIPTION
To force customization on deployment the vCloud Director API provides an `forceCustomization` attribute in the `deploy` operation. The method `post_deploy_vapp` which can handle this operation (and accepts this attribute) has been present for many years (lib/fog/vcloud_director/requests/compute/post_deploy_vapp.rb). However currently the method cannot be accessed from a `VcloudDirector::Vm` or a `VcloudDirector::Vapp`. Hence this proposal to add this method in those classes.

During development it raised the following `TaskError`:

    Fog::Compute::VcloudDirector::TaskError: status: error, error: {:majorErrorCode=>"400", :message=>"[ a36d1a98-288a-46ce-9e64-3143c55a2c49 ] Parameter forceCustomization is not supported for vApps.", :minorErrorCode=>"BAD_REQUEST"}

Should I provide some documentation and testing on the `deploy` method? Are there any other optimizations I can or should add?
