### PR TITLE
Hotfix bump needed for fog-google in fog-1.X

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-dnsimple", "~> 1.0")
   s.add_dependency("fog-dynect", "~> 0.0.2")
   s.add_dependency("fog-ecloud", "~> 0.1")
-  s.add_dependency("fog-google", "<= 0.1.0")
+  s.add_dependency("fog-google", "~> 0.1.3")
   s.add_dependency("fog-internet-archive")
   s.add_dependency("fog-joyent")
   s.add_dependency("fog-local")


### PR DESCRIPTION
I've mentioned this before but the gist is - due to unexpected `resourceviews` API deprecation <=0.1.X versions of `fog-google` no longer load. Problem is fog-1.X is the last version to support Ruby 1.9, so it would be good to provide a `1.43` for legacy users with the hotfix.

However, I do understand that it's somewhat complicated to release a legacy version so if you think this is too much hassle - no worries - just let me know.

Targeting release-1.42.0 branch.

For more info on why this happened see https://github.com/fog/fog-google/commit/3ba154554382d9cfe9f29710795ec638be881260