### PR TITLE
Add SemVer stability badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ fog is the Ruby cloud services library, top to bottom:
 * Mocks make testing and integrating a breeze.
 
 [![Build Status](https://secure.travis-ci.org/fog/fog.svg?branch=master)](http://travis-ci.org/fog/fog)
-[![Dependency Status](https://gemnasium.com/fog/fog.svg)](https://gemnasium.com/fog/fog)
 [![Code Climate](https://codeclimate.com/github/fog/fog/badges/gpa.svg)](https://codeclimate.com/github/fog/fog)
 [![Gem Version](https://badge.fury.io/rb/fog.svg)](http://badge.fury.io/rb/fog)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=fog&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=fog&package-manager=bundler&version-scheme=semver)
 
 ## Dependency Notice
 
@@ -17,10 +17,10 @@ Currently all fog providers are getting separated into metagems to lower the
 load time and dependency count.
 
 If there's a metagem available for your cloud provider, e.g. `fog-aws`,
-you should be using it instead of requiring the full fog collection to avoid 
+you should be using it instead of requiring the full fog collection to avoid
 unnecessary dependencies.
 
-'fog' should be required explicitly only if the provider you use doesn't yet 
+'fog' should be required explicitly only if the provider you use doesn't yet
 have a metagem available.
 
 ## Getting Started


### PR DESCRIPTION
First of all, thanks for fog!

Would you be up for adding a badge that shows how SemVer compliant / bug free new releases are? I was looking through the data we gather at Dependabot and realised we could put one together, so threw together the below:

[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=fog&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=fog&package-manager=bundler&version-scheme=semver)

If you click through then there's a description of how it's calculated - basically it takes all of the relevant updates Dependabot has done for projects that use fog and checks what percentage of the time specs pass on the upgrade PR.

The score is slightly lower than 100% because some projects have flaky specs, but I'm working on filtering them out from the data, too :octocat:.

Finally, I've removed the old Gemnasium badge, as it now just serves an advert for GitLab.