### PR TITLE
[ovirt] adding disks and clone to attribute

### DIFF
--- a/lib/fog/ovirt/models/compute/server.rb
+++ b/lib/fog/ovirt/models/compute/server.rb
@@ -31,6 +31,8 @@ module Fog
         attribute :ips
         attribute :ha
         attribute :ha_priority
+        attribute :clone
+        attribute :disks
 
         def ready?
           !(status =~ /down/i)


### PR DESCRIPTION
This is to be able to pass `disks` and `clone` to become a part of the xml created here: https://github.com/abenari/rbovirt/blob/master/lib/ovirt/vm.rb#L111-L117

See comment: https://github.com/theforeman/foreman/pull/4512#issuecomment-301305759