### PR TITLE
Suppress warning

### DIFF
--- a/lib/fog/vcloud_director/requests/compute/post_power_on_vapp.rb
+++ b/lib/fog/vcloud_director/requests/compute/post_power_on_vapp.rb
@@ -65,7 +65,7 @@ module Fog
             :body => body
           )
         end
-        end
+      end
     end
   end
 end

--- a/lib/tasks/changelog_task.rb
+++ b/lib/tasks/changelog_task.rb
@@ -177,7 +177,7 @@ Watchers      | #{watchers}
       end
 
       def committer_match
-        current_line.match /([-\w\s]+)\s+\(\d+\)/
+        current_line.match (/([-\w\s]+)\s+\(\d+\)/)
       end
 
       def last_release_sha

--- a/lib/tasks/github_release_task.rb
+++ b/lib/tasks/github_release_task.rb
@@ -47,7 +47,7 @@ module Fog
       end
 
       def release_match
-        @current_line.match /## (\d+\.\d+\.\d+) \d+\/\d+\d+/
+        @current_line.match (/## (\d+\.\d+\.\d+) \d+\/\d+\d+/)
       end
 
       def github


### PR DESCRIPTION
This PR suppresses the following warning.

``` ruby
ruby -v
ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-darwin16]

RUBYOPT=-w bundle exec rake  
/fog/lib/tasks/changelog_task.rb:180: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/fog/lib/tasks/github_release_task.rb:50: warning: ambiguous first argument; put parentheses or a space even after `/' operator

/fog/lib/fog/vcloud_director/requests/compute/post_power_on_vapp.rb:68: warning: mismatched indentations at 'end' with 'class' at 34
```