### PR TITLE
[ovirt] wait for stopped before starting when rebooting

### DIFF
--- a/lib/fog/ovirt/models/compute/server.rb
+++ b/lib/fog/ovirt/models/compute/server.rb
@@ -44,7 +44,7 @@ module Fog
         end
 
         def stopped?
-          !!(status =~ /down/i)
+          status.downcase == 'down'
         end
 
         def mac
@@ -134,7 +134,10 @@ module Fog
         end
 
         def reboot(options = {})
-          stop unless stopped?
+          unless stopped?
+            stop
+            wait_for { stopped? }
+          end
           start options.merge(:blocking => true)
         end
 


### PR DESCRIPTION
When stopping and starting as part of the reboot, it can happen the VM
stopping is not finished before starting, leading to getting this error
in oVirt:

[Operation Failed: [Cannot run VM because the VM is in Powering Down status.]