### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,10 +30,6 @@ def date
   Date.today.to_s
 end
 
-def rubyforge_project
-  name
-end
-
 def gemspec_file
   "#{name}.gemspec"
 end
@@ -200,8 +196,6 @@ task :gemspec => :validate do
   replace_header(spec, :name)
   replace_header(spec, :version)
   replace_header(spec, :date)
-  #comment this out if your rubyforge_project has a different name
-  replace_header(spec, :rubyforge_project)
 
   File.open(gemspec_file, 'w') { |io| io.write(spec) }
   puts "Updated #{gemspec_file}"

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -13,7 +13,6 @@ Gem::Specification.new do |s|
   s.name              = "fog"
   s.version           = "2.2.0"
   s.date              = "2019-06-18"
-  s.rubyforge_project = "fog"
 
   ## Make sure your summary is short. The description may be as long
   ## as you like.


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.