### PR TITLE
Fix compatibility with fog-brightbox 1.0.0+.

### DIFF
--- a/lib/fog/bin/brightbox.rb
+++ b/lib/fog/bin/brightbox.rb
@@ -3,9 +3,9 @@ class Brightbox < Fog::Bin
     def class_for(key)
       case key
       when :compute
-        Fog::Compute::Brightbox
+        Fog::Brightbox::Compute
       when :storage
-        Fog::Storage::Brightbox
+        Fog::Brightbox::Storage
       else
         raise ArgumentError, "Unsupported #{self} service: #{key}"
       end

--- a/spec/fog/bin/brightbox_spec.rb
+++ b/spec/fog/bin/brightbox_spec.rb
@@ -17,13 +17,13 @@ describe Brightbox do
   describe "#class_for" do
     describe "when requesting compute service" do
       it "returns correct class" do
-        assert_equal Fog::Compute::Brightbox, Brightbox.class_for(:compute)
+        assert_equal Fog::Brightbox::Compute, Brightbox.class_for(:compute)
       end
     end
 
     describe "when requesting storage service" do
       it "returns correct class" do
-        assert_equal Fog::Storage::Brightbox, Brightbox.class_for(:storage)
+        assert_equal Fog::Brightbox::Storage, Brightbox.class_for(:storage)
       end
     end
   end


### PR DESCRIPTION
fog-brightbox updated namespaces into Fog::Brightbox format.

I am not sure if this is compatible with older fog-brightbox, which is now demanded by fog, but I guess I'll know soon :)