### PR TITLE
[cloudstack] Allow specifying the size of root volume

### DIFF
--- a/lib/fog/cloudstack/models/compute/server.rb
+++ b/lib/fog/cloudstack/models/compute/server.rb
@@ -40,6 +40,7 @@ module Fog
         attribute :nics,                   :type => :array, :aliases => 'nic'
         attribute :job_id,                                  :aliases => 'jobid'   # only on create
         attribute :size,                   :type => :integer
+        attribute :root_disk_size,         :type => :integer
 
         attr_accessor :network_ids, :disk_offering_id, :ip_address, :ip_to_network_list
         attr_writer :security_group_ids
@@ -132,6 +133,7 @@ module Fog
             'size'              => size,
           }
 
+          options.merge!('rootdisksize' => root_disk_size) if root_disk_size
           options.merge!('networkids' => network_ids) if network_ids
           options.merge!('securitygroupids' => security_group_ids) unless security_group_ids.empty?
 


### PR DESCRIPTION
Similar to https://github.com/fog/fog/pull/3566

Not only the size of DATADISK, but also I would like to specify the size of root disk for cloudstack.

http://cloudstack.apache.org/docs/api/apidocs-4.4/root_admin/deployVirtualMachine.html