### PR TITLE
json-dos-cve-2020-10663

### DIFF
--- a/fog.gemspec
+++ b/fog.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   s.add_dependency("fog-json")
   s.add_dependency("fog-xml", "~> 0.1.1")
 
-  s.add_dependency("json", "~> 2.0")
+  s.add_dependency("json", "~> 2.3")
   s.add_dependency("ipaddress", "~> 0.5")
 
   # Modular providers (please keep sorted)


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/

Upgreade json gem version