### PR TITLE
Removing leftover file from fog-ovirt extraction

### DIFF
--- a/lib/fog/ovirt.rb
+++ b/lib/fog/ovirt.rb
@@ -1,1 +1,0 @@
-require 'fog/ovirt/compute'


### PR DESCRIPTION
@plribeiro3000 This is what we talked about regarding:https://github.com/fog/fog-ovirt/pull/29#issuecomment-399957348.
I will open another PR against master that also removed 2 more leftover files I found (and open a PR to `fog-ovirt` to add them).