### PR TITLE
Upgrade JSON to ~> 2.0

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -47,9 +47,8 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-core", "~> 1.45")
   s.add_dependency("fog-json")
   s.add_dependency("fog-xml", "~> 0.1.1")
-  
-  # JSON locked for Ruby 1.9, remove once deprecated
-  s.add_dependency("json", ">= 1.8", "< 2.0")
+
+  s.add_dependency("json", "~> 2.0")
   s.add_dependency("ipaddress", "~> 0.5")
 
   # Modular providers (please keep sorted)


### PR DESCRIPTION
The README states

> Fog requires Ruby 2.0.0 or later.

and `json` 2.0 should thus now work properly.

(Also see #3707, which removed Ruby 1.9.3 support.)