### PR TITLE
CI against Ruby 3.2

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', 'head']
+        ruby-version: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', 'head']
     continue-on-error: ${{ matrix.ruby-version == 'head' }}
 
     steps:


### PR DESCRIPTION
It seems CI isn't stable now.
But this setting affects to CI of `fog-core`. So I would like to add this for that.
https://github.com/fog/fog-core/blob/75b972e0d241a4e40911c1003643605533dba26b/.github/workflows/ruby.yml#L18