### PR TITLE
lib/fog/linode: Add Tokyo2 to avail_datacenters

### DIFF
--- a/lib/fog/linode/requests/compute/avail_datacenters.rb
+++ b/lib/fog/linode/requests/compute/avail_datacenters.rb
@@ -32,6 +32,7 @@ module Fog
               { "LOCATION" => "Tokyo, JP",           "DATACENTERID" => 8,  "ABBR" => "tokyo" },
               { "LOCATION" => "Singapore, SGP",      "DATACENTERID" => 9,  "ABBR" => "singapore" },
               { "LOCATION" => "Frankfurt, DE",       "DATACENTERID" => 10, "ABBR" => "frankfurt" },
+              { "LOCATION" => "Tokyo 2, JP",         "DATACENTERID" => 11, "ABBR" => "tokyo2" },
             ],
             "ACTION" => "avail.datacenters"
           }


### PR DESCRIPTION
It would appear that the existing test cases should suffice for providing coverage: https://github.com/fog/fog/blob/master/tests/linode/requests/compute/datacenter_tests.rb
