### PR TITLE
[ovirt] support passing cloud-init data as custom script

### DIFF
--- a/lib/fog/ovirt/models/compute/server.rb
+++ b/lib/fog/ovirt/models/compute/server.rb
@@ -123,7 +123,11 @@ module Fog
 
         def start_with_cloudinit(options = {})
           wait_for { !locked? } if options[:blocking]
-          user_data = Hash[YAML.load(options[:user_data]).map{|a| [a.first.to_sym, a.last]}]
+          if options[:use_custom_script]
+            user_data = { :custom_script => options[:user_data] }
+          else
+            user_data = Hash[YAML.load(options[:user_data]).map{|a| [a.first.to_sym, a.last]}]
+          end
           service.vm_start_with_cloudinit(:id =>id, :user_data =>user_data)
           reload
         end


### PR DESCRIPTION
Currently, the cloud-init integration with ovirt supports only
a sub-set of cloud-init commands. With `custom_script` support,
one can pass arbitrary cloud-init yaml to the managed host and
make sure the provisioned host will get it unchanged (which
is not the case when passing the user data currently,
as the rbovirt parses into ovirt-specific keys and ignored the keys it
doesn't know)

Example:

```
cloudinit = <<EOF
yum_repos:
    zoo:
        baseurl: https://example.com/yumrepo
        name: example-repo
        enabled: true
EOF

vm.start_with_cloudinit(:blocking => true,
                        :user_data => cloudinit,
                        :use_custom_script => true)
```

This way, the cloudinit will get to the VM in the same format it was
passed during the call.

Requires 'https://github.com/abenari/rbovirt/pull/121'