### PR TITLE
Upgrade fog-google and mime-types

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -115,7 +115,7 @@ If there's a metagem available for your cloud provider, e.g. `fog-aws`,
 you should be using it instead of requiring the full fog collection to avoid
 unnecessary dependencies.
 
-'fog' should be required explicitly only if the provider you use doesn't yet 
+'fog' should be required explicitly only if the provider you use doesn't yet
 have a metagem available.
 ------------------------------
   POSTINST

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -86,7 +86,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("docker-api", ">= 1.13.6")
   s.add_development_dependency("fission")
-  s.add_development_dependency("mime-types", "<=2.99.1")
+  s.add_development_dependency("mime-types")
   s.add_development_dependency("minitest")
   s.add_development_dependency("minitest-stub-const")
   s.add_development_dependency("opennebula")

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -63,7 +63,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-dnsimple", "~> 1.0")
   s.add_dependency("fog-dynect", "~> 0.0.2")
   s.add_dependency("fog-ecloud", "~> 0.1")
-  s.add_dependency("fog-google", "<= 0.1.0")
+  s.add_dependency("fog-google", "~> 1.0")
   s.add_dependency("fog-internet-archive")
   s.add_dependency("fog-joyent")
   s.add_dependency("fog-local")


### PR DESCRIPTION
Now that we have released 2.0.0, and are no longer supporting ruby-1.9.3, fog-google and mime-types can be unpinned. mime-types 3.0 dropped ruby-1.9.3 support, as did fog-google at v0.1.1.