### PR TITLE
Ruby 2.5 compatibility

### DIFF
--- a/tests/cloudstack/signed_params_tests.rb
+++ b/tests/cloudstack/signed_params_tests.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 Shindo.tests('Cloudstack | escape', ['cloudstack']) do
-  returns( Fog::Cloudstack.escape( "'Stöp!' said Fred_-~." ) ) { "%27St%C3%B6p%21%27%20said%20Fred_-%7E." }
+  returns( Fog::Cloudstack.escape( "'Stöp!' said Fred_-~." ) ) { "%27St%C3%B6p%21%27+said+Fred_-~." }
 end
 
 Shindo.tests('Cloudstack | signed_params', ['cloudstack']) do


### PR DESCRIPTION
[CGI::escape](https://github.com/fog/fog/blob/master/lib/fog/cloudstack/core.rb#L14) in Ruby 2.5 behaves differently.

I do not know how to make it pass for Ruby < 2.5 at the same time.

```
irb(main):011:0> RUBY_VERSION
=> "2.5.1"
irb(main):012:0> CGI::escape("'Stöp!' said Fred_-~.")
=> "%27St%C3%B6p%21%27+said+Fred_-~."
```