### PR TITLE
Supported Ruby version is 2.5+ now

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.4', '2.5', '2.6', '2.7', '3.0', 'head']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', 'head']
 
     steps:
     - uses: actions/checkout@v2.3.4

--- a/fog.gemspec
+++ b/fog.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.extra_rdoc_files = %w[README.md]
 
-  s.required_ruby_version = '>= 2.0.0'
+  s.required_ruby_version = '>= 2.5.0'
 
   s.add_dependency("fog-core", "~> 2.1")
   s.add_dependency("fog-json")


### PR DESCRIPTION
Ruby 2.0 is EOL, supported Ruby versions are 2.6+ and currentl Rubocop supports 2.4+. This is a good compromise.