### PR TITLE
Fix deprecation warning appearing in tests

### DIFF
--- a/spec/fog/bin/atmos_spec.rb
+++ b/spec/fog/bin/atmos_spec.rb
@@ -20,14 +20,4 @@ describe Atmos do
       end
     end
   end
-
-  describe "#[]" do
-    describe "when requesting storage service" do
-      it "returns instance" do
-        Fog::Storage::Atmos.stub(:new, "instance") do
-          assert_equal "instance", Atmos[:storage]
-        end
-      end
-    end
-  end
 end

--- a/spec/fog/bin/aws_spec.rb
+++ b/spec/fog/bin/aws_spec.rb
@@ -77,22 +77,4 @@ describe AWS do
       end
     end
   end
-
-  describe "#[]" do
-    describe "when service is recognised" do
-      it "returns correct instance" do
-        KEY_CLASS_MAPPING.each do |key, klass|
-          klass.stub(:new, "#{klass} instance") do
-            assert_equal "#{klass} instance", AWS[key]
-          end
-        end
-      end
-    end
-
-    describe "when service is not recognised" do
-      it "raises ArgumentError" do
-        assert_raises(ArgumentError) { AWS[:bad_service] }
-      end
-    end
-  end
 end

--- a/spec/fog/bin/baremetalcloud_spec.rb
+++ b/spec/fog/bin/baremetalcloud_spec.rb
@@ -20,14 +20,4 @@ describe BareMetalCloud do
       end
     end
   end
-
-  describe "#[]" do
-    describe "when requesting compute service" do
-      it "returns instance" do
-        Fog::Compute::BareMetalCloud.stub(:new, "instance") do
-          assert_equal "instance", BareMetalCloud[:compute]
-        end
-      end
-    end
-  end
 end

--- a/spec/fog/bin/bluebox_spec.rb
+++ b/spec/fog/bin/bluebox_spec.rb
@@ -34,22 +34,4 @@ describe Bluebox do
       end
     end
   end
-
-  describe "#[]" do
-    describe "when requesting compute service" do
-      it "returns instance" do
-        Fog::Compute::Bluebox.stub(:new, "instance") do
-          assert_equal "instance", Bluebox[:compute]
-        end
-      end
-    end
-
-    describe "when requesting dns service" do
-      it "returns instance" do
-        Fog::DNS::Bluebox.stub(:new, "instance") do
-          assert_equal "instance", Bluebox[:dns]
-        end
-      end
-    end
-  end
 end

--- a/tests/cloudstack/compute/models/volume_tests.rb
+++ b/tests/cloudstack/compute/models/volume_tests.rb
@@ -4,7 +4,7 @@ def volume_tests(connection, params, mocks_implemented = true)
       @instance.wait_for { ready? }
     end
 
-    @server = @instance.connection.servers.create(params[:server_attributes])
+    @server = @instance.service.servers.create(params[:server_attributes])
     @server.wait_for { ready? }
 
     tests('attach').succeeds do


### PR DESCRIPTION
This fixes a number of references to deprecated methods or classes.

The main bulk is removing the tests for the Fog "binary" that allowed providers to call their services directly from the top level, e.g. `Brightbox[:compute]`

These tests would flood the testing output with deprecation warnings when no one will hopefully be using that interface anymore.

It also fixes a reference to `#connection` which should be `#service`.

The warnings have disappeared on Travis but there are still plenty more.